### PR TITLE
Make workspace PR badge clickable

### DIFF
--- a/crates/luban_app/src/services.rs
+++ b/crates/luban_app/src/services.rs
@@ -750,6 +750,27 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             state,
         }))
     }
+
+    fn gh_open_pull_request(&self, worktree_path: PathBuf) -> Result<(), String> {
+        let output = Command::new("gh")
+            .args(["pr", "view", "--web"])
+            .current_dir(worktree_path)
+            .output();
+
+        let Ok(output) = output else {
+            return Err("Failed to run gh".to_owned());
+        };
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        if stderr.is_empty() {
+            Err("Failed to open pull request".to_owned())
+        } else {
+            Err(stderr)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -47,6 +47,12 @@ pub enum Action {
     OpenWorkspaceInIdeFailed {
         message: String,
     },
+    OpenWorkspacePullRequest {
+        workspace_id: WorkspaceId,
+    },
+    OpenWorkspacePullRequestFailed {
+        message: String,
+    },
     ArchiveWorkspace {
         workspace_id: WorkspaceId,
     },

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -120,4 +120,6 @@ pub trait ProjectWorkspaceService: Send + Sync {
         &self,
         worktree_path: PathBuf,
     ) -> Result<Option<PullRequestInfo>, String>;
+
+    fn gh_open_pull_request(&self, worktree_path: PathBuf) -> Result<(), String>;
 }

--- a/crates/luban_domain/src/effects.rs
+++ b/crates/luban_domain/src/effects.rs
@@ -11,6 +11,9 @@ pub enum Effect {
     OpenWorkspaceInIde {
         workspace_id: WorkspaceId,
     },
+    OpenWorkspacePullRequest {
+        workspace_id: WorkspaceId,
+    },
     ArchiveWorkspace {
         workspace_id: WorkspaceId,
     },

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -212,6 +212,17 @@ impl AppState {
                 self.last_error = Some(message);
                 Vec::new()
             }
+            Action::OpenWorkspacePullRequest { workspace_id } => {
+                if self.workspace(workspace_id).is_none() {
+                    self.last_error = Some("Workspace not found".to_owned());
+                    return Vec::new();
+                }
+                vec![Effect::OpenWorkspacePullRequest { workspace_id }]
+            }
+            Action::OpenWorkspacePullRequestFailed { message } => {
+                self.last_error = Some(message);
+                Vec::new()
+            }
             Action::ArchiveWorkspace { workspace_id } => {
                 if let Some((project_idx, workspace_idx)) =
                     self.find_workspace_indices(workspace_id)
@@ -2188,6 +2199,43 @@ mod tests {
     fn open_workspace_in_ide_sets_error_when_workspace_missing() {
         let mut state = AppState::new();
         let effects = state.apply(Action::OpenWorkspaceInIde {
+            workspace_id: WorkspaceId(1),
+        });
+        assert!(effects.is_empty());
+        assert_eq!(state.last_error.as_deref(), Some("Workspace not found"));
+    }
+
+    #[test]
+    fn open_workspace_pull_request_emits_effect_for_existing_workspace() {
+        let mut state = AppState::new();
+        state.apply(Action::AddProject {
+            path: PathBuf::from("/tmp/repo"),
+        });
+        let project_id = state.projects[0].id;
+        state.apply(Action::WorkspaceCreated {
+            project_id,
+            workspace_name: "abandon-about".to_owned(),
+            branch_name: "luban/abandon-about".to_owned(),
+            worktree_path: PathBuf::from("/tmp/luban/worktrees/repo/abandon-about"),
+        });
+        let workspace_id = workspace_id_by_name(&state, "abandon-about");
+
+        let effects = state.apply(Action::OpenWorkspacePullRequest { workspace_id });
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [Effect::OpenWorkspacePullRequest {
+                    workspace_id: effect_workspace_id
+                }] if *effect_workspace_id == workspace_id
+            ),
+            "unexpected effects: {effects:?}"
+        );
+    }
+
+    #[test]
+    fn open_workspace_pull_request_sets_error_when_workspace_missing() {
+        let mut state = AppState::new();
+        let effects = state.apply(Action::OpenWorkspacePullRequest {
             workspace_id: WorkspaceId(1),
         });
         assert!(effects.is_empty());

--- a/crates/luban_ui/src/root/dashboard.rs
+++ b/crates/luban_ui/src/root/dashboard.rs
@@ -1437,6 +1437,23 @@ fn render_dashboard_card(
                             .bg(theme.muted)
                             .text_xs()
                             .text_color(theme.muted_foreground)
+                            .cursor_pointer()
+                            .hover({
+                                let hover = theme.scrollbar_thumb_hover;
+                                move |s| s.bg(hover)
+                            })
+                            .on_mouse_down(MouseButton::Left, {
+                                let view_handle = view_handle.clone();
+                                move |_, _window, app| {
+                                    app.stop_propagation();
+                                    let _ = view_handle.update(app, |view, cx| {
+                                        view.dispatch(
+                                            Action::OpenWorkspacePullRequest { workspace_id },
+                                            cx,
+                                        );
+                                    });
+                                }
+                            })
                             .child(label),
                     )
                 }),

--- a/crates/luban_ui/src/root/sidebar.rs
+++ b/crates/luban_ui/src/root/sidebar.rs
@@ -381,6 +381,23 @@ fn render_workspace_row(
                             .debug_selector(move || {
                                 format!("workspace-pr-{project_index}-{workspace_index}")
                             })
+                            .cursor_pointer()
+                            .hover({
+                                let hover = theme.link;
+                                move |s| s.text_color(hover)
+                            })
+                            .on_mouse_down(MouseButton::Left, {
+                                let view_handle = view_handle.clone();
+                                move |_, _window, app| {
+                                    app.stop_propagation();
+                                    let _ = view_handle.update(app, |view, cx| {
+                                        view.dispatch(
+                                            Action::OpenWorkspacePullRequest { workspace_id },
+                                            cx,
+                                        );
+                                    });
+                                }
+                            })
                             .child(label),
                     )
                 })

