### PR TITLE
refactor(domain): simplify draft attachment ordering

### DIFF
--- a/crates/luban_domain/src/chat_draft.rs
+++ b/crates/luban_domain/src/chat_draft.rs
@@ -1,10 +1,14 @@
 use crate::{AttachmentRef, DraftAttachment};
 
+fn draft_attachment_sort_key(a: &DraftAttachment) -> (usize, u64) {
+    (a.anchor, a.id)
+}
+
 pub fn ordered_draft_attachments_for_display(
     attachments: &[DraftAttachment],
 ) -> Vec<DraftAttachment> {
     let mut out = attachments.to_vec();
-    out.sort_by(|a, b| (a.anchor, a.id).cmp(&(b.anchor, b.id)));
+    out.sort_by_key(draft_attachment_sort_key);
     out
 }
 
@@ -14,19 +18,19 @@ pub fn compose_user_message_text(draft_text: &str, attachments: &[DraftAttachmen
 }
 
 pub fn ordered_draft_attachments_for_send(attachments: &[DraftAttachment]) -> Vec<AttachmentRef> {
-    let mut ready = attachments
-        .iter()
-        .filter(|a| a.attachment.is_some() && !a.failed)
-        .collect::<Vec<_>>();
-    if ready.is_empty() {
-        return Vec::new();
+    let mut out = Vec::new();
+    for attachment in attachments {
+        let Some(value) = attachment.attachment.as_ref() else {
+            continue;
+        };
+        if attachment.failed {
+            continue;
+        }
+        out.push((draft_attachment_sort_key(attachment), value.clone()));
     }
 
-    ready.sort_by(|a, b| (a.anchor, a.id).cmp(&(b.anchor, b.id)));
-    ready
-        .into_iter()
-        .filter_map(|a| a.attachment.clone())
-        .collect()
+    out.sort_by_key(|(key, _)| *key);
+    out.into_iter().map(|(_, v)| v).collect()
 }
 
 #[cfg(test)]
@@ -37,5 +41,95 @@ mod tests {
     fn compose_returns_plain_text() {
         let composed = compose_user_message_text(" Hello ", &[]);
         assert_eq!(composed, "Hello");
+    }
+
+    #[test]
+    fn attachments_for_display_are_sorted_by_anchor_then_id() {
+        let attachments = vec![
+            DraftAttachment {
+                id: 2,
+                kind: crate::ContextTokenKind::File,
+                anchor: 10,
+                attachment: None,
+                failed: false,
+            },
+            DraftAttachment {
+                id: 1,
+                kind: crate::ContextTokenKind::File,
+                anchor: 10,
+                attachment: None,
+                failed: false,
+            },
+            DraftAttachment {
+                id: 3,
+                kind: crate::ContextTokenKind::File,
+                anchor: 5,
+                attachment: None,
+                failed: false,
+            },
+        ];
+
+        let ordered = ordered_draft_attachments_for_display(&attachments);
+        let ids: Vec<u64> = ordered.into_iter().map(|a| a.id).collect();
+        assert_eq!(ids, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn attachments_for_send_are_filtered_and_sorted() {
+        let attachments = vec![
+            DraftAttachment {
+                id: 2,
+                kind: crate::ContextTokenKind::File,
+                anchor: 10,
+                attachment: Some(AttachmentRef {
+                    id: "b".to_owned(),
+                    kind: crate::AttachmentKind::File,
+                    name: "b".to_owned(),
+                    extension: "txt".to_owned(),
+                    mime: None,
+                    byte_len: 2,
+                }),
+                failed: false,
+            },
+            DraftAttachment {
+                id: 1,
+                kind: crate::ContextTokenKind::File,
+                anchor: 10,
+                attachment: Some(AttachmentRef {
+                    id: "a".to_owned(),
+                    kind: crate::AttachmentKind::File,
+                    name: "a".to_owned(),
+                    extension: "txt".to_owned(),
+                    mime: None,
+                    byte_len: 1,
+                }),
+                failed: false,
+            },
+            DraftAttachment {
+                id: 3,
+                kind: crate::ContextTokenKind::File,
+                anchor: 5,
+                attachment: None,
+                failed: false,
+            },
+            DraftAttachment {
+                id: 4,
+                kind: crate::ContextTokenKind::File,
+                anchor: 0,
+                attachment: Some(AttachmentRef {
+                    id: "c".to_owned(),
+                    kind: crate::AttachmentKind::File,
+                    name: "c".to_owned(),
+                    extension: "txt".to_owned(),
+                    mime: None,
+                    byte_len: 3,
+                }),
+                failed: true,
+            },
+        ];
+
+        let ordered = ordered_draft_attachments_for_send(&attachments);
+        let names: Vec<String> = ordered.into_iter().map(|a| a.name).collect();
+        assert_eq!(names, vec!["a", "b"]);
     }
 }


### PR DESCRIPTION
## Summary
- Centralizes draft attachment ordering logic via a shared sort key.
- Avoids building an intermediate `Vec<&DraftAttachment>` when selecting attachments to send.
- Adds unit tests for ordering and filtering behavior.

## User-visible behavior
- No intended behavior changes.

## Verification
- `just fmt`
- `just lint`
- `just test`

## Manual checks
1. Run `just run`.
2. Add multiple draft attachments at different anchors.
3. Confirm the UI ordering matches anchor then id.
4. Send a message and confirm only non-failed attachments with a resolved ref are included.

## Risk
- Low: domain-only refactor with unit coverage.

## Rollback
- Revert this PR.
