### PR TITLE
refactor(backend): extract unix time helpers

### DIFF
--- a/crates/luban_backend/src/lib.rs
+++ b/crates/luban_backend/src/lib.rs
@@ -1,5 +1,6 @@
 mod services;
 mod sqlite_store;
+mod time;
 
 pub use services::GitWorkspaceService;
 pub use sqlite_store::{SqliteStore, SqliteStoreOptions};

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -15,12 +15,13 @@ use std::{
     process::Command,
     sync::atomic::{AtomicBool, Ordering},
     sync::{Arc, Mutex},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::Instant,
 };
 
 use claude_process::{ClaudeProcessKey, ClaudeThreadProcess};
 
 use crate::sqlite_store::{SqliteStore, SqliteStoreOptions};
+use crate::time::{unix_epoch_micros_now, unix_epoch_nanos_now};
 
 mod amp_cli;
 mod claude_cli;
@@ -243,20 +244,6 @@ fn qualify_event(turn_scope_id: &str, event: CodexThreadEvent) -> CodexThreadEve
         },
         other => other,
     }
-}
-
-fn unix_epoch_micros_now() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_micros()
-}
-
-fn unix_epoch_nanos_now() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos()
 }
 
 fn generate_turn_scope_id() -> String {

--- a/crates/luban_backend/src/time.rs
+++ b/crates/luban_backend/src/time.rs
@@ -1,0 +1,15 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn unix_epoch_micros_now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros()
+}
+
+pub(crate) fn unix_epoch_nanos_now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}


### PR DESCRIPTION
## Summary
- Move unix epoch time helper functions out of `services.rs` into a dedicated module.

## Rationale
- Keeps `services.rs` focused on service logic and reduces local utility clutter.

## Verification
- `just fmt && just lint && just test`

## Risk
- Low: refactor-only; behavior unchanged.
