### PR TITLE
Fix draft attachments lost on workspace switch

### DIFF
--- a/web/tests/e2e/worktree-ui.spec.ts
+++ b/web/tests/e2e/worktree-ui.spec.ts
@@ -161,6 +161,61 @@ test("switching between worktrees keeps chat content stable (no flash)", async (
   expect(sawEmptyState).toBe(false)
 })
 
+test("draft attachments persist across worktree switches", async ({ page }) => {
+  await ensureWorkspace(page)
+
+  const widA = await activeWorkspaceId(page)
+  const snapA = await fetchAppSnapshot(page)
+  const projectDir =
+    snapA.projects.find((p: any) => p.name === "e2e-project")?.path ??
+    requireEnv("LUBAN_E2E_PROJECT_DIR")
+
+  const nameA = (() => {
+    for (const p of snapA.projects) {
+      const w = p.workspaces.find((x: any) => Number(x.id) === widA)
+      if (w) return String(w.branch_name)
+    }
+    return null
+  })()
+  if (!nameA) throw new Error("missing branch name for workspace A")
+
+  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  await projectToggle.waitFor({ timeout: 15_000 })
+  const projectContainer = projectToggle.locator("..").locator("..")
+  const branchEntries = projectContainer.getByTestId("worktree-branch-name")
+  const branchCountBefore = await branchEntries.count()
+
+  {
+    const png = new PNG({ width: 1, height: 1 })
+    png.data[0] = 255
+    png.data[1] = 0
+    png.data[2] = 0
+    png.data[3] = 255
+    const buffer = PNG.sync.write(png)
+    await page.getByTestId("chat-attach-input").setInputFiles({
+      name: "pasted.png",
+      mimeType: "image/png",
+      buffer,
+    })
+  }
+
+  await expect(page.getByTestId("chat-send")).toBeEnabled({ timeout: 20_000 })
+  await expect(page.getByTestId("chat-attachment-tile")).toHaveCount(1, { timeout: 20_000 })
+
+  await sendWsAction(page, { type: "create_workspace", project_id: projectDir })
+  await expect
+    .poll(async () => await branchEntries.count(), { timeout: 90_000 })
+    .toBe(branchCountBefore + 1)
+
+  await branchEntries.last().click()
+  const widB = await activeWorkspaceId(page)
+  expect(widB).not.toBe(widA)
+
+  await projectContainer.getByTestId("worktree-branch-name").filter({ hasText: nameA }).first().click()
+  await expect(page.getByTestId("chat-send")).toBeEnabled({ timeout: 20_000 })
+  await expect(page.getByTestId("chat-attachment-tile")).toHaveCount(1, { timeout: 20_000 })
+})
+
 test("new worktree highlight clears after a short delay", async ({ page }) => {
   await ensureWorkspace(page)
 


### PR DESCRIPTION
## What changed
- Persist chat draft attachments (ready only) together with draft text per `(workspaceId, threadId)`.
- Restore draft attachments when switching back to a workspace/thread.

## Why
Switching workspaces cleared composer attachments and only draft text was persisted, so pasted/uploaded images disappeared from the input.

## Tests
- `just fmt`
- `just lint`
- `just test`
- `cd web && pnpm playwright test tests/e2e/worktree-ui.spec.ts -g "draft attachments persist across worktree switches"`

## Manual verification
1. Paste or attach an image and wait until the tile is ready.
2. Switch to another workspace.
3. Switch back.
4. Confirm the attachment tile is still present and Send is enabled.

## Risk / rollback
- Only `ready` attachments are persisted; in-flight uploads may still be dropped on switch.
- Revert this PR to restore previous behavior.
