### PR TITLE
refactor(domain): centralize unix seconds to SystemTime

### DIFF
--- a/crates/luban_domain/src/persistence/load.rs
+++ b/crates/luban_domain/src/persistence/load.rs
@@ -1,6 +1,7 @@
 use super::fonts::normalize_font;
 use super::strings::normalize_optional_string;
 use crate::agent_settings::{parse_agent_runner_kind, parse_thinking_effort};
+use crate::time::system_time_from_unix_seconds;
 use crate::{
     AppState, AppearanceFonts, AppearanceTheme, Effect, MainPane, OperationStatus,
     PersistedAppState, PersistedProject, Project, ProjectId, RightPane, TaskIntentKind, Workspace,
@@ -10,7 +11,6 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::time::{Duration, UNIX_EPOCH};
 
 fn normalize_thread_tabs(
     active: WorkspaceThreadId,
@@ -278,7 +278,7 @@ fn load_projects(projects: Vec<PersistedProject>) -> (Vec<Project>, bool) {
                     status: w.status,
                     last_activity_at: w
                         .last_activity_at_unix_seconds
-                        .map(|secs| UNIX_EPOCH + Duration::from_secs(secs)),
+                        .map(system_time_from_unix_seconds),
                     archive_status: OperationStatus::Idle,
                     branch_rename_status: OperationStatus::Idle,
                 })

--- a/crates/luban_domain/src/time.rs
+++ b/crates/luban_domain/src/time.rs
@@ -1,7 +1,11 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub(crate) fn unix_seconds(time: SystemTime) -> Option<u64> {
     time.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
+}
+
+pub(crate) fn system_time_from_unix_seconds(secs: u64) -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs(secs)
 }
 
 pub(crate) fn unix_seconds_opt(time: Option<SystemTime>) -> Option<u64> {
@@ -15,13 +19,21 @@ pub(crate) fn unix_seconds_or_zero(time: Option<SystemTime>) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
     fn unix_seconds_handles_before_and_after_epoch() {
         assert_eq!(unix_seconds(UNIX_EPOCH), Some(0));
         assert_eq!(unix_seconds(UNIX_EPOCH + Duration::from_secs(1)), Some(1));
         assert_eq!(unix_seconds(UNIX_EPOCH - Duration::from_secs(1)), None);
+    }
+
+    #[test]
+    fn system_time_from_unix_seconds_maps_to_epoch() {
+        assert_eq!(system_time_from_unix_seconds(0), UNIX_EPOCH);
+        assert_eq!(
+            system_time_from_unix_seconds(3),
+            UNIX_EPOCH + Duration::from_secs(3)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `system_time_from_unix_seconds` to `crates/luban_domain/src/time.rs`.
- Use it in `crates/luban_domain/src/persistence/load.rs`.

## Behavior
- No user-visible behavior changes intended.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. `just run`
2. Open a workspace and ensure last-activity timestamps are restored as before.

## Contracts
- Not applicable (no web/server interaction surface changes).
