### PR TITLE
refactor(domain): centralize project path normalization

### DIFF
--- a/crates/luban_domain/src/persistence/load.rs
+++ b/crates/luban_domain/src/persistence/load.rs
@@ -8,7 +8,7 @@ use crate::{
     default_task_prompt_templates, default_thinking_effort, normalize_thinking_effort,
 };
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, UNIX_EPOCH};
 
 fn normalize_thread_tabs(
@@ -261,7 +261,7 @@ fn load_projects(projects: Vec<PersistedProject>) -> (Vec<Project>, bool) {
     let mut grouped: HashMap<PathBuf, Vec<Project>> = HashMap::new();
 
     for persisted in projects {
-        let normalized_path = normalize_project_path(&persisted.path);
+        let normalized_path = crate::paths::normalize_project_path(&persisted.path);
         if normalized_path != persisted.path {
             upgraded = true;
         }
@@ -401,25 +401,6 @@ fn dedupe_worktree_paths(workspaces: &mut Vec<Workspace>) -> bool {
     merged.sort_by_key(|w| w.id.0);
     *workspaces = merged;
     upgraded
-}
-
-fn normalize_project_path(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                let popped = out.pop();
-                if !popped {
-                    out.push(component);
-                }
-            }
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -1729,12 +1729,12 @@ impl AppState {
     }
 
     fn add_project(&mut self, path: PathBuf, is_git: bool) -> ProjectId {
-        let normalized_path = normalize_project_path(&path);
+        let normalized_path = crate::paths::normalize_project_path(&path);
 
         if let Some(project) = self
             .projects
             .iter_mut()
-            .find(|p| normalize_project_path(&p.path) == normalized_path)
+            .find(|p| crate::paths::normalize_project_path(&p.path) == normalized_path)
         {
             project.is_git = is_git;
             return project.id;
@@ -1946,25 +1946,6 @@ fn sanitize_slug(input: &str) -> String {
     } else {
         out
     }
-}
-
-fn normalize_project_path(path: &std::path::Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                let popped = out.pop();
-                if !popped {
-                    out.push(component);
-                }
-            }
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 fn start_next_queued_prompt(


### PR DESCRIPTION
Summary:
- Centralize `normalize_project_path` into `crates/luban_domain/src/paths.rs` as a single crate-visible implementation.
- Remove duplicated implementations from reducer and persistence load.
- Add unit tests for `.` and `..` normalization behavior.

Verification:
- `just fmt && just lint && just test`
