### PR TITLE
feat: improve resilience for remote UI sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/luban_server/Cargo.toml
+++ b/crates/luban_server/Cargo.toml
@@ -21,3 +21,4 @@ rfd = "0.17"
 
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+tokio-tungstenite = "0.28"

--- a/crates/luban_server/src/auth.rs
+++ b/crates/luban_server/src/auth.rs
@@ -50,6 +50,13 @@ impl AuthState {
             return false;
         }
 
+        {
+            let session = self.session_token.read().await;
+            if session.as_deref() == Some(token) {
+                return true;
+            }
+        }
+
         let mut bootstrap = self.bootstrap_token.lock().await;
         let Some(expected) = bootstrap.as_deref() else {
             return false;
@@ -58,9 +65,9 @@ impl AuthState {
             return false;
         }
 
-        *bootstrap = None;
         let mut session = self.session_token.write().await;
         *session = Some(token.to_owned());
+        *bootstrap = None;
         true
     }
 }

--- a/crates/luban_server/src/idempotency.rs
+++ b/crates/luban_server/src/idempotency.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::sync::{Mutex, oneshot};
+use tokio::time::Instant;
+
+#[derive(Clone)]
+pub(crate) struct IdempotencyStore<V> {
+    inner: std::sync::Arc<Mutex<HashMap<String, Entry<V>>>>,
+    ttl: Duration,
+    max_entries: usize,
+}
+
+enum Entry<V> {
+    InFlight {
+        started_at: Instant,
+        waiters: Vec<oneshot::Sender<Result<V, String>>>,
+    },
+    Done {
+        expires_at: Instant,
+        value: V,
+    },
+}
+
+pub(crate) enum Begin<V> {
+    Owner,
+    Done(V),
+    Wait(oneshot::Receiver<Result<V, String>>),
+}
+
+impl<V: Clone> IdempotencyStore<V> {
+    pub(crate) fn new(ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            inner: std::sync::Arc::new(Mutex::new(HashMap::new())),
+            ttl,
+            max_entries,
+        }
+    }
+
+    pub(crate) async fn begin(&self, key: String) -> Begin<V> {
+        let now = Instant::now();
+        let mut guard = self.inner.lock().await;
+        purge_expired(&mut guard, now);
+
+        match guard.get_mut(&key) {
+            Some(Entry::Done { value, .. }) => Begin::Done(value.clone()),
+            Some(Entry::InFlight { waiters, .. }) => {
+                let (tx, rx) = oneshot::channel();
+                waiters.push(tx);
+                Begin::Wait(rx)
+            }
+            None => {
+                guard.insert(
+                    key,
+                    Entry::InFlight {
+                        started_at: now,
+                        waiters: Vec::new(),
+                    },
+                );
+                if guard.len() > self.max_entries {
+                    purge_expired(&mut guard, now);
+                }
+                Begin::Owner
+            }
+        }
+    }
+
+    pub(crate) async fn complete(&self, key: String, result: Result<V, String>) {
+        let now = Instant::now();
+        let mut guard = self.inner.lock().await;
+
+        let waiters = match guard.remove(&key) {
+            Some(Entry::InFlight { waiters, .. }) => waiters,
+            Some(Entry::Done { .. }) | None => Vec::new(),
+        };
+
+        if let Ok(value) = &result {
+            let expires_at = now + self.ttl;
+            guard.insert(
+                key,
+                Entry::Done {
+                    expires_at,
+                    value: value.clone(),
+                },
+            );
+        }
+
+        for tx in waiters {
+            let _ = tx.send(result.clone());
+        }
+
+        if guard.len() > self.max_entries {
+            purge_expired(&mut guard, now);
+        }
+    }
+}
+
+fn purge_expired<V>(guard: &mut HashMap<String, Entry<V>>, now: Instant) {
+    guard.retain(|_, entry| match entry {
+        Entry::Done { expires_at, .. } => *expires_at > now,
+        Entry::InFlight { started_at, .. } => {
+            now.duration_since(*started_at) < Duration::from_secs(60)
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn idempotency_store_deduplicates_in_flight() {
+        let store = IdempotencyStore::<u64>::new(Duration::from_secs(30), 64);
+        let key = "k1".to_owned();
+
+        match store.begin(key.clone()).await {
+            Begin::Owner => {}
+            _ => panic!("expected owner"),
+        }
+
+        let waiter = match store.begin(key.clone()).await {
+            Begin::Wait(rx) => rx,
+            _ => panic!("expected waiter"),
+        };
+
+        store.complete(key.clone(), Ok(42)).await;
+
+        let got = waiter.await.expect("waiter dropped").expect("ok");
+        assert_eq!(got, 42);
+
+        match store.begin(key.clone()).await {
+            Begin::Done(v) => assert_eq!(v, 42),
+            _ => panic!("expected done"),
+        }
+    }
+}

--- a/crates/luban_server/src/lib.rs
+++ b/crates/luban_server/src/lib.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 mod auth;
 pub mod engine;
 mod git_changes;
+mod idempotency;
 mod mentions;
 pub mod pty;
 pub mod server;

--- a/crates/luban_server/tests/auth_bootstrap.rs
+++ b/crates/luban_server/tests/auth_bootstrap.rs
@@ -53,6 +53,13 @@ async fn auth_bootstrap_sets_cookie_and_unlocks_api() {
         "unexpected set-cookie: {set_cookie}"
     );
 
+    let bootstrap_again = client
+        .get(format!("http://{}/auth?token={}", server.addr, token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bootstrap_again.status(), reqwest::StatusCode::OK);
+
     let authorized = client
         .get(format!("http://{}/api/app", server.addr))
         .header(

--- a/crates/luban_server/tests/ws_resync.rs
+++ b/crates/luban_server/tests/ws_resync.rs
@@ -1,0 +1,62 @@
+use futures::{SinkExt as _, StreamExt as _};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+#[tokio::test]
+async fn ws_hello_triggers_app_changed_resync() {
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let server =
+        luban_server::start_server_with_config(addr, luban_server::ServerConfig::default())
+            .await
+            .unwrap();
+
+    let url = format!("ws://{}/api/events", server.addr);
+    let (mut socket, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    let first = tokio::time::timeout(Duration::from_secs(1), socket.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let Message::Text(first_text) = first else {
+        panic!("expected first message to be text");
+    };
+    let first_msg: luban_api::WsServerMessage = serde_json::from_str(&first_text).unwrap();
+    assert!(matches!(
+        first_msg,
+        luban_api::WsServerMessage::Hello { .. }
+    ));
+
+    let hello = luban_api::WsClientMessage::Hello {
+        protocol_version: luban_api::PROTOCOL_VERSION,
+        last_seen_rev: None,
+    };
+    socket
+        .send(Message::Text(serde_json::to_string(&hello).unwrap().into()))
+        .await
+        .unwrap();
+
+    let mut saw_app_changed = false;
+    for _ in 0..10 {
+        let next = tokio::time::timeout(Duration::from_secs(1), socket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let Message::Text(text) = next else {
+            continue;
+        };
+        let msg: luban_api::WsServerMessage = serde_json::from_str(&text).unwrap();
+        if let luban_api::WsServerMessage::Event { event, .. } = msg
+            && matches!(*event, luban_api::ServerEvent::AppChanged { .. })
+        {
+            saw_app_changed = true;
+            break;
+        }
+    }
+    assert!(
+        saw_app_changed,
+        "expected an AppChanged resync event after hello"
+    );
+}

--- a/docs/contracts/features/c-auth-single-user.md
+++ b/docs/contracts/features/c-auth-single-user.md
@@ -23,8 +23,8 @@ On success, the server:
   - `Set-Cookie: luban_session=<bootstrap_token>; Path=/; HttpOnly; SameSite=Lax`
 - Returns a small HTML page that replaces the current history entry and navigates to `/`.
 
-The `<bootstrap_token>` is accepted **once** per server process. After it is consumed, subsequent
-requests to `/auth` with the same token return `401`.
+The `<bootstrap_token>` is accepted **once** to establish the session, but may be reused to
+re-issue the session cookie (idempotent retry) for the lifetime of the server process.
 
 ## Unauthorized behavior
 
@@ -32,4 +32,3 @@ For protected surfaces, when no valid session cookie is present:
 
 - HTTP endpoints return `401` with a plain-text body: `unauthorized`.
 - WebSocket handshakes return `401`.
-

--- a/docs/contracts/features/c-http-attachments-upload.md
+++ b/docs/contracts/features/c-http-attachments-upload.md
@@ -19,6 +19,12 @@ Multipart form-data:
 - `kind`: `AttachmentKind` (`image` | `text` | `file`)
 - `file`: binary payload
 
+Optional headers:
+
+- `Idempotency-Key`: an opaque client-generated key used to deduplicate retries. If the same
+  request is retried with the same key, the provider may return the original `AttachmentRef`
+  instead of creating a new attachment.
+
 ## Response
 
 - `200 OK`

--- a/docs/contracts/features/c-ws-pty.md
+++ b/docs/contracts/features/c-ws-pty.md
@@ -16,6 +16,8 @@ PTY streaming for the terminal UI.
 - Provider invariants:
   - The server must provide a bounded replay on connect for stable refresh/reconnect UX.
   - The protocol must be robust to reconnects and network loss.
+  - If a client lags behind and drops output (e.g. due to a slow network), the server may replay the
+    bounded output history again to help the client recover.
 
 - Mock-mode invariant:
   - The UI must render an interactive terminal without requiring the server. This is implemented as a

--- a/web/lib/luban-transport.ts
+++ b/web/lib/luban-transport.ts
@@ -7,6 +7,10 @@ import { isMockMode } from "./luban-mode"
 import { mockDispatchAction, mockRequest } from "./mock/mock-runtime"
 
 const PROTOCOL_VERSION = 1
+const MAX_PENDING_ACTIONS = 128
+const HEARTBEAT_INTERVAL_MS = 20_000
+const RECONNECT_BASE_DELAY_MS = 200
+const RECONNECT_MAX_DELAY_MS = 5_000
 
 function randomRequestId(): string {
   return `req_${Math.random().toString(16).slice(2)}_${Date.now().toString(16)}`
@@ -23,6 +27,11 @@ type PendingResponse = {
   reject: (err: Error) => void
 }
 
+type QueuedAction = {
+  action: ClientAction
+  requestId: string
+}
+
 export function useLubanTransport(args: {
   onEvent: (event: ServerEvent) => void
   onError: (message: string) => void
@@ -34,9 +43,10 @@ export function useLubanTransport(args: {
   const [wsConnected, setWsConnected] = useState(false)
 
   const wsRef = useRef<WebSocket | null>(null)
-  const pendingActionsRef = useRef<ClientAction[]>([])
+  const pendingActionsRef = useRef<QueuedAction[]>([])
   const pendingResponsesRef = useRef<Map<string, PendingResponse>>(new Map())
   const handlersRef = useRef({ onEvent: args.onEvent, onError: args.onError })
+  const lastSeenRevRef = useRef<number | null>(null)
 
   useEffect(() => {
     handlersRef.current = { onEvent: args.onEvent, onError: args.onError }
@@ -52,18 +62,19 @@ export function useLubanTransport(args: {
       return
     }
 
+    const resolvedRequestId = requestId ?? randomRequestId()
     const ws = wsRef.current
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       const queue = pendingActionsRef.current
-      if (queue.length < 128) {
-        queue.push(action)
+      if (queue.length < MAX_PENDING_ACTIONS) {
+        queue.push({ action, requestId: resolvedRequestId })
       } else {
         queue.shift()
-        queue.push(action)
+        queue.push({ action, requestId: resolvedRequestId })
       }
       return
     }
-    const msg: WsClientMessage = { type: "action", request_id: requestId ?? randomRequestId(), action }
+    const msg: WsClientMessage = { type: "action", request_id: resolvedRequestId, action }
     ws.send(JSON.stringify(msg))
   }
 
@@ -86,7 +97,7 @@ export function useLubanTransport(args: {
     if (isMockMode()) {
       setWsConnected(true)
       const pending = pendingActionsRef.current.splice(0, pendingActionsRef.current.length)
-      for (const action of pending) {
+      for (const { action } of pending) {
         try {
           mockDispatchAction({ action, onEvent: handlersRef.current.onEvent })
         } catch (err) {
@@ -96,111 +107,179 @@ export function useLubanTransport(args: {
       return
     }
 
-    const ws = new WebSocket(wsUrl("/api/events"))
-    wsRef.current = ws
+    let disposed = false
+    let reconnectTimer: number | null = null
+    let heartbeatTimer: number | null = null
+    let connectAttempt = 0
 
-    ws.onopen = () => {
-      const hello: WsClientMessage = {
-        type: "hello",
-        protocol_version: PROTOCOL_VERSION,
-        last_seen_rev: null,
+    function rejectAllPending(reason: string) {
+      for (const [, pending] of pendingResponsesRef.current) {
+        pending.reject(new Error(reason))
       }
-      ws.send(JSON.stringify(hello))
-      setWsConnected(true)
+      pendingResponsesRef.current.clear()
+    }
 
-      const pending = pendingActionsRef.current.splice(0, pendingActionsRef.current.length)
-      for (const action of pending) {
-        const msg: WsClientMessage = { type: "action", request_id: randomRequestId(), action }
-        ws.send(JSON.stringify(msg))
+    function scheduleReconnect() {
+      if (disposed) return
+      if (reconnectTimer != null) return
+      const exp = Math.min(connectAttempt, 6)
+      const base = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** exp)
+      const jitter = Math.floor(Math.random() * 100)
+      reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null
+        connect()
+      }, base + jitter)
+      connectAttempt += 1
+    }
+
+    function stopHeartbeat() {
+      if (heartbeatTimer != null) {
+        window.clearInterval(heartbeatTimer)
+        heartbeatTimer = null
       }
     }
 
-    ws.onmessage = (ev) => {
-      if (typeof ev.data !== "string") return
+    function startHeartbeat(ws: WebSocket) {
+      stopHeartbeat()
+      heartbeatTimer = window.setInterval(() => {
+        if (ws.readyState !== WebSocket.OPEN) return
+        const ping: WsClientMessage = { type: "ping" }
+        ws.send(JSON.stringify(ping))
+      }, HEARTBEAT_INTERVAL_MS)
+    }
 
-      let msg: WsServerMessage
-      try {
-        msg = JSON.parse(ev.data) as WsServerMessage
-      } catch {
-        handlersRef.current.onError("Invalid server message")
-        return
+    function connect() {
+      if (disposed) return
+
+      const ws = new WebSocket(wsUrl("/api/events"))
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        connectAttempt = 0
+        setWsConnected(true)
+
+        const hello: WsClientMessage = {
+          type: "hello",
+          protocol_version: PROTOCOL_VERSION,
+          last_seen_rev: lastSeenRevRef.current,
+        }
+        ws.send(JSON.stringify(hello))
+
+        startHeartbeat(ws)
+
+        const pending = pendingActionsRef.current.splice(0, pendingActionsRef.current.length)
+        for (const queued of pending) {
+          const msg: WsClientMessage = { type: "action", request_id: queued.requestId, action: queued.action }
+          ws.send(JSON.stringify(msg))
+        }
       }
 
-      if (msg.type === "event") {
-        const event = msg.event
+      ws.onmessage = (ev) => {
+        if (typeof ev.data !== "string") return
 
-        if (
-          event.type === "project_path_picked" ||
-          event.type === "add_project_and_open_ready" ||
-          event.type === "task_preview_ready" ||
-          event.type === "task_executed" ||
-          event.type === "feedback_submitted" ||
-          event.type === "codex_check_ready" ||
-          event.type === "codex_config_tree_ready" ||
-          event.type === "codex_config_list_dir_ready" ||
-          event.type === "codex_config_file_ready" ||
-          event.type === "codex_config_file_saved" ||
-          event.type === "amp_check_ready" ||
-          event.type === "amp_config_tree_ready" ||
-          event.type === "amp_config_list_dir_ready" ||
-          event.type === "amp_config_file_ready" ||
-          event.type === "amp_config_file_saved" ||
-          event.type === "claude_check_ready" ||
-          event.type === "claude_config_tree_ready" ||
-          event.type === "claude_config_list_dir_ready" ||
-          event.type === "claude_config_file_ready" ||
-          event.type === "claude_config_file_saved"
-        ) {
-          const pending = pendingResponsesRef.current.get(event.request_id)
-          if (pending) {
-            pendingResponsesRef.current.delete(event.request_id)
-            if (event.type === "project_path_picked") pending.resolve(event.path)
-            if (event.type === "add_project_and_open_ready")
-              pending.resolve({ projectId: event.project_id, workspaceId: event.workspace_id })
-            if (event.type === "task_preview_ready") pending.resolve(event.draft)
-            if (event.type === "task_executed") pending.resolve(event.result)
-            if (event.type === "feedback_submitted") pending.resolve(event.result)
-            if (event.type === "codex_check_ready") pending.resolve({ ok: event.ok, message: event.message })
-            if (event.type === "codex_config_tree_ready") pending.resolve(event.tree)
-            if (event.type === "codex_config_list_dir_ready")
-              pending.resolve({ path: event.path, entries: event.entries })
-            if (event.type === "codex_config_file_ready") pending.resolve(event.contents)
-            if (event.type === "codex_config_file_saved") pending.resolve(null)
-            if (event.type === "amp_check_ready") pending.resolve({ ok: event.ok, message: event.message })
-            if (event.type === "amp_config_tree_ready") pending.resolve(event.tree)
-            if (event.type === "amp_config_list_dir_ready") pending.resolve({ path: event.path, entries: event.entries })
-            if (event.type === "amp_config_file_ready") pending.resolve(event.contents)
-            if (event.type === "amp_config_file_saved") pending.resolve(null)
-            if (event.type === "claude_check_ready") pending.resolve({ ok: event.ok, message: event.message })
-            if (event.type === "claude_config_tree_ready") pending.resolve(event.tree)
-            if (event.type === "claude_config_list_dir_ready") pending.resolve({ path: event.path, entries: event.entries })
-            if (event.type === "claude_config_file_ready") pending.resolve(event.contents)
-            if (event.type === "claude_config_file_saved") pending.resolve(null)
-          }
+        let msg: WsServerMessage
+        try {
+          msg = JSON.parse(ev.data) as WsServerMessage
+        } catch {
+          handlersRef.current.onError("Invalid server message")
           return
         }
 
-        handlersRef.current.onEvent(event)
-        return
-      }
+        if (msg.type === "event") {
+          lastSeenRevRef.current = msg.rev
+          const event = msg.event
 
-      if (msg.type === "error") {
-        if (msg.request_id) {
-          const pending = pendingResponsesRef.current.get(msg.request_id)
-          if (pending) {
-            pendingResponsesRef.current.delete(msg.request_id)
-            pending.reject(new Error(msg.message))
+          if (
+            event.type === "project_path_picked" ||
+            event.type === "add_project_and_open_ready" ||
+            event.type === "task_preview_ready" ||
+            event.type === "task_executed" ||
+            event.type === "feedback_submitted" ||
+            event.type === "codex_check_ready" ||
+            event.type === "codex_config_tree_ready" ||
+            event.type === "codex_config_list_dir_ready" ||
+            event.type === "codex_config_file_ready" ||
+            event.type === "codex_config_file_saved" ||
+            event.type === "amp_check_ready" ||
+            event.type === "amp_config_tree_ready" ||
+            event.type === "amp_config_list_dir_ready" ||
+            event.type === "amp_config_file_ready" ||
+            event.type === "amp_config_file_saved" ||
+            event.type === "claude_check_ready" ||
+            event.type === "claude_config_tree_ready" ||
+            event.type === "claude_config_list_dir_ready" ||
+            event.type === "claude_config_file_ready" ||
+            event.type === "claude_config_file_saved"
+          ) {
+            const pending = pendingResponsesRef.current.get(event.request_id)
+            if (pending) {
+              pendingResponsesRef.current.delete(event.request_id)
+              if (event.type === "project_path_picked") pending.resolve(event.path)
+              if (event.type === "add_project_and_open_ready")
+                pending.resolve({ projectId: event.project_id, workspaceId: event.workspace_id })
+              if (event.type === "task_preview_ready") pending.resolve(event.draft)
+              if (event.type === "task_executed") pending.resolve(event.result)
+              if (event.type === "feedback_submitted") pending.resolve(event.result)
+              if (event.type === "codex_check_ready") pending.resolve({ ok: event.ok, message: event.message })
+              if (event.type === "codex_config_tree_ready") pending.resolve(event.tree)
+              if (event.type === "codex_config_list_dir_ready")
+                pending.resolve({ path: event.path, entries: event.entries })
+              if (event.type === "codex_config_file_ready") pending.resolve(event.contents)
+              if (event.type === "codex_config_file_saved") pending.resolve(null)
+              if (event.type === "amp_check_ready") pending.resolve({ ok: event.ok, message: event.message })
+              if (event.type === "amp_config_tree_ready") pending.resolve(event.tree)
+              if (event.type === "amp_config_list_dir_ready")
+                pending.resolve({ path: event.path, entries: event.entries })
+              if (event.type === "amp_config_file_ready") pending.resolve(event.contents)
+              if (event.type === "amp_config_file_saved") pending.resolve(null)
+              if (event.type === "claude_check_ready") pending.resolve({ ok: event.ok, message: event.message })
+              if (event.type === "claude_config_tree_ready") pending.resolve(event.tree)
+              if (event.type === "claude_config_list_dir_ready")
+                pending.resolve({ path: event.path, entries: event.entries })
+              if (event.type === "claude_config_file_ready") pending.resolve(event.contents)
+              if (event.type === "claude_config_file_saved") pending.resolve(null)
+            }
             return
           }
+
+          handlersRef.current.onEvent(event)
+          return
         }
-        handlersRef.current.onError(msg.message)
+
+        if (msg.type === "error") {
+          if (msg.request_id) {
+            const pending = pendingResponsesRef.current.get(msg.request_id)
+            if (pending) {
+              pendingResponsesRef.current.delete(msg.request_id)
+              pending.reject(new Error(msg.message))
+              return
+            }
+          }
+          handlersRef.current.onError(msg.message)
+        }
+      }
+
+      ws.onerror = () => {}
+
+      ws.onclose = () => {
+        if (wsRef.current !== ws) return
+        stopHeartbeat()
+        setWsConnected(false)
+        rejectAllPending("disconnected")
+        scheduleReconnect()
       }
     }
 
-    ws.onerror = () => setWsConnected(false)
-    ws.onclose = () => setWsConnected(false)
+    connect()
 
-    return () => ws.close()
+    return () => {
+      disposed = true
+      if (reconnectTimer != null) window.clearTimeout(reconnectTimer)
+      stopHeartbeat()
+      rejectAllPending("disconnected")
+      wsRef.current?.close()
+      wsRef.current = null
+    }
   }, [])
 
   return { wsConnected, sendAction, request }


### PR DESCRIPTION
## User-visible behavior
- Auth bootstrap (`/auth?token=...`) is idempotent: retrying the same token succeeds and re-issues the cookie.
- WebSocket `/api/events` reconnects with backoff and triggers state resync on reconnect or server-side lag.
- PTY WebSocket `/api/pty/*` tolerates lag and reconnects; client input is bounded while disconnected.
- Attachment upload supports `Idempotency-Key` and a single retry on network errors without duplicating uploads.

## Implementation summary
- Server: add idempotent auth bootstrap, WS resync-on-hello and resync-on-lag, PTY lag replay, attachment upload idempotency store.
- Web: transport reconnect + heartbeat, resync UI data after reconnect, upload idempotency header + retry, PTY reconnect.
- Contracts: document idempotent auth, WS resync semantics, PTY replay-on-lag, and upload `Idempotency-Key`.

## Changed locations
- `crates/luban_server/src/auth.rs`
- `crates/luban_server/src/server.rs`
- `crates/luban_server/src/pty.rs`
- `crates/luban_server/src/idempotency.rs`
- `web/lib/luban-transport.ts`
- `web/lib/luban-context.tsx`
- `web/lib/luban-http.ts`
- `web/components/pty-terminal.tsx`
- `docs/contracts/features/c-auth-single-user.md`
- `docs/contracts/features/c-ws-events.md`
- `docs/contracts/features/c-ws-pty.md`
- `docs/contracts/features/c-http-attachments-upload.md`

## Contracts updated
- `docs/contracts/features/c-auth-single-user.md`
- `docs/contracts/features/c-ws-events.md`
- `docs/contracts/features/c-ws-pty.md`
- `docs/contracts/features/c-http-attachments-upload.md`

## Verification
- Ran: `just fmt && just lint && just test`
- Web typecheck is not run locally (missing `web/node_modules`). Optional: `pnpm -C web install && pnpm -C web run typecheck`.

## Manual verification steps
1) Run `just run`.
2) Open the UI in a browser and complete auth bootstrap.
3) Kill the server process, restart it, and confirm the UI reconnects and refreshes app/workspace data.
4) Start a PTY session, interrupt the network briefly (or restart the server), and confirm terminal reconnects.
5) Upload an attachment; retry the upload request (e.g. browser refresh during upload) and confirm it does not create duplicates.

## Risks / rollback
- Risk: in-memory idempotency cache is process-local and TTL-based; restarting the server removes dedupe state.
- Rollback: revert this commit; no data migrations or persistent format changes.
