### PR TITLE
fix(web): remove unexpected focus outline on worktree items

### DIFF
--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -503,7 +503,7 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
                     <div
                       key={worktree.workspaceId}
                       className={cn(
-                        "group/worktree relative flex items-center gap-2 px-2 py-1.5 transition-all cursor-pointer",
+                        "group/worktree relative flex items-center gap-2 px-2 py-1.5 transition-all cursor-pointer outline-none",
                         worktree.workspaceId === activeWorkspaceId ? "bg-primary/6" : "hover:bg-sidebar-accent/30",
                         newlyCreatedWorkspaceId === worktree.workspaceId &&
                           "animate-in slide-in-from-left-2 fade-in duration-300 ring-1 ring-primary/30",


### PR DESCRIPTION
## Problem

第一个展开的 project 的最后一个 workspace 会有奇怪的选中框（浏览器默认的 focus outline）。

## Solution

在 worktree 条目的 div 上添加 `outline-none` 类，禁用浏览器默认的 focus ring。

## Changes

- `web/components/sidebar.tsx`: 添加 `outline-none` 到 worktree 条目的 className