### PR TITLE
fix: pin model per thread tab

### DIFF
--- a/crates/luban_backend/migrations/0014_conversation_run_config.sql
+++ b/crates/luban_backend/migrations/0014_conversation_run_config.sql
@@ -1,0 +1,5 @@
+ALTER TABLE conversations
+    ADD COLUMN agent_model_id TEXT;
+
+ALTER TABLE conversations
+    ADD COLUMN thinking_effort TEXT;

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1336,6 +1336,25 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(|e| format!("{e:#}"))
     }
 
+    fn save_conversation_run_config(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+        thread_id: u64,
+        model_id: String,
+        thinking_effort: luban_domain::ThinkingEffort,
+    ) -> Result<(), String> {
+        self.sqlite
+            .save_conversation_run_config(
+                project_slug,
+                workspace_name,
+                thread_id,
+                model_id,
+                thinking_effort,
+            )
+            .map_err(|e| format!("{e:#}"))
+    }
+
     fn store_context_image(
         &self,
         project_slug: String,

--- a/crates/luban_backend/src/services/conversations.rs
+++ b/crates/luban_backend/src/services/conversations.rs
@@ -117,6 +117,8 @@ impl GitWorkspaceService {
         if !events_path.exists() {
             return Ok(Some(ConversationSnapshot {
                 thread_id: meta.thread_id,
+                agent_model_id: None,
+                thinking_effort: None,
                 entries: Vec::new(),
                 entries_total: 0,
                 entries_start: 0,
@@ -158,6 +160,8 @@ impl GitWorkspaceService {
         let entries_total = entries.len() as u64;
         Ok(Some(ConversationSnapshot {
             thread_id: meta.thread_id,
+            agent_model_id: None,
+            thinking_effort: None,
             entries,
             entries_total,
             entries_start: 0,

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -1,6 +1,6 @@
 use crate::{
     AgentRunnerKind, AgentThreadEvent, AttachmentRef, ContextItem, ConversationSnapshot,
-    ConversationThreadMeta, PersistedAppState, QueuedPrompt, SystemTaskKind,
+    ConversationThreadMeta, PersistedAppState, QueuedPrompt, SystemTaskKind, ThinkingEffort,
 };
 use std::collections::HashMap;
 use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool};
@@ -285,6 +285,17 @@ pub trait ProjectWorkspaceService: Send + Sync {
         _run_started_at_unix_ms: Option<u64>,
         _run_finished_at_unix_ms: Option<u64>,
         _pending_prompts: Vec<QueuedPrompt>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn save_conversation_run_config(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+        _thread_id: u64,
+        _model_id: String,
+        _thinking_effort: ThinkingEffort,
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/luban_domain/src/effects.rs
+++ b/crates/luban_domain/src/effects.rs
@@ -55,6 +55,12 @@ pub enum Effect {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
     },
+    StoreConversationRunConfig {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        model_id: String,
+        thinking_effort: crate::ThinkingEffort,
+    },
     LoadConversation {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,

--- a/crates/luban_domain/src/lib.rs
+++ b/crates/luban_domain/src/lib.rs
@@ -39,7 +39,8 @@ mod task_prompts;
 pub use agent_settings::{
     AgentModelSpec, AgentRunnerKind, ThinkingEffort, agent_model_label, agent_models,
     default_agent_model_id, default_agent_runner_kind, default_amp_mode, default_thinking_effort,
-    normalize_thinking_effort, parse_agent_runner_kind, thinking_effort_supported,
+    normalize_thinking_effort, parse_agent_runner_kind, parse_thinking_effort,
+    thinking_effort_supported,
 };
 pub use task_prompts::{default_task_prompt_template, default_task_prompt_templates};
 mod system_prompts;

--- a/crates/luban_domain/src/state.rs
+++ b/crates/luban_domain/src/state.rs
@@ -255,6 +255,10 @@ pub(crate) fn entries_is_suffix(suffix: &[ConversationEntry], full: &[Conversati
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ConversationSnapshot {
     pub thread_id: Option<String>,
+    #[serde(default)]
+    pub agent_model_id: Option<String>,
+    #[serde(default)]
+    pub thinking_effort: Option<crate::ThinkingEffort>,
     pub entries: Vec<ConversationEntry>,
     #[serde(default)]
     pub entries_total: u64,

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -2517,6 +2517,29 @@ impl Engine {
                 .await;
                 Ok(VecDeque::new())
             }
+            Effect::StoreConversationRunConfig {
+                workspace_id,
+                thread_id,
+                model_id,
+                thinking_effort,
+            } => {
+                let Some(scope) = workspace_scope(&self.state, workspace_id) else {
+                    return Ok(VecDeque::new());
+                };
+                let services = self.services.clone();
+                let thread_local_id = thread_id.as_u64();
+                let _ = tokio::task::spawn_blocking(move || {
+                    services.save_conversation_run_config(
+                        scope.project_slug,
+                        scope.workspace_name,
+                        thread_local_id,
+                        model_id,
+                        thinking_effort,
+                    )
+                })
+                .await;
+                Ok(VecDeque::new())
+            }
             Effect::RunAgentTurn {
                 workspace_id,
                 thread_id,


### PR DESCRIPTION
## Behavior
- Selecting a non-default model (and thinking effort) in a thread tab is now pinned to that thread.
- Switching tabs and restarting the app preserves the selected model/effort for each thread.

## Scope
- Domain: persist run config via effects and apply persisted config on load.
- Backend: store/load per-thread run config in SQLite.
- Server: handle the new persistence effect.

## Verification
- `just fmt && just lint && just test`

Manual:
1. Start the app.
2. Open thread A and change the model to a non-default value.
3. Send two messages; confirm both turns use the selected model.
4. Switch to thread B and back to A; confirm the selector remains on the chosen model.
5. Restart the app and reopen thread A; confirm the model/effort are still pinned.

## Tests added
- `crates/luban_domain/src/reducer.rs`: `conversation_loaded_applies_persisted_run_config`
- `crates/luban_backend/src/sqlite_store.rs`: `conversation_run_config_round_trip`

## Risk / Rollback
- Low risk: additive SQLite migration (`0014_conversation_run_config.sql`) adds `agent_model_id` and `thinking_effort` columns.
- Rollback: revert the commit; extra columns remain unused.

## Contracts
- No web/server API surface changes; no contract updates required.
