### PR TITLE
fix(web): clear stuck new worktree highlight

### DIFF
--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -118,6 +118,12 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
   }
 
   useEffect(() => {
+    if (newlyCreatedWorkspaceId == null) return
+    const t = window.setTimeout(() => setNewlyCreatedWorkspaceId(null), 1500)
+    return () => window.clearTimeout(t)
+  }, [newlyCreatedWorkspaceId])
+
+  useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<OpenSettingsDetail | null>).detail
       setSettingsInitialSectionId(detail?.sectionId ?? "agent")
@@ -258,8 +264,6 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
 
       setNewlyCreatedWorkspaceId(created)
       void openWorkspace(created).then(() => focusChatInput())
-      const t = window.setTimeout(() => setNewlyCreatedWorkspaceId(null), 1500)
-      return () => window.clearTimeout(t)
     }
 
     const running = app.projects.find((p) => p.create_workspace_status === "running")


### PR DESCRIPTION
## Problem

The last worktree row under the first expanded project could keep a persistent blue ring, instead of clearing after the initial creation highlight.

## Root cause

The highlight-clear timer was owned by an effect that re-runs on `app.rev`. Frequent refreshes could cancel the pending timeout, leaving `newlyCreatedWorkspaceId` stuck.

## Fix

Move the highlight-clear timeout into an effect keyed by `newlyCreatedWorkspaceId`, so it reliably clears after ~1.5s regardless of `app.rev` churn.

## Tests

- `just fmt`
- `just lint`
- `just test`
- `pnpm -C web typecheck`
- `pnpm -C web exec playwright test tests/e2e/worktree-ui.spec.ts`