--- a/crates/luban_ui/src/root/tests.rs
+++ b/crates/luban_ui/src/root/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use gpui::{
     Modifiers, MouseButton, MouseDownEvent, ScrollDelta, ScrollWheelEvent, point, px, size,
@@ -271,6 +270,10 @@ impl ProjectWorkspaceService for FakeService {
         _worktree_path: PathBuf,
     ) -> Result<Option<PullRequestInfo>, String> {
         Ok(None)
+    }
+
+    fn gh_open_pull_request(&self, _worktree_path: PathBuf) -> Result<(), String> {
+        Ok(())
     }
 }
 
@@ -4385,6 +4388,7 @@ async fn chat_input_cursor_moves_to_end_on_workspace_switch(cx: &mut gpui::TestA
 
 struct FakeGhService {
     pr_numbers: HashMap<PathBuf, Option<PullRequestInfo>>,
+    open_calls: Arc<AtomicUsize>,
 }
 
 impl ProjectWorkspaceService for FakeGhService {
@@ -4506,6 +4510,11 @@ impl ProjectWorkspaceService for FakeGhService {
     ) -> Result<Option<PullRequestInfo>, String> {
         Ok(self.pr_numbers.get(&worktree_path).copied().flatten())
     }
+
+    fn gh_open_pull_request(&self, _worktree_path: PathBuf) -> Result<(), String> {
+        self.open_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
 }
 
 #[gpui::test]
@@ -4541,7 +4550,10 @@ async fn workspace_row_shows_pull_request_number_when_available(cx: &mut gpui::T
         }),
     );
     pr_numbers.insert(PathBuf::from("/tmp/luban/worktrees/repo/w2"), None);
