### PR TITLE
feat(web): improve xterm WebGL clarity

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -60,6 +60,33 @@
   --luban-font-chat: "Inter";
   --luban-font-code: "Geist Mono";
   --luban-font-terminal: "Geist Mono";
+
+  --terminal-font-size: 12;
+  --terminal-line-height: 1.25;
+  --terminal-letter-spacing: 0;
+  --terminal-use-webgl: 1;
+  --terminal-allow-transparency: 0;
+  --terminal-background: var(--card);
+  --terminal-foreground: var(--card-foreground);
+  --terminal-cursor: var(--foreground);
+
+  --terminal-ansi-black: #111827;
+  --terminal-ansi-red: var(--destructive);
+  --terminal-ansi-green: var(--status-success);
+  --terminal-ansi-yellow: var(--status-warning);
+  --terminal-ansi-blue: var(--primary);
+  --terminal-ansi-magenta: var(--status-info);
+  --terminal-ansi-cyan: #06b6d4;
+  --terminal-ansi-white: #d1d5db;
+
+  --terminal-ansi-bright-black: var(--muted-foreground);
+  --terminal-ansi-bright-red: #f87171;
+  --terminal-ansi-bright-green: #4ade80;
+  --terminal-ansi-bright-yellow: #fbbf24;
+  --terminal-ansi-bright-blue: #60a5fa;
+  --terminal-ansi-bright-magenta: #a78bfa;
+  --terminal-ansi-bright-cyan: #22d3ee;
+  --terminal-ansi-bright-white: #f9fafb;
 }
 
 .dark {
@@ -111,6 +138,12 @@
   --status-warning: #fbbf24;
   --status-error: #f87171;
   --status-info: #a78bfa;
+
+  --terminal-ansi-black: #0a0a0a;
+  --terminal-ansi-cyan: #22d3ee;
+  --terminal-ansi-white: #d4d4d4;
+  --terminal-ansi-bright-black: #737373;
+  --terminal-ansi-bright-white: #fafafa;
 }
 
 @theme inline {

--- a/web/components/agent-ide.tsx
+++ b/web/components/agent-ide.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/ui-prefs"
 
 function clamp(n: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, n))
+  return Math.round(Math.max(min, Math.min(max, n)))
 }
 
 export function AgentIDE() {


### PR DESCRIPTION
## Summary
- Improve xterm rendering clarity while keeping WebGL enabled (disable transparency by default and refresh the WebGL atlas after resize/theme changes).
- Map terminal theme and typography via CSS tokens for consistent styling.
- Avoid subpixel layout widths that can blur canvas/WebGL text.
- Prevent xterm OSC color query replies from leaking back into the PTY.
- Stabilize terminal E2E readiness checks.

## Verification
- `just fmt && just lint && just test`
- `cd web && pnpm playwright test tests/e2e/terminal-ui.spec.ts --reporter=list`
