### PR TITLE
refactor(domain): extract thread title helper

### DIFF
--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -18,6 +18,10 @@ use std::{
     path::PathBuf,
 };
 
+mod title;
+
+pub use title::derive_thread_title;
+
 fn cancel_running_turn(conversation: &mut WorkspaceConversation) -> Option<u64> {
     if conversation.run_status != OperationStatus::Running {
         return None;
@@ -1959,18 +1963,6 @@ fn normalize_project_path(path: &std::path::Path) -> PathBuf {
             }
             other => out.push(other),
         }
-    }
-    out
-}
-
-pub fn derive_thread_title(text: &str) -> String {
-    let first_line = text.lines().next().unwrap_or("").trim();
-    if first_line.is_empty() {
-        return String::new();
-    }
-    let mut out = String::new();
-    for ch in first_line.chars().take(crate::THREAD_TITLE_MAX_CHARS) {
-        out.push(ch);
     }
     out
 }

--- a/crates/luban_domain/src/reducer/title.rs
+++ b/crates/luban_domain/src/reducer/title.rs
@@ -1,0 +1,34 @@
+pub fn derive_thread_title(text: &str) -> String {
+    let first_line = text.lines().next().unwrap_or("").trim();
+    if first_line.is_empty() {
+        return String::new();
+    }
+
+    first_line
+        .chars()
+        .take(crate::THREAD_TITLE_MAX_CHARS)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::derive_thread_title;
+
+    #[test]
+    fn derive_thread_title_returns_empty_for_whitespace() {
+        assert_eq!(derive_thread_title(""), "");
+        assert_eq!(derive_thread_title("   \n  "), "");
+    }
+
+    #[test]
+    fn derive_thread_title_uses_first_line_only() {
+        assert_eq!(derive_thread_title("hello\nworld"), "hello");
+    }
+
+    #[test]
+    fn derive_thread_title_truncates_to_limit() {
+        let input = "a".repeat(crate::THREAD_TITLE_MAX_CHARS + 10);
+        let out = derive_thread_title(&input);
+        assert_eq!(out.len(), crate::THREAD_TITLE_MAX_CHARS);
+    }
+}


### PR DESCRIPTION
Summary:
- Extract `derive_thread_title` into a small reducer submodule (`crates/luban_domain/src/reducer/title.rs`).
- Add unit tests for whitespace/multiline/truncation edge cases.

Verification:
- `just fmt && just lint && just test`
