### PR TITLE
chore(release): tag-driven nightly releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,165 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # 03:00 UTC every day.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Create a release even if there are no new commits since the latest release tag"
+        required: false
+        type: boolean
+        default: false
+      build_date:
+        description: "Override build date (UTC, YYYYMMDD). Leave empty to use current UTC date."
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  create_release:
+    name: Create tag + GitHub release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure on latest main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --prune --tags origin main
+          git checkout -B main origin/main
+
+      - name: Compute nightly release version
+        id: bump
+        shell: bash
+        env:
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
+          BUILD_DATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_date || '' }}
+        run: |
+          set -euo pipefail
+          force="${FORCE}"
+          build_date="${BUILD_DATE}"
+
+          if [[ -z "${build_date}" ]]; then
+            build_date="$(date -u +%Y%m%d)"
+          fi
+          if [[ ! "${build_date}" =~ ^[0-9]{8}$ ]]; then
+            echo "build_date must be YYYYMMDD (UTC), got: ${build_date}" >&2
+            exit 2
+          fi
+
+          last_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1 || true)"
+          if [[ -z "${last_tag}" ]]; then
+            {
+              echo "should_release=false"
+              echo "reason=no_release_tags_found"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          last_rev="$(git rev-list -n 1 "${last_tag}")"
+          current_rev="$(git rev-list -n 1 HEAD)"
+          if [[ "${last_rev}" == "${current_rev}" && "${force}" != "true" ]]; then
+            {
+              echo "should_release=false"
+              echo "reason=no_new_commits_since_last_release"
+              echo "last_tag=${last_tag}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          core="${last_tag#v}"
+          core="${core%%+*}"
+          IFS='.' read -r major minor patch <<<"${core}"
+          if [[ -z "${major}" || -z "${minor}" || -z "${patch}" ]]; then
+            echo "failed to parse semver from tag: ${last_tag}" >&2
+            exit 2
+          fi
+          if [[ ! "${major}" =~ ^[0-9]+$ || ! "${minor}" =~ ^[0-9]+$ || ! "${patch}" =~ ^[0-9]+$ ]]; then
+            echo "tag is not numeric semver: ${last_tag}" >&2
+            exit 2
+          fi
+
+          new_patch="$((patch + 1))"
+          version="${major}.${minor}.${new_patch}+${build_date}"
+          tag="v${version}"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            {
+              echo "should_release=false"
+              echo "reason=tag_already_exists"
+              echo "tag=${tag}"
+              echo "version=${version}"
+              echo "last_tag=${last_tag}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          reason="new_commits_detected"
+          if [[ "${last_rev}" == "${current_rev}" ]]; then
+            reason="forced"
+          fi
+
+          {
+            echo "should_release=true"
+            echo "reason=${reason}"
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "last_tag=${last_tag}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Configure git identity
+        if: steps.bump.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "Luban Robot"
+          git config user.email "robot@luban.dev"
+
+      - name: Tag and push
+        if: steps.bump.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.bump.outputs.tag }}"
+          git tag -a "${tag}" -m "${tag}"
+          git push origin "refs/tags/${tag}"
+
+      - name: Create GitHub release
+        if: steps.bump.outputs.should_release == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = `${{ steps.bump.outputs.tag }}`;
+            const reason = `${{ steps.bump.outputs.reason }}`;
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: tag,
+                generate_release_notes: true,
+                prerelease: false,
+              });
+              core.info(`Created release ${tag} (${reason})`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.info(`Release already exists for ${tag}`);
+              } else {
+                throw e;
+              }
+            }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luban_api"
-version = "0.1.6"
+version = "42.7.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "luban_backend"
-version = "0.1.6"
+version = "42.7.20"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "luban_domain"
-version = "0.1.6"
+version = "42.7.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "luban_server"
-version = "0.1.6"
+version = "42.7.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "luban_tauri"
-version = "0.1.6"
+version = "42.7.20"
 dependencies = [
  "anyhow",
  "luban_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "42.7.20"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/luban_tauri/tauri.conf.json
+++ b/crates/luban_tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Luban",
-  "version": "0.1.6",
+  "version": "42.7.20",
   "identifier": "io.xuanwo.luban",
   "app": {
     "withGlobalTauri": true,

--- a/docs/release-ci.md
+++ b/docs/release-ci.md
@@ -48,6 +48,24 @@ Packaging outputs are written under `dist/` (gitignored) by default.
 Recommended: create and push a tag:
 
 1. Ensure `LUBAN_VAULT` and `OP_SERVICE_ACCOUNT_TOKEN` are configured.
-2. Create a tag like `v0.1.5` and push it (tags containing `-` are rejected).
+2. Create a tag like `v0.1.5+20260127` and push it (tags containing `-` are rejected).
 3. Wait for the `Release` workflow to finish.
 4. Verify `latest.json` and the uploaded artifacts on `releases.luban.dev`.
+
+Note: Repository versions (`Cargo.toml`, `web/package.json`, `crates/luban_tauri/tauri.conf.json`) are placeholders. Release builds derive the user-visible version from the git tag and inject it at build time.
+
+## Nightly patch releases
+
+Workflow file: `.github/workflows/nightly-release.yml`
+
+This workflow runs daily (03:00 UTC) and:
+
+- Checks whether `main` has new commits since the latest release tag.
+- If yes, bumps the patch version and appends a build metadata suffix `+YYYYMMDD`.
+- Creates an annotated tag `v<version>` and a GitHub release.
+- The existing `Release` workflow will then package and upload artifacts when the tag is pushed.
+
+Notes:
+
+- Build date uses UTC by default. Override via workflow dispatch input `build_date` (or `BUILD_DATE=YYYYMMDD`) if needed.
+- If `Cargo.toml` is already ahead of the latest tag (e.g. a manual version bump), the workflow will release that version (with a build suffix) instead of bumping patch again.

--- a/justfile
+++ b/justfile
@@ -25,10 +25,13 @@ web cmd profile="debug":
       (cd web && pnpm install); \
       (cd web && \
         channel="$([ "{{profile}}" = "release" ] && echo release || echo dev)" && \
-        NEXT_PUBLIC_LUBAN_VERSION="$(node -p 'require("./package.json").version')" \
+        tag="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" && \
+        version="${LUBAN_DISPLAY_VERSION:-${tag#v}}" && \
+        version="${version:-$(node -p 'require("./package.json").version')}" && \
+        NEXT_PUBLIC_LUBAN_VERSION="$version" \
         NEXT_PUBLIC_LUBAN_BUILD_CHANNEL="$channel" \
         NEXT_PUBLIC_LUBAN_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)" \
-        NEXT_PUBLIC_LUBAN_GIT_TAG="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" \
+        NEXT_PUBLIC_LUBAN_GIT_TAG="$tag" \
         NEXT_PUBLIC_LUBAN_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" \
         pnpm build); \
       mkdir -p web/out; \
@@ -53,10 +56,13 @@ web cmd profile="debug":
     fi; \
     (cd web && \
       channel="$([ "{{profile}}" = "release" ] && echo release || echo dev)" && \
-      NEXT_PUBLIC_LUBAN_VERSION="$(node -p 'require("./package.json").version')" \
+      tag="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" && \
+      version="${LUBAN_DISPLAY_VERSION:-${tag#v}}" && \
+      version="${version:-$(node -p 'require("./package.json").version')}" && \
+      NEXT_PUBLIC_LUBAN_VERSION="$version" \
       NEXT_PUBLIC_LUBAN_BUILD_CHANNEL="$channel" \
       NEXT_PUBLIC_LUBAN_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)" \
-      NEXT_PUBLIC_LUBAN_GIT_TAG="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" \
+      NEXT_PUBLIC_LUBAN_GIT_TAG="$tag" \
       NEXT_PUBLIC_LUBAN_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" \
       pnpm dev); \
   elif [ "{{cmd}}" = "dev-mock" ]; then \
