### PR TITLE
Fix Windows MSI bundling for +build metadata versions

### DIFF
--- a/docs/release-ci.md
+++ b/docs/release-ci.md
@@ -51,6 +51,7 @@ Recommended: create and push a tag:
 
 1. Ensure `LUBAN_VAULT` and `OP_SERVICE_ACCOUNT_TOKEN` are configured.
 2. Create a tag like `v0.1.5+20260127` and push it (tags containing `-` are rejected).
+   - Note: Windows MSI packaging requires numeric-only build metadata that is <= 65535; the release tooling will normalize `+YYYYMMDD` into an MSI-safe build number while keeping the user-visible version as the tag.
 3. Wait for the `Release` workflow to finish.
 4. Verify `latest.json` and the uploaded artifacts on `releases.luban.dev`.
 5. Verify the GitHub release assets and notes on the corresponding tag release page.


### PR DESCRIPTION
## Summary
- Fix Windows MSI bundling failures when the tag/app version contains SemVer build metadata (e.g. `+YYYYMMDD`).
- Keep the user-visible version unchanged, but normalize the MSI bundle version to a numeric-only build metadata value within `1..=65535`.
- Add unit tests and document the Windows MSI constraint.

## Verification
- `just ci`

## Manual check
1. `just package windows-x86_64 release dist/windows-x86_64`
2. Confirm the log prints an MSI normalization message and an `.msi` is produced under `dist/windows-x86_64/`.

## Risk / Rollback
- Risk: the MSI internal version may differ from the tag build metadata for Windows builds.
- Rollback: revert commit `1130540`.
