### PR TITLE
fix(web): make conversation pagination triggerable without overflow

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -179,7 +179,7 @@
   --status-info: var(--base0e);
 
   --terminal-bright-mix: var(--base07);
-  --terminal-ansi-black: var(--base00);
+  --terminal-ansi-black: #0a0a0a;
   --terminal-ansi-cyan: var(--base0c);
   --terminal-ansi-white: var(--base05);
   --terminal-ansi-bright-black: var(--base03);

--- a/web/components/chat-panel.tsx
+++ b/web/components/chat-panel.tsx
@@ -1128,6 +1128,18 @@ export function ChatPanel({
             data-testid="chat-scroll-container"
             className="flex-1 overflow-y-auto relative"
             ref={setScrollContainer}
+            onWheel={(e) => {
+              const el = e.currentTarget
+              const start = conversation?.entries_start ?? 0
+              if (
+                !loadingOlderRef.current &&
+                start > 0 &&
+                e.deltaY < 0 &&
+                el.scrollTop <= 0
+              ) {
+                void requestOlderConversationPage()
+              }
+            }}
             onScroll={(e) => {
               if (activeWorkspaceId == null || activeThreadId == null) return
               const el = e.target as HTMLDivElement

--- a/web/tests/e2e/conversation-pagination.spec.ts
+++ b/web/tests/e2e/conversation-pagination.spec.ts
@@ -108,6 +108,7 @@ test("loads older conversation entries when scrolling to top", async ({ page }) 
 
   const tabTitles = page.getByTestId("thread-tab-title")
   const beforeTabs = await tabTitles.count()
+  const existingTab = tabTitles.first().locator("..")
   await page.getByTitle("New tab").click()
   await expect(tabTitles).toHaveCount(beforeTabs + 1, { timeout: 20_000 })
   const newTab = tabTitles.last().locator("..")
@@ -132,57 +133,75 @@ test("loads older conversation entries when scrolling to top", async ({ page }) 
       const res = await page.request.get(
         `/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}?limit=1`,
       )
+      if (!res.ok()) return { run_status: "idle", queue_paused: false }
+      const snap = (await res.json()) as { run_status?: string; queue_paused?: boolean }
+      return {
+        run_status: String(snap.run_status ?? "idle"),
+        queue_paused: Boolean(snap.queue_paused ?? false),
+      }
+    }, { timeout: 90_000 })
+    .toMatchObject({ run_status: "idle", queue_paused: true })
+
+  await expect
+    .poll(async () => {
+      const res = await page.request.get(
+        `/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}?limit=1`,
+      )
       if (!res.ok()) return 0
       const snap = (await res.json()) as { entries_total?: number }
       return snap.entries_total ?? 0
     }, { timeout: 60_000 })
     .toBeGreaterThan(2000)
 
-  await expect
-    .poll(async () => {
-      const res = await page.request.get(
-        `/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}?limit=2000`,
-      )
-      if (!res.ok()) return 0
-      const snap = (await res.json()) as { entries_start?: number }
-      return snap.entries_start ?? 0
-    }, { timeout: 60_000 })
-    .toBeGreaterThan(0)
-
   // Force the UI to refresh the conversation via HTTP so the client-side state has
   // `entries_start` populated before we attempt to load older pages.
-  const refreshTab = page.getByTestId("thread-tab-title").last().locator("..")
-  await refreshTab.scrollIntoViewIfNeeded()
-  await refreshTab.click()
-
   const container = page.getByTestId("chat-scroll-container")
-  await page.waitForTimeout(750)
+  await expect(container).toBeVisible()
 
-  const expectedBefore = await page.request
-    .get(`/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}?limit=2000`)
-    .then(async (res) => {
-      const snap = (await res.json()) as { entries_start?: number }
-      return snap.entries_start ?? 0
-    })
+  const refreshResponse = page.waitForResponse((res) => {
+    if (res.request().method() !== "GET") return false
+    const url = res.url()
+    if (!url.includes(`/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}`)) return false
+    try {
+      const parsed = new URL(url)
+      return parsed.searchParams.get("limit") === "2000" && !parsed.searchParams.has("before") && res.status() === 200
+    } catch {
+      return false
+    }
+  })
+
+  await existingTab.scrollIntoViewIfNeeded()
+  await existingTab.click()
+  await newTab.scrollIntoViewIfNeeded()
+  await newTab.click()
+
+  const entriesStart = await refreshResponse.then(async (res) => {
+    const snap = (await res.json()) as { entries_start?: number }
+    return snap.entries_start ?? 0
+  })
+  expect(entriesStart).toBeGreaterThan(0)
 
   const beforeRequest = page.waitForRequest((req) => {
+    if (req.method() !== "GET") return false
     const url = req.url()
-    return (
-      url.includes(`/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}`) &&
-      url.includes(`before=${expectedBefore}`)
-    )
+    if (!url.includes(`/api/workspaces/${ids.workspaceId}/conversations/${ids.threadId}`)) return false
+    try {
+      const parsed = new URL(url)
+      return parsed.searchParams.get("limit") === "2000" && parsed.searchParams.has("before")
+    } catch {
+      return false
+    }
   })
 
+  await container.hover()
   await container.evaluate((el) => {
-    el.scrollTop = el.scrollHeight
-    el.dispatchEvent(new Event("scroll", { bubbles: true }))
-    el.scrollTop = 10
-    el.dispatchEvent(new Event("scroll", { bubbles: true }))
     el.scrollTop = 0
-    el.dispatchEvent(new Event("scroll", { bubbles: true }))
   })
+  await page.mouse.wheel(0, -2000)
 
-  await beforeRequest
+  const req = await beforeRequest
+  const before = Number(new URL(req.url()).searchParams.get("before") ?? NaN)
+  expect(Number.isFinite(before) && before > 0).toBeTruthy()
 
   await expect(page.getByTestId("chat-input")).toBeVisible()
   await expect(page.getByText("Application error:", { exact: false })).toHaveCount(0)


### PR DESCRIPTION
## What
- Allow loading older conversation pages even when the chat scroll container is not overflow-scrollable.
- Update the pagination E2E to trigger paging via wheel-at-top and assert a `before=` request.
- Darken terminal ANSI black in dark mode to keep it visually distinct from the card background (restores E2E invariant).

## Why
- When many `agent_item` entries collapse into a small number of rendered messages, the chat view may not overflow, so scroll-driven pagination never fires.
- The dark theme base palette had card/background too close for the terminal ANSI black contrast test.

## Verification
- `just fmt && just lint && just test`
- `pnpm -C web lint && pnpm -C web typecheck`
- `just test-ui`
