### PR TITLE
refactor(domain): share persistence string normalization

### DIFF
--- a/crates/luban_domain/src/persistence/fonts.rs
+++ b/crates/luban_domain/src/persistence/fonts.rs
@@ -1,10 +1,4 @@
-fn normalize_string(raw: Option<&str>, fallback: &str, max_len: usize) -> String {
-    raw.map(str::trim)
-        .filter(|v| !v.is_empty())
-        .filter(|v| v.len() <= max_len)
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| fallback.to_owned())
-}
+use super::strings::normalize_string;
 
 pub(super) fn normalize_font(raw: Option<&str>, fallback: &str) -> String {
     normalize_string(raw, fallback, 128)

--- a/crates/luban_domain/src/persistence/load.rs
+++ b/crates/luban_domain/src/persistence/load.rs
@@ -1,4 +1,5 @@
 use super::fonts::normalize_font;
+use super::strings::normalize_optional_string;
 use crate::agent_settings::{parse_agent_runner_kind, parse_thinking_effort};
 use crate::{
     AppState, AppearanceFonts, AppearanceTheme, Effect, MainPane, OperationStatus,
@@ -25,13 +26,6 @@ fn normalize_thread_tabs(
     }
     archived_tabs.retain(|id| *id != active);
     (open_tabs, archived_tabs)
-}
-
-fn normalize_optional_string(raw: Option<&str>, max_len: usize) -> Option<String> {
-    raw.map(str::trim)
-        .filter(|v| !v.is_empty())
-        .filter(|v| v.len() <= max_len)
-        .map(ToOwned::to_owned)
 }
 
 pub(crate) fn apply_persisted_app_state(
@@ -627,16 +621,5 @@ mod tests {
         );
         assert_eq!(open, vec![WorkspaceThreadId(2), active]);
         assert!(archived.is_empty());
-    }
-
-    #[test]
-    fn normalize_optional_string_trims_and_enforces_max_len() {
-        assert_eq!(
-            normalize_optional_string(Some("  abc  "), 3),
-            Some("abc".to_owned())
-        );
-        assert_eq!(normalize_optional_string(Some("  abc  "), 2), None);
-        assert_eq!(normalize_optional_string(Some("   "), 10), None);
-        assert_eq!(normalize_optional_string(None, 10), None);
     }
 }

--- a/crates/luban_domain/src/persistence/mod.rs
+++ b/crates/luban_domain/src/persistence/mod.rs
@@ -1,6 +1,7 @@
 mod fonts;
 mod load;
 mod save;
+mod strings;
 
 pub(crate) use load::apply_persisted_app_state;
 pub(crate) use save::to_persisted_app_state;

--- a/crates/luban_domain/src/persistence/strings.rs
+++ b/crates/luban_domain/src/persistence/strings.rs
@@ -1,0 +1,34 @@
+pub(super) fn normalize_optional_string(raw: Option<&str>, max_len: usize) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|v| !v.is_empty())
+        .filter(|v| v.len() <= max_len)
+        .map(ToOwned::to_owned)
+}
+
+pub(super) fn normalize_string(raw: Option<&str>, fallback: &str, max_len: usize) -> String {
+    normalize_optional_string(raw, max_len).unwrap_or_else(|| fallback.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_optional_string_trims_and_enforces_max_len() {
+        assert_eq!(
+            normalize_optional_string(Some("  abc  "), 3),
+            Some("abc".to_owned())
+        );
+        assert_eq!(normalize_optional_string(Some("  abc  "), 2), None);
+        assert_eq!(normalize_optional_string(Some("   "), 10), None);
+        assert_eq!(normalize_optional_string(None, 10), None);
+    }
+
+    #[test]
+    fn normalize_string_falls_back_on_invalid_input() {
+        assert_eq!(normalize_string(Some("  abc  "), "fallback", 3), "abc");
+        assert_eq!(normalize_string(Some("  abc  "), "fallback", 2), "fallback");
+        assert_eq!(normalize_string(Some("   "), "fallback", 10), "fallback");
+        assert_eq!(normalize_string(None, "fallback", 10), "fallback");
+    }
+}


### PR DESCRIPTION
## Summary
- Move persistence string normalization helpers into `crates/luban_domain/src/persistence/strings.rs`.
- Reuse the helpers from `persistence/load.rs` and `persistence/fonts.rs`.

## Behavior
- No user-visible behavior changes intended.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. `just run`
2. Start the UI and ensure persisted settings load (appearance fonts, AMP mode, open button selection).
3. Quit and restart; verify settings still load as before.

## Contracts
- Not applicable (no web/server interaction surface changes).
