### PR TITLE
Sync workspace branch name via HEAD file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1903,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2065,26 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2216,6 +2265,7 @@ dependencies = [
  "luban_api",
  "luban_backend",
  "luban_domain",
+ "notify",
  "portable-pty",
  "reqwest 0.13.1",
  "rfd",
@@ -2343,6 +2393,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -2453,6 +2515,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4769,7 +4850,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5753,6 +5834,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5800,6 +5890,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5861,6 +5966,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5879,6 +5990,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5894,6 +6011,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5927,6 +6050,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5942,6 +6071,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5963,6 +6098,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5978,6 +6119,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -99,6 +99,10 @@ pub enum Action {
         workspace_id: WorkspaceId,
         branch_name: String,
     },
+    WorkspaceBranchSynced {
+        workspace_id: WorkspaceId,
+        branch_name: String,
+    },
     WorkspaceBranchRenameFailed {
         workspace_id: WorkspaceId,
         message: String,

--- a/crates/luban_server/Cargo.toml
+++ b/crates/luban_server/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.3"
 luban_api = { path = "../luban_api" }
 luban_backend = { path = "../luban_backend" }
 luban_domain = { path = "../luban_domain" }
+notify = "6"
 portable-pty.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/luban_server/src/branch_watch.rs
+++ b/crates/luban_server/src/branch_watch.rs
@@ -1,0 +1,233 @@
+use crate::engine::EngineCommand;
+use luban_domain::WorkspaceId;
+use notify::{Event, RecursiveMode, Watcher as _};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+
+#[derive(Debug)]
+pub(crate) struct BranchWatchHandle {
+    tx: mpsc::Sender<BranchWatchMessage>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+#[derive(Debug)]
+enum BranchWatchMessage {
+    Command(BranchWatchCommand),
+    Event(notify::Result<Event>),
+}
+
+#[derive(Debug)]
+enum BranchWatchCommand {
+    SyncWorkspaces {
+        workspaces: Vec<(WorkspaceId, PathBuf)>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug)]
+struct WatchedWorkspace {
+    head_path: PathBuf,
+    last_branch_name: Option<String>,
+}
+
+impl BranchWatchHandle {
+    pub(crate) fn start(engine_tx: tokio::sync::mpsc::Sender<EngineCommand>) -> Self {
+        let (tx, rx) = mpsc::channel::<BranchWatchMessage>();
+
+        let callback_tx = tx.clone();
+        let join = thread::spawn(move || {
+            let mut watcher = match notify::recommended_watcher(move |res| {
+                let _ = callback_tx.send(BranchWatchMessage::Event(res));
+            }) {
+                Ok(w) => w,
+                Err(err) => {
+                    tracing::error!(error = %err, "failed to initialize branch watcher");
+                    return;
+                }
+            };
+
+            let mut watched = HashMap::<WorkspaceId, WatchedWorkspace>::new();
+            let mut path_to_workspace = HashMap::<PathBuf, WorkspaceId>::new();
+
+            while let Ok(msg) = rx.recv() {
+                match msg {
+                    BranchWatchMessage::Command(cmd) => match cmd {
+                        BranchWatchCommand::SyncWorkspaces { workspaces } => {
+                            sync_workspaces(
+                                &mut watcher,
+                                &mut watched,
+                                &mut path_to_workspace,
+                                workspaces,
+                            );
+                        }
+                        BranchWatchCommand::Shutdown => break,
+                    },
+                    BranchWatchMessage::Event(res) => {
+                        let event = match res {
+                            Ok(event) => event,
+                            Err(err) => {
+                                tracing::debug!(error = %err, "branch watcher event error");
+                                continue;
+                            }
+                        };
+
+                        for path in &event.paths {
+                            let Some(workspace_id) = path_to_workspace.get(path).copied() else {
+                                continue;
+                            };
+                            let Some(entry) = watched.get_mut(&workspace_id) else {
+                                continue;
+                            };
+
+                            let Some(branch_name) = read_branch_name_from_head(&entry.head_path)
+                            else {
+                                continue;
+                            };
+                            if entry.last_branch_name.as_deref() == Some(branch_name.as_str()) {
+                                continue;
+                            }
+                            entry.last_branch_name = Some(branch_name.clone());
+                            let _ = engine_tx.try_send(EngineCommand::WorkspaceBranchObserved {
+                                workspace_id,
+                                branch_name,
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            tx,
+            join: Some(join),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn disabled() -> Self {
+        let (tx, _rx) = mpsc::channel::<BranchWatchMessage>();
+        Self { tx, join: None }
+    }
+
+    pub(crate) fn sync_workspaces(&self, workspaces: Vec<(WorkspaceId, PathBuf)>) {
+        let _ = self.tx.send(BranchWatchMessage::Command(
+            BranchWatchCommand::SyncWorkspaces { workspaces },
+        ));
+    }
+}
+
+impl Drop for BranchWatchHandle {
+    fn drop(&mut self) {
+        let _ = self
+            .tx
+            .send(BranchWatchMessage::Command(BranchWatchCommand::Shutdown));
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn sync_workspaces(
+    watcher: &mut notify::RecommendedWatcher,
+    watched: &mut HashMap<WorkspaceId, WatchedWorkspace>,
+    path_to_workspace: &mut HashMap<PathBuf, WorkspaceId>,
+    workspaces: Vec<(WorkspaceId, PathBuf)>,
+) {
+    let desired_ids = workspaces.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let desired_set = desired_ids
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+
+    let existing_ids = watched.keys().copied().collect::<Vec<_>>();
+    for workspace_id in existing_ids {
+        if desired_set.contains(&workspace_id) {
+            continue;
+        }
+        let Some(entry) = watched.remove(&workspace_id) else {
+            continue;
+        };
+        let _ = watcher.unwatch(&entry.head_path);
+        path_to_workspace.remove(&entry.head_path);
+    }
+
+    for (workspace_id, worktree_path) in workspaces {
+        let Some(head_path) = resolve_head_path(&worktree_path) else {
+            continue;
+        };
+
+        if let Some(existing) = watched.get(&workspace_id)
+            && existing.head_path == head_path
+        {
+            continue;
+        }
+
+        if let Some(existing) = watched.remove(&workspace_id) {
+            let _ = watcher.unwatch(&existing.head_path);
+            path_to_workspace.remove(&existing.head_path);
+        }
+
+        if watcher
+            .watch(&head_path, RecursiveMode::NonRecursive)
+            .is_err()
+        {
+            continue;
+        }
+        path_to_workspace.insert(head_path.clone(), workspace_id);
+        watched.insert(
+            workspace_id,
+            WatchedWorkspace {
+                head_path,
+                last_branch_name: None,
+            },
+        );
+    }
+}
+
+fn resolve_head_path(worktree_path: &Path) -> Option<PathBuf> {
+    let dot_git = worktree_path.join(".git");
+    if dot_git.is_dir() {
+        let head = dot_git.join("HEAD");
+        return Some(std::fs::canonicalize(&head).unwrap_or(head));
+    }
+
+    let git_file = std::fs::read_to_string(&dot_git).ok()?;
+    let git_file = git_file.trim();
+    let rest = git_file.strip_prefix("gitdir:")?.trim();
+    if rest.is_empty() {
+        return None;
+    }
+
+    let gitdir = PathBuf::from(rest);
+    let gitdir = if gitdir.is_absolute() {
+        gitdir
+    } else {
+        worktree_path.join(gitdir)
+    };
+    let head = gitdir.join("HEAD");
+    Some(std::fs::canonicalize(&head).unwrap_or(head))
+}
+
+fn read_branch_name_from_head(head_path: &Path) -> Option<String> {
+    let head = std::fs::read_to_string(head_path).ok()?;
+    Some(branch_name_from_head_contents(&head))
+}
+
+fn branch_name_from_head_contents(contents: &str) -> String {
+    let trimmed = contents.trim();
+    let Some(rest) = trimmed.strip_prefix("ref:") else {
+        return "HEAD".to_owned();
+    };
+
+    let reference = rest.trim();
+    if let Some(stripped) = reference.strip_prefix("refs/heads/") {
+        return stripped.to_owned();
+    }
+    if let Some(stripped) = reference.strip_prefix("refs/") {
+        return stripped.to_owned();
+    }
+
+    reference.to_owned()
+}

--- a/crates/luban_server/src/lib.rs
+++ b/crates/luban_server/src/lib.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use std::net::SocketAddr;
 
 mod auth;
+mod branch_watch;
 pub mod engine;
 mod git_changes;
 mod idempotency;


### PR DESCRIPTION
Summary:
- Add a server-side HEAD watcher for active git workspaces (worktrees) and sync Workspace.branch_name when HEAD changes.
- Introduce domain Action::WorkspaceBranchSynced that updates state and persists only on change.

Testing:
- just fmt
- just lint
- just test

Manual verification:
1) Open a git workspace in Luban.
2) Run `git switch -c test-branch` in the worktree.
3) Confirm the branch label updates without restarting.
4) Run `git branch -m test-branch renamed-branch` and confirm it updates.

Risks:
- File watcher behavior can vary across platforms/filesystems; fallback remains restart (startup reconciliation still applies).

Rollback:
- Revert this commit.

Contracts:
- No changes to HTTP/WebSocket schemas.
