### PR TITLE
refactor(backend): centralize env path parsing

### DIFF
--- a/crates/luban_backend/src/env.rs
+++ b/crates/luban_backend/src/env.rs
@@ -1,0 +1,106 @@
+use anyhow::anyhow;
+use std::path::PathBuf;
+
+pub(crate) fn optional_trimmed_path_from_env(name: &str) -> anyhow::Result<Option<PathBuf>> {
+    let value = match std::env::var_os(name) {
+        Some(value) => value,
+        None => return Ok(None),
+    };
+
+    let value = value.to_string_lossy();
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("{name} is set but empty"));
+    }
+
+    Ok(Some(PathBuf::from(trimmed)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::optional_trimmed_path_from_env;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn optional_trimmed_path_from_env_returns_none_when_unset() {
+        let _guard = lock_env();
+
+        let prev = std::env::var_os("LUBAN_TEST_TRIMMED_PATH_ENV");
+        unsafe {
+            std::env::remove_var("LUBAN_TEST_TRIMMED_PATH_ENV");
+        }
+
+        let loaded = optional_trimmed_path_from_env("LUBAN_TEST_TRIMMED_PATH_ENV")
+            .expect("unset env should not error");
+        assert!(loaded.is_none());
+
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var("LUBAN_TEST_TRIMMED_PATH_ENV", value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("LUBAN_TEST_TRIMMED_PATH_ENV");
+            }
+        }
+    }
+
+    #[test]
+    fn optional_trimmed_path_from_env_errors_on_empty() {
+        let _guard = lock_env();
+
+        let prev = std::env::var_os("LUBAN_TEST_TRIMMED_PATH_ENV");
+        unsafe {
+            std::env::set_var("LUBAN_TEST_TRIMMED_PATH_ENV", "   ");
+        }
+
+        let err = optional_trimmed_path_from_env("LUBAN_TEST_TRIMMED_PATH_ENV")
+            .expect_err("empty env should error");
+        assert!(
+            err.to_string()
+                .contains("LUBAN_TEST_TRIMMED_PATH_ENV is set but empty"),
+            "unexpected error: {err:?}"
+        );
+
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var("LUBAN_TEST_TRIMMED_PATH_ENV", value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("LUBAN_TEST_TRIMMED_PATH_ENV");
+            }
+        }
+    }
+
+    #[test]
+    fn optional_trimmed_path_from_env_trims_value() {
+        let _guard = lock_env();
+
+        let prev = std::env::var_os("LUBAN_TEST_TRIMMED_PATH_ENV");
+        unsafe {
+            std::env::set_var("LUBAN_TEST_TRIMMED_PATH_ENV", " luban-test ");
+        }
+
+        let loaded = optional_trimmed_path_from_env("LUBAN_TEST_TRIMMED_PATH_ENV")
+            .expect("non-empty env should succeed");
+        assert_eq!(loaded, Some(PathBuf::from("luban-test")));
+
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var("LUBAN_TEST_TRIMMED_PATH_ENV", value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("LUBAN_TEST_TRIMMED_PATH_ENV");
+            }
+        }
+    }
+}

--- a/crates/luban_backend/src/lib.rs
+++ b/crates/luban_backend/src/lib.rs
@@ -1,3 +1,4 @@
+mod env;
 mod services;
 mod sqlite_store;
 mod time;

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -20,6 +20,7 @@ use std::{
 
 use claude_process::{ClaudeProcessKey, ClaudeThreadProcess};
 
+use crate::env::optional_trimmed_path_from_env;
 use crate::sqlite_store::{SqliteStore, SqliteStoreOptions};
 use crate::time::{unix_epoch_micros_now, unix_epoch_nanos_now};
 
@@ -253,13 +254,8 @@ fn generate_turn_scope_id() -> String {
 }
 
 fn resolve_luban_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = std::env::var_os(paths::LUBAN_ROOT_ENV) {
-        let root = root.to_string_lossy();
-        let trimmed = root.trim();
-        if trimmed.is_empty() {
-            return Err(anyhow!("{} is set but empty", paths::LUBAN_ROOT_ENV));
-        }
-        return Ok(PathBuf::from(trimmed));
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_ROOT_ENV)? {
+        return Ok(root);
     }
 
     if cfg!(test) {
@@ -273,13 +269,8 @@ fn resolve_luban_root() -> anyhow::Result<PathBuf> {
 }
 
 fn resolve_codex_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = std::env::var_os(paths::LUBAN_CODEX_ROOT_ENV) {
-        let root = root.to_string_lossy();
-        let trimmed = root.trim();
-        if trimmed.is_empty() {
-            return Err(anyhow!("{} is set but empty", paths::LUBAN_CODEX_ROOT_ENV));
-        }
-        return Ok(PathBuf::from(trimmed));
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CODEX_ROOT_ENV)? {
+        return Ok(root);
     }
 
     if cfg!(test) {
@@ -291,13 +282,8 @@ fn resolve_codex_root() -> anyhow::Result<PathBuf> {
 }
 
 fn resolve_amp_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = std::env::var_os(paths::LUBAN_AMP_ROOT_ENV) {
-        let root = root.to_string_lossy();
-        let trimmed = root.trim();
-        if trimmed.is_empty() {
-            return Err(anyhow!("{} is set but empty", paths::LUBAN_AMP_ROOT_ENV));
-        }
-        return Ok(PathBuf::from(trimmed));
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_AMP_ROOT_ENV)? {
+        return Ok(root);
     }
 
     if cfg!(test) {
@@ -317,13 +303,8 @@ fn resolve_amp_root() -> anyhow::Result<PathBuf> {
 }
 
 fn resolve_claude_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = std::env::var_os(paths::LUBAN_CLAUDE_ROOT_ENV) {
-        let root = root.to_string_lossy();
-        let trimmed = root.trim();
-        if trimmed.is_empty() {
-            return Err(anyhow!("{} is set but empty", paths::LUBAN_CLAUDE_ROOT_ENV));
-        }
-        return Ok(PathBuf::from(trimmed));
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CLAUDE_ROOT_ENV)? {
+        return Ok(root);
     }
 
     if cfg!(test) {


### PR DESCRIPTION
## Summary
- Add a small helper for reading path env vars with trim + empty validation.
- Reuse it from `services.rs` for `LUBAN_*_ROOT` resolution.

## Rationale
- Deduplicates repeated env parsing logic and keeps the behavior consistent.

## Verification
- `just fmt && just lint && just test`

## Risk
- Low: refactor-only; existing semantics preserved.
