### PR TITLE
CI: Trigger Release workflow from Nightly Release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -23,6 +23,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create_release:
@@ -163,3 +164,18 @@ jobs:
                 throw e;
               }
             }
+
+      - name: Trigger Release workflow
+        if: steps.bump.outputs.should_release == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = `${{ steps.bump.outputs.tag }}`;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "release.yml",
+              ref: tag,
+            });
+            core.info(`Dispatched Release workflow for ${tag}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/release.yml
       - crates/luban_tauri/tauri.conf.json
       - crates/luban_tauri/icons/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +31,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runs_on) }}
     if: >-
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      (startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
     timeout-minutes: ${{ matrix.platform == 'macos' && 180 || 90 }}
     strategy:
       fail-fast: false
@@ -60,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate tag
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: bash
         run: |
           set -euo pipefail
@@ -287,12 +288,12 @@ jobs:
         run: just package "${{ matrix.target }}" release "dist/${{ matrix.target }}"
 
       - name: Upload artifacts to R2
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: bash
         run: just upload "dist/${{ matrix.target }}/package.env" false
 
       - name: Export package env
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: package-env-${{ matrix.target }}
@@ -300,7 +301,7 @@ jobs:
           if-no-files-found: error
 
       - name: Export release assets
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: release-assets-${{ matrix.target }}
@@ -318,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: >-
-      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Nightly Release creates a tag using `GITHUB_TOKEN`, which does not trigger other workflows on `push`.
- After tagging, dispatch `release.yml` on the newly created tag so the Release build runs reliably.

## Changes
- `Nightly Release`: add `actions: write` and dispatch `release.yml` on the created tag.
- `Release`: add `workflow_dispatch` and treat tag-based `workflow_dispatch` the same as tag `push` for publish steps.

## Verification
- `just fmt && just lint && just test-fast`

## Risk
- If tag pushes are later switched to a PAT (which may trigger `on: push`), Release could be triggered twice (push + dispatch). The existing concurrency group should cancel one run.