-    let services: Arc<dyn ProjectWorkspaceService> = Arc::new(FakeGhService { pr_numbers });
+    let services: Arc<dyn ProjectWorkspaceService> = Arc::new(FakeGhService {
+        pr_numbers,
+        open_calls: Arc::new(AtomicUsize::new(0)),
+    });
 
     let view_slot: Arc<std::sync::Mutex<Option<gpui::Entity<LubanRootView>>>> =
         Arc::new(std::sync::Mutex::new(None));
@@ -4590,6 +4602,83 @@ async fn workspace_row_shows_pull_request_number_when_available(cx: &mut gpui::T
             .is_some(),
         "expected branch icon for workspace without PR number"
     );
+}
+
+#[gpui::test]
+async fn workspace_pr_label_opens_pull_request(cx: &mut gpui::TestAppContext) {
+    cx.update(gpui_component::init);
+
+    let mut state = AppState::new();
+    state.apply(Action::AddProject {
+        path: PathBuf::from("/tmp/repo"),
+    });
+    let project_id = state.projects[0].id;
+    state.apply(Action::WorkspaceCreated {
+        project_id,
+        workspace_name: "w1".to_owned(),
+        branch_name: "repo/w1".to_owned(),
+        worktree_path: PathBuf::from("/tmp/luban/worktrees/repo/w1"),
+    });
+    state.projects[0].expanded = true;
+
+    let mut pr_numbers = HashMap::new();
+    pr_numbers.insert(
+        PathBuf::from("/tmp/luban/worktrees/repo/w1"),
+        Some(PullRequestInfo {
+            number: 123,
+            is_draft: false,
+            state: PullRequestState::Open,
+        }),
+    );
+
+    let open_calls = Arc::new(AtomicUsize::new(0));
+    let services: Arc<dyn ProjectWorkspaceService> = Arc::new(FakeGhService {
+        pr_numbers,
+        open_calls: open_calls.clone(),
+    });
+
+    let view_slot: Arc<std::sync::Mutex<Option<gpui::Entity<LubanRootView>>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let view_slot_for_window = view_slot.clone();
+
+    let (_, window_cx) = cx.add_window_view(|window, cx| {
+        let view = cx.new(|cx| LubanRootView::with_state(services, state, cx));
+        *view_slot_for_window.lock().expect("poisoned mutex") = Some(view.clone());
+        gpui_component::Root::new(view, window, cx)
+    });
+    let view = view_slot
+        .lock()
+        .expect("poisoned mutex")
+        .clone()
+        .expect("missing view handle");
+
+    window_cx.refresh().unwrap();
+    window_cx.update(|_, app| {
+        view.update(app, |view, cx| {
+            view.dispatch(Action::ClearError, cx);
+        });
+    });
+
+    for _ in 0..8 {
+        window_cx.run_until_parked();
+        window_cx.refresh().unwrap();
+    }
+
+    let bounds = window_cx
+        .debug_bounds("workspace-pr-0-0")
+        .expect("missing PR label bounds");
+    let click = bounds.center();
+
+    window_cx.simulate_mouse_move(click, None, Modifiers::none());
+    window_cx.simulate_mouse_down(click, MouseButton::Left, Modifiers::none());
+    window_cx.simulate_mouse_up(click, MouseButton::Left, Modifiers::none());
+
+    for _ in 0..4 {
+        window_cx.run_until_parked();
+        window_cx.refresh().unwrap();
+    }
+
+    assert_eq!(open_calls.load(Ordering::SeqCst), 1);
 }
 
 #[gpui::test]


### PR DESCRIPTION
- Turn the workspace PR badge (#NNN) into a clickable element in sidebar and dashboard.\n- Clicking opens the corresponding GitHub PR via "gh pr view --web".\n- Adds a GPUI test to assert the click triggers the open call.\n\nVerification:\n- just fmt && just lint && just test