### PR TITLE
refactor(server): reduce idempotency store clones

### DIFF
--- a/crates/luban_server/src/idempotency.rs
+++ b/crates/luban_server/src/idempotency.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use tokio::sync::{Mutex, oneshot};
 use tokio::time::Instant;
 
+const IN_FLIGHT_MAX_AGE: Duration = Duration::from_secs(60);
+
 #[derive(Clone)]
 pub(crate) struct IdempotencyStore<V> {
     inner: std::sync::Arc<Mutex<HashMap<String, Entry<V>>>>,
@@ -41,21 +43,20 @@ impl<V: Clone> IdempotencyStore<V> {
         let mut guard = self.inner.lock().await;
         purge_expired(&mut guard, now);
 
-        match guard.get_mut(&key) {
-            Some(Entry::Done { value, .. }) => Begin::Done(value.clone()),
-            Some(Entry::InFlight { waiters, .. }) => {
-                let (tx, rx) = oneshot::channel();
-                waiters.push(tx);
-                Begin::Wait(rx)
-            }
-            None => {
-                guard.insert(
-                    key,
-                    Entry::InFlight {
-                        started_at: now,
-                        waiters: Vec::new(),
-                    },
-                );
+        match guard.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => match entry.get_mut() {
+                Entry::Done { value, .. } => Begin::Done(value.clone()),
+                Entry::InFlight { waiters, .. } => {
+                    let (tx, rx) = oneshot::channel();
+                    waiters.push(tx);
+                    Begin::Wait(rx)
+                }
+            },
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(Entry::InFlight {
+                    started_at: now,
+                    waiters: Vec::new(),
+                });
                 if guard.len() > self.max_entries {
                     purge_expired(&mut guard, now);
                 }
@@ -84,8 +85,12 @@ impl<V: Clone> IdempotencyStore<V> {
             );
         }
 
-        for tx in waiters {
-            let _ = tx.send(result.clone());
+        let mut waiters = waiters;
+        if let Some(last_tx) = waiters.pop() {
+            for tx in waiters {
+                let _ = tx.send(result.clone());
+            }
+            let _ = last_tx.send(result);
         }
 
         if guard.len() > self.max_entries {
@@ -97,9 +102,7 @@ impl<V: Clone> IdempotencyStore<V> {
 fn purge_expired<V>(guard: &mut HashMap<String, Entry<V>>, now: Instant) {
     guard.retain(|_, entry| match entry {
         Entry::Done { expires_at, .. } => *expires_at > now,
-        Entry::InFlight { started_at, .. } => {
-            now.duration_since(*started_at) < Duration::from_secs(60)
-        }
+        Entry::InFlight { started_at, .. } => now.duration_since(*started_at) < IN_FLIGHT_MAX_AGE,
     });
 }
 
@@ -131,5 +134,33 @@ mod tests {
             Begin::Done(v) => assert_eq!(v, 42),
             _ => panic!("expected done"),
         }
+    }
+
+    #[tokio::test]
+    async fn idempotency_store_notifies_multiple_waiters() {
+        let store = IdempotencyStore::<u64>::new(Duration::from_secs(30), 64);
+        let key = "k1".to_owned();
+
+        match store.begin(key.clone()).await {
+            Begin::Owner => {}
+            _ => panic!("expected owner"),
+        }
+
+        let waiter1 = match store.begin(key.clone()).await {
+            Begin::Wait(rx) => rx,
+            _ => panic!("expected waiter"),
+        };
+
+        let waiter2 = match store.begin(key.clone()).await {
+            Begin::Wait(rx) => rx,
+            _ => panic!("expected waiter"),
+        };
+
+        store.complete(key.clone(), Ok(42)).await;
+
+        let got1 = waiter1.await.expect("waiter dropped").expect("ok");
+        let got2 = waiter2.await.expect("waiter dropped").expect("ok");
+        assert_eq!(got1, 42);
+        assert_eq!(got2, 42);
     }
 }


### PR DESCRIPTION
## Summary
- Refactors `IdempotencyStore` to use `HashMap::entry` for clearer control flow and fewer lookups.
- Avoids cloning the completion `Result` for the final waiter.
- Makes in-flight max age an explicit constant.

## User-visible behavior
- No intended behavior changes.

## Verification
- `just fmt`
- `just lint`
- `just test`

## Manual checks
1. Run `just run`.
2. Trigger an attachment upload that hits the idempotency path (or any flow that uses `/api/*` attachments).
3. Repeat the same request quickly and confirm the server responds deterministically.
4. Confirm no log spam or panics.

## Risk
- Low: internal refactor with added unit coverage.

## Rollback
- Revert this PR.
