### PR TITLE
Fix sidecar stdout framing to prevent agent summary corruption

### DIFF
--- a/crates/luban_app/agent_sidecar/run.mjs
+++ b/crates/luban_app/agent_sidecar/run.mjs
@@ -1,5 +1,31 @@
 import { Codex } from "@openai/codex-sdk";
 
+const EVENT_PREFIX = "__LUBAN_EVENT__ ";
+
+function redirectConsoleToStderr() {
+  const write = (args) => {
+    try {
+      const msg = args
+        .map((a) =>
+          typeof a === "string" ? a : JSON.stringify(a, null, 2),
+        )
+        .join(" ");
+      process.stderr.write(msg + "\n");
+    } catch {
+      process.stderr.write(String(args) + "\n");
+    }
+  };
+
+  console.log = (...args) => write(args);
+  console.info = (...args) => write(args);
+  console.warn = (...args) => write(args);
+  console.error = (...args) => write(args);
+
+  process.on("warning", (warning) => {
+    process.stderr.write(String(warning?.stack ?? warning) + "\n");
+  });
+}
+
 function readAllStdin() {
   return new Promise((resolve, reject) => {
     let data = "";
@@ -11,6 +37,8 @@ function readAllStdin() {
 }
 
 async function main() {
+  redirectConsoleToStderr();
+
   const raw = await readAllStdin();
   const req = JSON.parse(raw);
 
@@ -30,7 +58,7 @@ async function main() {
 
   const { events } = await thread.runStreamed(req.prompt);
   for await (const event of events) {
-    process.stdout.write(JSON.stringify(event) + "\n");
+    process.stdout.write(EVENT_PREFIX + JSON.stringify(event) + "\n");
   }
 }
 


### PR DESCRIPTION
Problem: the Rust sidecar reader assumed every stdout line is a Codex JSON event. Any extra stdout noise (e.g. retry/reconnect logs) could break JSON parsing and corrupt the turn stream, causing the agent turn summary UI to get out of sync.

Fix:
- Prefix protocol event lines on stdout ("__LUBAN_EVENT__ "), and redirect console output/warnings to stderr.
- Make the Rust parser tolerant: accept prefixed events, keep legacy JSON compatibility, ignore unknown event types and non-JSON noise.
- Add unit tests covering prefixed/legacy events, unknown events, and plain-text noise.