### PR TITLE
Use system Zig toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Luban is a standalone AI code editor app built with GPUI, with a Zed-like layout
 
 This project uses `just` to manage all common dev commands.
 
-The embedded terminal requires Zig (0.14.1) for building `ghostty_vt_sys` (install via `brew install zig` or set `ZIG=/path/to/zig`).
+The embedded terminal requires Zig (0.14.1) for building `ghostty_vt_sys`.
 
-To install a local Zig binary into `.context/zig/zig`:
-
-```bash
-just zig-bootstrap
-```
+Install Zig using a toolchain manager (recommended: `zvm`) or your system package manager, and ensure `zig` is available in `PATH` (or set `ZIG=/path/to/zig`).
 
 ```bash
 just -l

--- a/justfile
+++ b/justfile
@@ -15,18 +15,18 @@ fmt:
   cargo fmt --all
 
 lint:
-  ZIG=$(pwd)/.context/zig/zig cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+  cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 
 test:
-  ZIG=$(pwd)/.context/zig/zig cargo test --workspace --all-targets --all-features
+  cargo test --workspace --all-targets --all-features
 
 test-fast:
-  ZIG=$(pwd)/.context/zig/zig cargo test -p luban_domain
+  cargo test -p luban_domain
 
 run:
-  ZIG=$(pwd)/.context/zig/zig cargo run -p luban_app
+  cargo run -p luban_app
 
 build:
-  ZIG=$(pwd)/.context/zig/zig cargo build -p luban_app
+  cargo build -p luban_app
 
 ci: fmt lint test


### PR DESCRIPTION
- Stop hardcoding a repo-local Zig path in Available recipes:
    build
    ci
    default
    fmt
    lint
    run
    sidecar-build
    sidecar-install
    test
    test-fast
    zig-bootstrap recipes; use  from PATH or  instead.\n- Update developer docs to reflect the new setup (Zig 0.14.1 via system/toolchain manager such as zvm).\n\nNotes:\n-  remains available for local convenience, but it is no longer the default dependency.