@@ -69,11 +75,14 @@ web cmd profile="debug":
     fi; \
     (cd web && \
       channel="$([ "{{profile}}" = "release" ] && echo release || echo dev)" && \
+      tag="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" && \
+      version="${LUBAN_DISPLAY_VERSION:-${tag#v}}" && \
+      version="${version:-$(node -p 'require("./package.json").version')}" && \
       NEXT_PUBLIC_LUBAN_MODE=mock \
-      NEXT_PUBLIC_LUBAN_VERSION="$(node -p 'require("./package.json").version')" \
+      NEXT_PUBLIC_LUBAN_VERSION="$version" \
       NEXT_PUBLIC_LUBAN_BUILD_CHANNEL="$channel" \
       NEXT_PUBLIC_LUBAN_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)" \
-      NEXT_PUBLIC_LUBAN_GIT_TAG="$( [ "$channel" = "release" ] && git describe --tags --exact-match 2>/dev/null || true )" \
+      NEXT_PUBLIC_LUBAN_GIT_TAG="$tag" \
       NEXT_PUBLIC_LUBAN_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" \
       pnpm dev); \
   else \

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luban-web",
-  "version": "0.1.6",
+  "version": "42.7.20",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Summary
- Add a nightly scheduled workflow that creates a new patch tag when main has new commits. The tag format is vX.Y.(Z+1)+YYYYMMDD (UTC).
- Stop committing version bumps for releases: build-time version is injected from the tag into Next.js and Tauri.
- Pin required manifest versions to 42.7.20 as placeholders.

Details
- Nightly workflow: .github/workflows/nightly-release.yml
  - Computes latest v* tag using Git version sort and bumps patch.
  - Supports workflow_dispatch inputs: force, build_date.
  - Creates annotated tag and GitHub release; does not push to main.
- Version injection
  - Web: NEXT_PUBLIC_LUBAN_VERSION is derived from LUBAN_DISPLAY_VERSION or the current exact tag.
  - Tauri bundling: dev tooling passes --config '{"version": "..."}' so bundle metadata and updater version match the tag.
  - Desktop About dialog shows the injected version via LUBAN_DISPLAY_VERSION.

Why Cargo.lock changed
- Workspace version changes require updating the lockfile entries to keep the repo consistent.

Verification
- just fmt && just lint && just test

Manual check
1) Push a tag like v0.1.7+20260127 and confirm the Release workflow runs.
2) Verify latest.json reports version 0.1.7+20260127.
3) Confirm the desktop app About dialog shows 0.1.7+20260127.
