### PR TITLE
feat: add zero-config browser launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +513,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +560,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1833,6 +1929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2182,20 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "luban_cli"
+version = "0.1.6"
+dependencies = [
+ "anyhow",
+ "clap",
+ "luban_server",
+ "open",
+ "rand 0.8.5",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2612,6 +2728,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -3953,6 +4075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4638,6 +4770,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -5070,6 +5203,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/luban_api",
     "crates/luban_backend",
     "crates/luban_domain",
+    "crates/luban_cli",
     "crates/luban_server",
     "crates/luban_tauri",
 ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ just app run
 
 The Tauri app starts the local server in-process and loads the UI in a WebView.
 
+### Run (browser, zero-config launcher)
+
+```bash
+cargo run -p luban_cli -- ui
+```
+
+This starts the local server on a random available port, prints a local URL, and opens it in your
+browser.
+
 ### Run (browser, same-origin UI + APIs)
 
 ```bash
@@ -119,6 +128,7 @@ See `docs/contracts/README.md`.
 
 ## Repository layout
 
+- `crates/luban_cli/`: `luban` CLI entrypoint (`luban ui`)
 - `crates/luban_domain/`: pure state + reducers (most regressions should be captured here)
 - `crates/luban_server/`: HTTP + WebSocket server, serves `web/`
 - `crates/luban_tauri/`: Tauri desktop wrapper

--- a/crates/luban_cli/Cargo.toml
+++ b/crates/luban_cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "luban_cli"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "luban"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { version = "4", features = ["derive"] }
+luban_server = { path = "../luban_server" }
+open = "5"
+rand.workspace = true
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+

--- a/crates/luban_cli/src/main.rs
+++ b/crates/luban_cli/src/main.rs
@@ -1,0 +1,91 @@
+use anyhow::Context as _;
+use clap::{Parser, Subcommand};
+use rand::RngCore as _;
+use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+#[command(name = "luban", version, about = "Luban CLI")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start Luban server and open the browser UI.
+    Ui {
+        /// Bind address for the local server (defaults to `127.0.0.1:0`).
+        #[arg(long)]
+        addr: Option<SocketAddr>,
+
+        /// Print the URL but do not open a browser.
+        #[arg(long, default_value_t = false)]
+        no_open: bool,
+    },
+}
+
+fn random_hex(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    let mut out = String::with_capacity(bytes * 2);
+    for b in buf {
+        out.push(hex_char(b >> 4));
+        out.push(hex_char(b & 0x0f));
+    }
+    out
+}
+
+fn hex_char(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        10..=15 => (b'a' + (nibble - 10)) as char,
+        _ => '0',
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+    match cli.cmd {
+        Command::Ui { addr, no_open } => ui(addr, no_open).await,
+    }
+}
+
+async fn ui(addr: Option<SocketAddr>, no_open: bool) -> anyhow::Result<()> {
+    let addr = addr.unwrap_or_else(|| {
+        std::env::var("LUBAN_SERVER_ADDR")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or_else(|| "127.0.0.1:0".parse().expect("valid socket addr"))
+    });
+
+    let token = random_hex(32);
+
+    let server = luban_server::start_server_with_config(
+        addr,
+        luban_server::ServerConfig {
+            auth: luban_server::AuthConfig {
+                mode: luban_server::AuthMode::SingleUser,
+                bootstrap_token: Some(token.clone()),
+            },
+        },
+    )
+    .await?;
+    let url = format!("http://{}/auth?token={}", server.addr, token);
+
+    println!("{url}");
+    if !no_open && let Err(err) = open::that(&url) {
+        tracing::warn!(error = %err, "failed to open browser");
+    }
+
+    tracing::info!(addr = %server.addr, "luban ui started (press Ctrl+C to stop)");
+    tokio::signal::ctrl_c()
+        .await
+        .context("failed to install Ctrl+C handler")?;
+    Ok(())
+}

--- a/crates/luban_server/src/auth.rs
+++ b/crates/luban_server/src/auth.rs
@@ -1,0 +1,147 @@
+use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+use axum::http::header::{COOKIE, SET_COOKIE};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::{Router, routing::get};
+use axum::{extract::Query, extract::State};
+use tokio::sync::{Mutex, RwLock};
+
+static SESSION_COOKIE_NAME: &str = "luban_session";
+
+#[derive(Clone)]
+pub(crate) struct AuthState {
+    mode: crate::AuthMode,
+    bootstrap_token: std::sync::Arc<Mutex<Option<String>>>,
+    session_token: std::sync::Arc<RwLock<Option<String>>>,
+}
+
+impl AuthState {
+    pub(crate) fn new(config: crate::AuthConfig) -> Self {
+        Self {
+            mode: config.mode,
+            bootstrap_token: std::sync::Arc::new(Mutex::new(config.bootstrap_token)),
+            session_token: std::sync::Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.mode != crate::AuthMode::Disabled
+    }
+
+    async fn is_authorized(&self, headers: &HeaderMap) -> bool {
+        if !self.enabled() {
+            return true;
+        }
+
+        let Some(cookie) = headers.get(COOKIE).and_then(|h| h.to_str().ok()) else {
+            return false;
+        };
+        let Some(found) = cookie_value(cookie, SESSION_COOKIE_NAME) else {
+            return false;
+        };
+
+        let session = self.session_token.read().await;
+        session.as_deref() == Some(found)
+    }
+
+    async fn consume_bootstrap_token(&self, token: &str) -> bool {
+        if !self.enabled() {
+            return false;
+        }
+
+        let mut bootstrap = self.bootstrap_token.lock().await;
+        let Some(expected) = bootstrap.as_deref() else {
+            return false;
+        };
+        if expected != token {
+            return false;
+        }
+
+        *bootstrap = None;
+        let mut session = self.session_token.write().await;
+        *session = Some(token.to_owned());
+        true
+    }
+}
+
+fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    for part in cookie_header.split(';') {
+        let trimmed = part.trim();
+        let Some((k, v)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if k.trim() == name {
+            return Some(v.trim());
+        }
+    }
+    None
+}
+
+pub(crate) async fn require_session(
+    State(state): State<crate::server::AppStateHolder>,
+    req: axum::http::Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if state.auth.is_authorized(req.headers()).await {
+        return next.run(req).await;
+    }
+    (StatusCode::UNAUTHORIZED, "unauthorized").into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct AuthBootstrapQuery {
+    pub(crate) token: String,
+}
+
+pub(crate) async fn auth_bootstrap(
+    State(state): State<crate::server::AppStateHolder>,
+    Query(query): Query<AuthBootstrapQuery>,
+) -> impl IntoResponse {
+    if !state.auth.enabled() {
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+    if !state.auth.consume_bootstrap_token(query.token.trim()).await {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+
+    let cookie = format!(
+        "{name}={token}; Path=/; HttpOnly; SameSite=Lax",
+        name = SESSION_COOKIE_NAME,
+        token = query.token.trim(),
+    );
+
+    let body = r#"<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="referrer" content="no-referrer" />
+    <title>Luban</title>
+  </head>
+  <body>
+    <script>
+      window.history.replaceState(null, "", "/");
+      window.location.replace("/");
+    </script>
+  </body>
+</html>
+"#;
+
+    let mut resp = (
+        StatusCode::OK,
+        [
+            (CONTENT_TYPE, "text/html; charset=utf-8"),
+            (CACHE_CONTROL, "no-store"),
+        ],
+        body,
+    )
+        .into_response();
+    if let Ok(value) = HeaderValue::from_str(&cookie) {
+        resp.headers_mut().append(SET_COOKIE, value);
+    }
+    resp
+}
+
+pub(crate) fn router() -> Router<crate::server::AppStateHolder> {
+    Router::new().route("/auth", get(auth_bootstrap))
+}

--- a/crates/luban_server/src/lib.rs
+++ b/crates/luban_server/src/lib.rs
@@ -2,11 +2,57 @@ use anyhow::Context as _;
 use axum::Router;
 use std::net::SocketAddr;
 
+mod auth;
 pub mod engine;
 mod git_changes;
 mod mentions;
 pub mod pty;
 pub mod server;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthMode {
+    Disabled,
+    SingleUser,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthConfig {
+    pub mode: AuthMode,
+    pub bootstrap_token: Option<String>,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            mode: AuthMode::Disabled,
+            bootstrap_token: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ServerConfig {
+    pub auth: AuthConfig,
+}
+
+impl ServerConfig {
+    pub fn from_env() -> Self {
+        let mut out = Self::default();
+
+        let mode = std::env::var("LUBAN_AUTH_MODE").unwrap_or_default();
+        out.auth.mode = match mode.trim().to_ascii_lowercase().as_str() {
+            "single_user" | "single-user" | "singleuser" => AuthMode::SingleUser,
+            _ => AuthMode::Disabled,
+        };
+
+        out.auth.bootstrap_token = std::env::var("LUBAN_AUTH_BOOTSTRAP_TOKEN")
+            .ok()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty());
+
+        out
+    }
+}
 
 pub struct StartedServer {
     pub addr: SocketAddr,
@@ -35,7 +81,14 @@ impl Drop for StartedServer {
 }
 
 pub async fn start_server(addr: SocketAddr) -> anyhow::Result<StartedServer> {
-    let app: Router = server::router().await?;
+    start_server_with_config(addr, ServerConfig::from_env()).await
+}
+
+pub async fn start_server_with_config(
+    addr: SocketAddr,
+    config: ServerConfig,
+) -> anyhow::Result<StartedServer> {
+    let app: Router = server::router(config).await?;
 
     let listener = tokio::net::TcpListener::bind(addr)
         .await

--- a/crates/luban_server/tests/auth_bootstrap.rs
+++ b/crates/luban_server/tests/auth_bootstrap.rs
@@ -1,0 +1,66 @@
+use std::net::SocketAddr;
+
+#[tokio::test]
+async fn auth_bootstrap_sets_cookie_and_unlocks_api() {
+    let token = "test_bootstrap_token".to_owned();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let server = luban_server::start_server_with_config(
+        addr,
+        luban_server::ServerConfig {
+            auth: luban_server::AuthConfig {
+                mode: luban_server::AuthMode::SingleUser,
+                bootstrap_token: Some(token.clone()),
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    let health = client
+        .get(format!("http://{}/api/health", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+    let unauthorized = client
+        .get(format!("http://{}/api/app", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let bootstrap = client
+        .get(format!("http://{}/auth?token={}", server.addr, token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bootstrap.status(), reqwest::StatusCode::OK);
+    let set_cookie = bootstrap
+        .headers()
+        .get(reqwest::header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        set_cookie.starts_with("luban_session="),
+        "unexpected set-cookie: {set_cookie}"
+    );
+
+    let authorized = client
+        .get(format!("http://{}/api/app", server.addr))
+        .header(
+            reqwest::header::COOKIE,
+            "luban_session=test_bootstrap_token",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authorized.status(), reqwest::StatusCode::OK);
+}

--- a/docs/contracts/features/c-auth-single-user.md
+++ b/docs/contracts/features/c-auth-single-user.md
@@ -1,0 +1,35 @@
+# C-AUTH-SINGLE-USER
+
+This contract defines the optional single-user authentication flow used by the `luban ui` launcher.
+
+## Scope
+
+When `AuthMode::SingleUser` is enabled on the Rust server:
+
+- All `/api/*` endpoints are protected **except** `GET /api/health`.
+- Both WebSocket endpoints (`/api/events`, `/api/pty/*`) are protected during the handshake.
+
+When auth is disabled, requests behave as documented by the individual endpoint contracts.
+
+## Bootstrap flow
+
+The launcher generates a random token and opens the browser at:
+
+- `GET /auth?token=<bootstrap_token>`
+
+On success, the server:
+
+- Sets a session cookie:
+  - `Set-Cookie: luban_session=<bootstrap_token>; Path=/; HttpOnly; SameSite=Lax`
+- Returns a small HTML page that replaces the current history entry and navigates to `/`.
+
+The `<bootstrap_token>` is accepted **once** per server process. After it is consumed, subsequent
+requests to `/auth` with the same token return `401`.
+
+## Unauthorized behavior
+
+For protected surfaces, when no valid session cookie is present:
+
+- HTTP endpoints return `401` with a plain-text body: `unauthorized`.
+- WebSocket handshakes return `401`.
+

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -49,6 +49,7 @@ Legend:
 
 ## Feature contracts
 
+- `docs/contracts/features/c-auth-single-user.md`
 - `docs/contracts/features/c-http-health.md`
 - `docs/contracts/features/c-http-app.md`
 - `docs/contracts/features/c-http-codex-prompts.md`

--- a/docs/cs-web-quickstart.md
+++ b/docs/cs-web-quickstart.md
@@ -12,6 +12,18 @@ This repo contains a local Rust server (`luban_server`) and a browser UI (`web/`
 `just web run` builds `web/` (requires `pnpm`) and starts `luban_server`, which serves
 the built assets from `/`.
 
+## Run (browser, zero-config launcher)
+
+1. Run:
+   - `cargo run -p luban_cli -- ui`
+2. Your default browser should open automatically.
+
+The launcher:
+
+- binds to `127.0.0.1` with a random available port
+- bootstraps a session cookie via `GET /auth?token=...`
+- then navigates to `/` to load the UI
+
 ## Run (mock mode, UI-first preview)
 
 Mock mode runs the browser UI without starting the Rust server. This is the preferred workflow for


### PR DESCRIPTION
## Summary
- Add a new `luban` CLI with `ui` subcommand for a zero-config browser launch.
- Start `luban_server` on a random localhost port and open the browser automatically.
- Add optional single-user auth bootstrap at `GET /auth?token=...`:
  - sets `HttpOnly` session cookie
  - protects `/api/*` (except `GET /api/health`) and WS endpoints (`/api/events`, `/api/pty/*`)

## Verification
- `just fmt && just lint && just test`
- Manual:
  - `cargo run -p luban_cli -- ui`

## Contracts
- `docs/contracts/features/c-auth-single-user.md`
- `docs/contracts/progress.md`

## Notes / Risks
- The bootstrap token is passed via URL, then removed from browser history by the bootstrap HTML page.
- This is intended for localhost usage (no TLS).
