### PR TITLE
Open workspace in Zed

### DIFF
--- a/crates/luban_app/assets/icons/zed.svg
+++ b/crates/luban_app/assets/icons/zed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="2" y="2" width="20" height="20" rx="4" fill="#111827"/>
+  <path d="M7 8h10v2l-8 8h8v2H7v-2l8-8H7z" fill="#ffffff"/>
+</svg>

--- a/crates/luban_app/src/app_assets.rs
+++ b/crates/luban_app/src/app_assets.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 
 const BRAIN_SVG: &[u8] = include_bytes!("../assets/icons/brain.svg");
 const TIMER_SVG: &[u8] = include_bytes!("../assets/icons/timer.svg");
+const ZED_SVG: &[u8] = include_bytes!("../assets/icons/zed.svg");
 
 pub struct AppAssets {
     fallback: ComponentAssets,
@@ -26,6 +27,7 @@ impl AssetSource for AppAssets {
         match path {
             "icons/brain.svg" => Ok(Some(Cow::Borrowed(BRAIN_SVG))),
             "icons/timer.svg" => Ok(Some(Cow::Borrowed(TIMER_SVG))),
+            "icons/zed.svg" => Ok(Some(Cow::Borrowed(ZED_SVG))),
             _ => self.fallback.load(path),
         }
     }
@@ -38,6 +40,9 @@ impl AssetSource for AppAssets {
         }
         if "icons/timer.svg".starts_with(path) {
             assets.push("icons/timer.svg".into());
+        }
+        if "icons/zed.svg".starts_with(path) {
+            assets.push("icons/zed.svg".into());
         }
 
         assets.sort();


### PR DESCRIPTION
Adds a top-right Zed tile that opens the selected workspace worktree path via the service/effect pipeline (macOS: open -a Zed).