### PR TITLE
refactor(domain): centralize unix seconds conversion

### DIFF
--- a/crates/luban_domain/src/dashboard.rs
+++ b/crates/luban_domain/src/dashboard.rs
@@ -1,9 +1,10 @@
+use crate::time::unix_seconds_or_zero;
 use crate::{
     AppState, CodexThreadItem, ConversationEntry, OperationStatus, Project, PullRequestInfo,
     Workspace, WorkspaceId, WorkspaceStatus,
 };
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum DashboardStage {
@@ -177,9 +178,7 @@ pub fn dashboard_preview(
 }
 
 fn sort_key(when: Option<SystemTime>) -> u64 {
-    when.and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    unix_seconds_or_zero(when)
 }
 
 fn stage_for_workspace(

--- a/crates/luban_domain/src/lib.rs
+++ b/crates/luban_domain/src/lib.rs
@@ -48,6 +48,7 @@ pub use system_prompts::{
     SystemTaskKind, default_system_prompt_template, default_system_prompt_templates,
 };
 mod dashboard;
+mod time;
 pub use dashboard::{
     DashboardCardModel, DashboardPreviewMessage, DashboardPreviewModel, DashboardStage,
     dashboard_cards, dashboard_preview,

--- a/crates/luban_domain/src/persistence/save.rs
+++ b/crates/luban_domain/src/persistence/save.rs
@@ -1,6 +1,6 @@
+use crate::time::unix_seconds;
 use crate::{AppState, PersistedAppState, PersistedProject, PersistedWorkspace};
 use std::collections::HashMap;
-use std::time::UNIX_EPOCH;
 
 pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
     PersistedAppState {
@@ -23,9 +23,7 @@ pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
                         branch_name: w.branch_name.clone(),
                         worktree_path: w.worktree_path.clone(),
                         status: w.status,
-                        last_activity_at_unix_seconds: w
-                            .last_activity_at
-                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())),
+                        last_activity_at_unix_seconds: w.last_activity_at.and_then(unix_seconds),
                     })
                     .collect(),
             })

--- a/crates/luban_domain/src/time.rs
+++ b/crates/luban_domain/src/time.rs
@@ -1,0 +1,37 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn unix_seconds(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
+}
+
+pub(crate) fn unix_seconds_opt(time: Option<SystemTime>) -> Option<u64> {
+    time.and_then(unix_seconds)
+}
+
+pub(crate) fn unix_seconds_or_zero(time: Option<SystemTime>) -> u64 {
+    unix_seconds_opt(time).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn unix_seconds_handles_before_and_after_epoch() {
+        assert_eq!(unix_seconds(UNIX_EPOCH), Some(0));
+        assert_eq!(unix_seconds(UNIX_EPOCH + Duration::from_secs(1)), Some(1));
+        assert_eq!(unix_seconds(UNIX_EPOCH - Duration::from_secs(1)), None);
+    }
+
+    #[test]
+    fn unix_seconds_helpers_handle_optional_values() {
+        assert_eq!(unix_seconds_opt(None), None);
+        assert_eq!(unix_seconds_opt(Some(UNIX_EPOCH)), Some(0));
+        assert_eq!(unix_seconds_or_zero(None), 0);
+        assert_eq!(
+            unix_seconds_or_zero(Some(UNIX_EPOCH + Duration::from_secs(3))),
+            3
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize `SystemTime -> unix seconds` conversion into `crates/luban_domain/src/time.rs`.
- Reuse it from `dashboard.rs` and `persistence/save.rs`.

## Behavior
- No user-visible behavior changes intended.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. `just run`
2. Verify dashboard sorting still looks correct.
3. Create a workspace, close and reopen, verify last-activity related UI behaves as before.

## Contracts
- Not applicable (no web/server interaction surface changes).
