### PR TITLE
Terminal: open links on cmd/ctrl-click

### DIFF
--- a/web/components/pty-terminal.tsx
+++ b/web/components/pty-terminal.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useRef } from "react"
 import { Terminal, type ITheme } from "@xterm/xterm"
 import { FitAddon } from "@xterm/addon-fit"
+import { WebLinksAddon } from "@xterm/addon-web-links"
 import { WebglAddon } from "@xterm/addon-webgl"
 import { useTheme } from "next-themes"
 
 import { useLuban } from "@/lib/luban-context"
+import { openExternalUrl } from "@/lib/open-external-url"
 import { useAppearance } from "@/components/appearance-provider"
 import { isMockMode } from "@/lib/luban-mode"
 
@@ -441,6 +443,12 @@ export function PtyTerminal() {
     termRef.current = term
 
     term.loadAddon(fitAddon)
+    term.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        event.preventDefault()
+        void openExternalUrl(uri)
+      }),
+    )
     if (webglAddon) {
       try {
         term.loadAddon(webglAddon)

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@vercel/analytics": "1.6.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "autoprefixer": "^10.4.23",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xterm/addon-webgl':
         specifier: ^0.19.0
         version: 0.19.0
@@ -1771,6 +1774,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -5426,6 +5432,8 @@ snapshots:
       react: 19.2.3
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 


### PR DESCRIPTION
## What changed
- PTY terminal now recognizes URLs and opens them on cmd/ctrl-click.
- Uses the existing external URL opener so it works both in browser and Tauri.

## Verification
- `just fmt && just lint && just test`
- `cd web && pnpm lint && pnpm typecheck`
- `cd web && pnpm test:e2e -- tests/e2e/terminal-ui.spec.ts -g "cmd/ctrl-click"`

## Manual check
1. Open the PTY terminal.
2. Print a URL (e.g. `https://example.com`).
3. Hold `cmd` (macOS) or `ctrl` (others) and click the URL.
4. Confirm it opens in a new tab/window and the current page does not navigate.

## Risk / rollback
- Risk: URLs in the terminal become clickable on modifier-click (intended).
- Rollback: remove `WebLinksAddon` usage in `web/components/pty-terminal.tsx` and drop `@xterm/addon-web-links`.
