### PR TITLE
UI: follow chat tail (auto-scroll)

### DIFF
--- a/crates/luban_ui/src/root/dashboard.rs
+++ b/crates/luban_ui/src/root/dashboard.rs
@@ -444,6 +444,18 @@ impl LubanRootView {
             }
         }
 
+        if chat_target_changed {
+            let offset_y10 = quantize_pixels_y10(self.chat_scroll_handle.offset().y);
+            self.chat_last_observed_scroll_offset_y10
+                .insert(chat_key, offset_y10);
+        }
+        update_chat_follow_state(
+            chat_key,
+            &self.chat_scroll_handle,
+            &mut self.chat_follow_tail,
+            &mut self.chat_last_observed_scroll_offset_y10,
+        );
+
         let theme = cx.theme();
 
         let draft_text = conversation.map(|c| c.draft.clone()).unwrap_or_default();
@@ -554,6 +566,10 @@ impl LubanRootView {
             &running_turn_summary_items,
             force_expand_current_turn,
         );
+
+        if self.should_chat_follow_tail(chat_key) {
+            self.chat_scroll_handle.scroll_to_bottom();
+        }
         self.last_chat_workspace_id = Some(chat_key);
         self.last_chat_item_count = entries_len;
 


### PR DESCRIPTION
Behavior:\n- Auto-scroll to the bottom as new messages/items arrive (including streaming updates).\n- Stop auto-scrolling once the user manually scrolls up; resume when they return to the bottom.\n- When switching back to a chat, keep following the newest messages unless the user had scrolled up.\n\nVerification:\n- just fmt && just lint && just test\n\nTests added:\n- chat_auto_scroll_follows_tail_on_new_entries\n- chat_auto_scroll_stops_when_user_scrolled_up\n- chat_auto_scroll_follows_tail_after_returning_to_chat\n