### PR TITLE
Sidebar: workspace running + unread completion indicators

### DIFF
--- a/crates/luban_app/assets/icons/message-square-dot.svg
+++ b/crates/luban_app/assets/icons/message-square-dot.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12.7 3H4a2 2 0 0 0-2 2v16.286a.71.71 0 0 0 1.212.502l2.202-2.202A2 2 0 0 1 6.828 19H20a2 2 0 0 0 2-2v-4.7" />
+  <circle cx="19" cy="6" r="3" />
+</svg>

--- a/crates/luban_app/src/app_assets.rs
+++ b/crates/luban_app/src/app_assets.rs
@@ -9,6 +9,7 @@ const GIT_BRANCH_SVG: &[u8] = include_bytes!("../assets/icons/git-branch.svg");
 const GIT_PULL_REQUEST_ARROW_SVG: &[u8] =
     include_bytes!("../assets/icons/git-pull-request-arrow.svg");
 const HOUSE_SVG: &[u8] = include_bytes!("../assets/icons/house.svg");
+const MESSAGE_SQUARE_DOT_SVG: &[u8] = include_bytes!("../assets/icons/message-square-dot.svg");
 const MESSAGE_SQUARE_MORE_SVG: &[u8] = include_bytes!("../assets/icons/message-square-more.svg");
 const NOTEBOOK_TEXT_SVG: &[u8] = include_bytes!("../assets/icons/notebook-text.svg");
 const PLAY_SVG: &[u8] = include_bytes!("../assets/icons/play.svg");
@@ -44,6 +45,7 @@ impl AssetSource for AppAssets {
                 Ok(Some(Cow::Borrowed(GIT_PULL_REQUEST_ARROW_SVG)))
             }
             "icons/house.svg" => Ok(Some(Cow::Borrowed(HOUSE_SVG))),
+            "icons/message-square-dot.svg" => Ok(Some(Cow::Borrowed(MESSAGE_SQUARE_DOT_SVG))),
             "icons/message-square-more.svg" => Ok(Some(Cow::Borrowed(MESSAGE_SQUARE_MORE_SVG))),
             "icons/notebook-text.svg" => Ok(Some(Cow::Borrowed(NOTEBOOK_TEXT_SVG))),
             "icons/play.svg" => Ok(Some(Cow::Borrowed(PLAY_SVG))),
