### PR TITLE
ci: rename fmt/lint/test job to Checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   checks:
-    name: fmt / lint / test
+    name: Checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
Rename the CI job display name from `fmt / lint / test` to `Checks`.

This keeps the workflow behavior unchanged while presenting a single, stable required check name.

Verification:
- `just fmt && just lint && just test`
