### PR TITLE
Sidebar: make projects list scrollable

### DIFF
--- a/crates/luban_ui/src/root.rs
+++ b/crates/luban_ui/src/root.rs
@@ -316,6 +316,16 @@ impl LubanRootView {
         quantize_pixels_y10(self.chat_scroll_handle.max_offset().height)
     }
 
+    #[cfg(test)]
+    pub fn debug_projects_scroll_offset_y10(&self) -> i32 {
+        quantize_pixels_y10(self.projects_scroll_handle.offset().y)
+    }
+
+    #[cfg(test)]
+    pub fn debug_projects_scroll_max_offset_y10(&self) -> i32 {
+        quantize_pixels_y10(self.projects_scroll_handle.max_offset().height)
+    }
+
     fn dispatch(&mut self, action: Action, cx: &mut Context<Self>) {
         let previous_chat_key_for_scroll = match self.state.main_pane {
             MainPane::Workspace(workspace_id) => {

--- a/crates/luban_ui/src/root/sidebar.rs
+++ b/crates/luban_ui/src/root/sidebar.rs
@@ -23,16 +23,17 @@ pub(super) fn render_sidebar(
         .text_color(theme.sidebar_foreground)
         .border_r_1()
         .border_color(theme.sidebar_border)
-        .child(
+        .child(min_height_zero(
             div()
                 .flex_1()
                 .relative()
                 .flex()
                 .flex_col()
-                .child(
+                .child(min_height_zero(
                     div()
                         .flex_1()
                         .id("projects-scroll")
+                        .debug_selector(|| "projects-scroll".to_owned())
                         .overflow_y_scroll()
                         .track_scroll(&projects_scroll_handle)
                         .py_2()
@@ -56,14 +57,14 @@ pub(super) fn render_sidebar(
                                 workspace_pull_request_numbers,
                             )
                         })),
-                )
+                ))
                 .child(
                     div()
                         .absolute()
                         .top_0()
-                        .left_0()
                         .right_0()
                         .bottom_0()
+                        .w(px(12.0))
                         .debug_selector(|| "projects-scrollbar".to_owned())
                         .child(
                             Scrollbar::vertical(&projects_scroll_handle)
@@ -71,7 +72,7 @@ pub(super) fn render_sidebar(
                                 .scrollbar_show(ScrollbarShow::Always),
                         ),
                 ),
-        )
+        ))
 }
 
 fn render_project(


### PR DESCRIPTION
- Fix sidebar projects list scrolling by ensuring the scroll container can shrink in flex layouts (min-height: 0).\n- Keep the projects scrollbar overlay narrow to avoid intercepting scroll wheel events.\n- Add a GPUI test covering wheel scrolling in an overflowing sidebar.\n\nLocal verification: 
running 14 tests
test app_assets::tests::app_assets_load_custom_icons ... ok
test services::codex_cli::tests::codex_stdout_parsing_treats_plain_text_as_noise ... ok
test services::tests::codex_item_ids_are_scoped_per_turn ... ok
test services::codex_cli::tests::codex_stdout_parsing_accepts_legacy_json_events ... ok
test services::codex_cli::tests::codex_stdout_parsing_accepts_events ... ok
test services::codex_cli::tests::codex_stdout_parsing_ignores_unknown_events ... ok
test services::tests::transient_reconnect_notice_detection_is_stable ... ok
test services::tests::codex_runner_reports_missing_executable ... ok
test tests::init_components_forces_light_theme ... ok
test sqlite_store::tests::migrations_create_schema ... ok
test sqlite_store::tests::conversation_append_allows_same_raw_id_across_turns_when_scoped ... ok
test sqlite_store::tests::save_and_load_app_state_roundtrips ... ok
test sqlite_store::tests::conversation_append_is_idempotent_by_codex_item_id ... ok
test services::tests::worktree_remove_force_allows_dirty_worktree ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s


running 45 tests
test chat_draft::tests::extracts_context_tokens_and_returns_clean_draft ... ok
test context_tokens::tests::unknown_kinds_are_ignored ... ok
test chat_draft::tests::compose_inserts_context_tokens_at_anchors_in_order ... ok
test context_tokens::tests::context_token_parsing_is_tolerant_and_ordered ... ok
test dashboard::tests::dashboard_cards_exclude_main_workspaces ... ok
test paths::tests::workspace_context_dir_is_nested_under_conversations ... ok
test paths::tests::roots_join_to_expected_subdirs ... ok
test dashboard::tests::dashboard_stage_tracks_pull_request_completion ... ok
test reducer::tests::add_project_emits_save_app_state_effect ... ok
test reducer::tests::agent_item_completed_is_idempotent ... ok
test reducer::tests::app_started_emits_load_app_state_effect ... ok
test reducer::tests::agent_item_completed_is_idempotent_even_if_not_last_entry ... ok
test reducer::tests::cancel_agent_turn_sets_idle_and_emits_effect ... ok
test reducer::tests::app_state_restores_last_open_workspace ... ok
test reducer::tests::chat_draft_edits_update_attachment_anchors_without_removing ... ok
test reducer::tests::chat_drafts_are_isolated_and_preserved_on_reload ... ok
test reducer::tests::completed_turn_auto_sends_next_queued_prompt ... ok
test reducer::tests::conversation_loaded_does_not_overwrite_newer_local_entries ... ok
test reducer::tests::conversation_loaded_does_not_reset_running_turn_state ... ok
test reducer::tests::conversation_loaded_replaces_entries_when_snapshot_is_newer ... ok
test reducer::tests::create_workspace_sets_busy_and_emits_effect ... ok
test reducer::tests::demo_state_is_consistent ... ok
test reducer::tests::failed_turn_pauses_queue_until_resumed ... ok
test reducer::tests::in_progress_order_tracks_started_items_and_removes_on_complete ... ok
test reducer::tests::main_workspace_cannot_be_archived ... ok
test reducer::tests::new_threads_use_last_selected_agent_settings ... ok
test reducer::tests::open_dashboard_loads_conversations_for_non_main_workspaces ... ok
test reducer::tests::open_workspace_emits_conversation_load_effect ... ok
test reducer::tests::open_workspace_in_ide_emits_effect_for_existing_workspace ... ok
test reducer::tests::open_workspace_in_ide_sets_error_when_workspace_missing ... ok
test reducer::tests::open_workspace_pull_request_emits_effect_for_existing_workspace ... ok
test reducer::tests::open_workspace_pull_request_sets_error_when_workspace_missing ... ok
test reducer::tests::project_expanded_is_persisted ... ok
test reducer::tests::project_slug_is_sanitized_and_unique ... ok
test reducer::tests::queued_turn_updates_current_run_config_when_started ... ok
test reducer::tests::right_pane_tracks_selected_main_pane ... ok
test reducer::tests::running_turn_keeps_its_run_config_when_user_changes_defaults ... ok
test reducer::tests::send_agent_message_sets_running_and_emits_effect ... ok
test reducer::tests::send_agent_message_while_running_is_queued ... ok
test reducer::tests::sidebar_width_is_persisted ... ok
test reducer::tests::terminal_pane_width_is_persisted ... ok
test reducer::tests::toggle_terminal_pane_hides_and_shows_when_workspace_open ... ok
test reducer::tests::toggle_terminal_pane_is_disabled_outside_workspace ... ok
test reducer::tests::workspace_chat_scroll_is_persisted ... ok
test reducer::tests::workspace_thread_tabs_preserve_order_and_allow_reorder ... ok

test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 77 tests
test root::tests::agent_turn_summary_uses_thinking_label_and_omits_messages ... ok
test root::tests::chat_new_items_badge_is_not_rendered ... ok
test root::tests::agent_messages_with_scoped_ids_render_in_multiple_turns ... ok
test root::tests::chat_composer_is_visible_in_workspace ... ok
test root::tests::chat_composer_remains_visible_with_long_history ... ok
test root::tests::chat_column_remains_primary_when_terminal_is_visible ... ok
test root::tests::codex_item_icon_paths_are_stable ... ok
test root::tests::compact_item_summary_is_stable ... ok
test root::tests::chat_composer_renders_model_and_effort_selectors ... ok
test root::tests::chat_surface_does_not_shift_horizontally_on_wide_window_resize ... ok
test root::tests::chat_composer_renders_attachments_inside_surface_in_order ... ok
test root::tests::clicking_project_header_toggles_expanded ... ok
test root::tests::dashboard_columns_show_inset_and_card_spacing ... ok
test root::tests::archiving_workspace_shows_prompt_and_updates_state ... ok
test root::tests::chat_copy_buttons_copy_user_and_agent_messages ... ok
test root::tests::debug_layout_env_parsing ... ok
test root::tests::chat_input_cursor_moves_to_end_on_workspace_switch ... ok
test root::tests::duration_format_is_compact ... ok
test root::tests::clicking_turn_summary_row_toggles_expanded ... ok
test root::tests::chat_composer_can_send_attachments_without_text ... ok
test root::tests::dashboard_uses_full_window_and_renders_horizontal_columns ... ok
test root::tests::main_pane_title_tracks_selected_context ... ok
test root::tests::chat_composer_inserts_attachments_at_anchor_positions ... ok
test root::tests::dashboard_preview_updates_chat_draft ... ok
test root::tests::duplicate_agent_message_ids_render_independently ... ok
test root::tests::chat_input_draft_is_isolated_per_workspace ... ok
test root::tests::markdown_messages_render_in_workspace ... ok
test root::tests::clicking_turn_item_summary_row_toggles_expanded ... ok
test root::tests::long_user_message_bubble_keeps_right_gutter ... ok
test root::tests::project_header_has_extra_spacing_before_main_workspace ... ok
test root::tests::scroll_wheel_events_are_delivered ... ok
test root::tests::dashboard_toggle_returns_to_workspace_without_moving ... ok
test root::tests::open_button_is_in_titlebar_for_workspace ... ok
test root::tests::main_workspace_row_is_rendered_and_is_not_archivable ... ok
test root::tests::long_in_progress_reasoning_does_not_expand_chat_column ... ok
test root::tests::sidebar_workspace_metadata_uses_workspace_name ... ok
test root::tests::sidebar_workspace_title_uses_branch_name ... ok
test root::tests::short_user_message_does_not_fill_max_width ... ok
test root::tests::success_toast_is_shown_and_auto_dismissed ... ok
test root::tests::running_turn_summary_auto_collapses_on_turn_end ... ok
test root::tests::sidebar_buttons_remain_visible_with_long_titles ... ok
test root::tests::dashboard_renders_kanban_cards_and_preview ... ok
test root::tests::dashboard_preview_closes_when_clicking_outside ... ok
test root::tests::running_turn_summary_is_expanded_and_not_toggleable ... ok
test root::tests::running_turn_summary_keeps_completed_items_visible_while_running ... ok
test root::tests::dashboard_preview_panel_can_be_resized ... ok
test root::tests::titlebar_context_tracks_selected_workspace ... ok
test root::tests::terminal_is_reinitialized_after_session_exits ... ok
test root::tests::titlebar_buttons_keep_terminal_toggle_on_far_right ... ok
test root::tests::tail_turn_duration_renders_from_view_pending_state ... ok
test root::tests::titlebar_double_click_triggers_window_action ... ok
test root::tests::terminal_pane_has_reasonable_default_width ... ok
test root::tests::long_command_execution_does_not_expand_chat_column ... ok
test root::tests::sidebar_can_be_resized_by_dragging_divider ... ok
test root::tests::terminal_title_is_rendered_in_titlebar_when_visible ... ok
test root::tests::user_message_context_attachments_render_in_order ... ok
test root::tests::titlebar_workspace_title_does_not_render_prefix_icon ... ok
test root::tests::terminal_grid_updates_after_sidebar_resize ... ok
test root::tests::turn_duration_renders_below_messages ... ok
test root::tests::workspace_icons_are_vertically_centered_in_rows ... ok
test root::tests::turn_summary_includes_error_items ... ok
test root::tests::user_messages_render_context_tokens_in_order ... ok
test root::tests::user_message_reflows_on_window_resize ... ok
test root::tests::terminal_pane_can_be_resized_by_dragging_divider ... ok
test root::tests::sidebar_projects_list_renders_scrollbar_when_overflowing ... ok
test root::tests::user_message_text_can_be_selected_and_copied ... ok
test root::tests::workspace_thread_tabs_do_not_expand_to_fill_strip ... ok
test root::tests::workspace_thread_tabs_render_all_open_tabs_and_menu ... ok
test root::tests::chat_composer_stays_in_viewport_with_terminal_and_long_history ... ok
test root::tests::workspace_pr_label_opens_pull_request ... ok
test root::tests::dashboard_preview_blocks_kanban_scroll ... ok
test root::tests::workspace_thread_tabs_menu_hides_archived_section_when_empty ... ok
test root::tests::workspace_row_shows_pull_request_number_when_available ... ok
test root::tests::workspace_row_shows_running_spinner_and_unread_completion_badge ... ok
test root::tests::workspace_thread_tabs_menu_separates_active_and_archived ... ok
test root::tests::sidebar_projects_list_can_scroll_with_wheel ... ok
test root::tests::chat_scroll_position_is_saved_and_restored ... ok

test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.15s.