@@ -75,6 +77,9 @@ impl AssetSource for AppAssets {
         }
         if "icons/house.svg".starts_with(path) {
             assets.push("icons/house.svg".into());
+        }
+        if "icons/message-square-dot.svg".starts_with(path) {
+            assets.push("icons/message-square-dot.svg".into());
         }
         if "icons/message-square-more.svg".starts_with(path) {
             assets.push("icons/message-square-more.svg".into());
@@ -118,6 +123,7 @@ mod tests {
             "icons/house.svg",
             "icons/git-branch.svg",
             "icons/git-pull-request-arrow.svg",
+            "icons/message-square-dot.svg",
             "icons/message-square-more.svg",
             "icons/notebook-text.svg",
             "icons/play.svg",

--- a/crates/luban_domain/src/state.rs
+++ b/crates/luban_domain/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{CodexThreadItem, CodexUsage, ContextTokenKind, ThinkingEffort};
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::PathBuf,
 };
 
@@ -366,6 +366,7 @@ pub struct AppState {
     pub last_open_workspace_id: Option<WorkspaceId>,
     pub last_error: Option<String>,
     pub workspace_chat_scroll_y10: HashMap<(WorkspaceId, WorkspaceThreadId), i32>,
+    pub workspace_unread_completions: HashSet<WorkspaceId>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -381,6 +382,7 @@ pub struct PersistedAppState {
     pub workspace_archived_tabs: HashMap<u64, Vec<u64>>,
     pub workspace_next_thread_id: HashMap<u64, u64>,
     pub workspace_chat_scroll_y10: HashMap<(u64, u64), i32>,
+    pub workspace_unread_completions: HashMap<u64, bool>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/luban_ui/src/root/tests.rs
+++ b/crates/luban_ui/src/root/tests.rs
@@ -132,6 +132,7 @@ impl ProjectWorkspaceService for FakeService {
             workspace_archived_tabs: HashMap::new(),
             workspace_next_thread_id: HashMap::new(),
             workspace_chat_scroll_y10: HashMap::new(),
+            workspace_unread_completions: HashMap::new(),
         })
     }
 
@@ -980,6 +981,109 @@ async fn main_workspace_row_is_rendered_and_is_not_archivable(cx: &mut gpui::Tes
     assert!(
         matches!(selected, MainPane::Workspace(id) if id == main_workspace_id),
         "expected main workspace to be selected after click"
+    );
+}
+
+#[gpui::test]
+async fn workspace_row_shows_running_spinner_and_unread_completion_badge(
+    cx: &mut gpui::TestAppContext,
+) {
+    cx.update(gpui_component::init);
+
+    let services: Arc<dyn ProjectWorkspaceService> = Arc::new(FakeService);
+
+    let mut state = AppState::new();
+    state.apply(Action::AddProject {
+        path: PathBuf::from("/tmp/repo"),
+    });
+    let project_id = state.projects[0].id;
+    state.apply(Action::ToggleProjectExpanded { project_id });
+    state.apply(Action::WorkspaceCreated {
+        project_id,
+        workspace_name: "abandon-about".to_owned(),
+        branch_name: "luban/abandon-about".to_owned(),
+        worktree_path: PathBuf::from("/tmp/luban/worktrees/repo/abandon-about"),
+    });
+    state.apply(Action::OpenProjectSettings { project_id });
+
+    let workspace_id = workspace_id_by_name(&state, "abandon-about");
+    let thread_id = default_thread_id();
+    state.apply(Action::SendAgentMessage {
+        workspace_id,
+        thread_id,
+        text: "run".to_owned(),
+    });
+
+    let (view, window_cx) =
+        cx.add_window_view(|_, cx| LubanRootView::with_state(services, state, cx));
+    window_cx.refresh().unwrap();
+
+    assert!(
+        window_cx
+            .debug_bounds("workspace-status-running-0-0")
+            .is_some(),
+        "expected running spinner indicator to be visible"
+    );
+
+    window_cx.update(|_, app| {
+        view.update(app, |view, cx| {
+            view.dispatch(
+                Action::AgentTurnFinished {
+                    workspace_id,
+                    thread_id,
+                },
+                cx,
+            );
+        });
+    });
+    window_cx.refresh().unwrap();
+    window_cx.run_until_parked();
+    window_cx.refresh().unwrap();
+
+    let running = view.read_with(window_cx, |v, _| {
+        v.debug_state().workspace_has_running_turn(workspace_id)
+    });
+    assert!(
+        !running,
+        "expected state to clear running status after turn finishes"
+    );
+    let unread = view.read_with(window_cx, |v, _| {
+        v.debug_state()
+            .workspace_has_unread_completion(workspace_id)
+    });
+    assert!(
+        unread,
+        "expected state to mark workspace as having unread completion after turn finishes"
+    );
+    assert!(
+        window_cx
+            .debug_bounds("workspace-status-unread-0-0")
+            .is_some(),
+        "expected unread completion badge to be rendered in the sidebar"
+    );
+
+    let row_bounds = window_cx
+        .debug_bounds("workspace-row-0-0")
+        .expect("missing debug bounds for workspace-row-0-0");
+    window_cx.simulate_click(row_bounds.center(), Modifiers::none());
+    window_cx.refresh().unwrap();
+    window_cx.run_until_parked();
+    window_cx.refresh().unwrap();
+
+    let (main_pane, unread) = view.read_with(window_cx, |v, _| {
+        (
+            v.debug_state().main_pane,
+            v.debug_state()
+                .workspace_has_unread_completion(workspace_id),
+        )
+    });
+    assert!(
+        matches!(main_pane, MainPane::Workspace(id) if id == workspace_id),
+        "expected workspace to become selected after click"
+    );
+    assert!(
+        !unread,
+        "expected unread completion badge to clear when the workspace is opened"
     );
 }
 
@@ -4407,6 +4511,7 @@ impl ProjectWorkspaceService for FakeGhService {
             workspace_archived_tabs: HashMap::new(),
             workspace_next_thread_id: HashMap::new(),
             workspace_chat_scroll_y10: HashMap::new(),
+            workspace_unread_completions: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
Adds a per-workspace status slot in the sidebar: a spinner while an agent turn is running, and a highlighted message-square-dot badge when a turn completes while the workspace isn't currently visible (clears on open/preview).\n\n- Persists unread-completion state via app_settings (workspace_unread_completion_*).\n- Adds UI + domain coverage for the new behavior.\n\nVerification: just fmt && just lint && just test