### PR TITLE
refactor(backend): centralize HOME resolution

### DIFF
--- a/crates/luban_backend/src/env.rs
+++ b/crates/luban_backend/src/env.rs
@@ -1,6 +1,11 @@
 use anyhow::anyhow;
 use std::path::PathBuf;
 
+pub(crate) fn home_dir() -> anyhow::Result<PathBuf> {
+    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
+    Ok(PathBuf::from(home))
+}
+
 pub(crate) fn optional_trimmed_path_from_env(name: &str) -> anyhow::Result<Option<PathBuf>> {
     let value = match std::env::var_os(name) {
         Some(value) => value,
@@ -18,7 +23,7 @@ pub(crate) fn optional_trimmed_path_from_env(name: &str) -> anyhow::Result<Optio
 
 #[cfg(test)]
 mod tests {
-    use super::optional_trimmed_path_from_env;
+    use super::{home_dir, optional_trimmed_path_from_env};
     use std::path::PathBuf;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -26,6 +31,55 @@ mod tests {
 
     fn lock_env() -> MutexGuard<'static, ()> {
         ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn home_dir_errors_when_unset() {
+        let _guard = lock_env();
+
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::remove_var("HOME");
+        }
+
+        let err = home_dir().expect_err("missing HOME should error");
+        assert!(
+            err.to_string().contains("HOME is not set"),
+            "unexpected error: {err:?}"
+        );
+
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var("HOME", value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    #[test]
+    fn home_dir_returns_value() {
+        let _guard = lock_env();
+
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", "luban-home");
+        }
+
+        let loaded = home_dir().expect("HOME should be read");
+        assert_eq!(loaded, PathBuf::from("luban-home"));
+
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var("HOME", value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("HOME");
+            }
+        }
     }
 
     #[test]

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -20,7 +20,7 @@ use std::{
 
 use claude_process::{ClaudeProcessKey, ClaudeThreadProcess};
 
-use crate::env::optional_trimmed_path_from_env;
+use crate::env::{home_dir, optional_trimmed_path_from_env};
 use crate::sqlite_store::{SqliteStore, SqliteStoreOptions};
 use crate::time::{unix_epoch_micros_now, unix_epoch_nanos_now};
 
@@ -252,8 +252,7 @@ fn resolve_luban_root() -> anyhow::Result<PathBuf> {
         return Ok(std::env::temp_dir().join(format!("luban-test-{pid}-{nanos}")));
     }
 
-    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-    Ok(PathBuf::from(home).join("luban"))
+    Ok(home_dir()?.join("luban"))
 }
 
 fn resolve_codex_root() -> anyhow::Result<PathBuf> {
@@ -265,8 +264,7 @@ fn resolve_codex_root() -> anyhow::Result<PathBuf> {
         return Ok(PathBuf::from(".codex"));
     }
 
-    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-    Ok(PathBuf::from(home).join(".codex"))
+    Ok(home_dir()?.join(".codex"))
 }
 
 fn resolve_amp_root() -> anyhow::Result<PathBuf> {
@@ -286,8 +284,7 @@ fn resolve_amp_root() -> anyhow::Result<PathBuf> {
         }
     }
 
-    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-    Ok(PathBuf::from(home).join(".config").join("amp"))
+    Ok(home_dir()?.join(".config").join("amp"))
 }
 
 fn resolve_claude_root() -> anyhow::Result<PathBuf> {
@@ -299,8 +296,7 @@ fn resolve_claude_root() -> anyhow::Result<PathBuf> {
         return Ok(PathBuf::from(".claude"));
     }
 
-    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-    Ok(PathBuf::from(home).join(".claude"))
+    Ok(home_dir()?.join(".claude"))
 }
 
 fn parse_amp_mode_from_config_text(contents: &str) -> Option<String> {

--- a/crates/luban_backend/src/services/task.rs
+++ b/crates/luban_backend/src/services/task.rs
@@ -1,3 +1,4 @@
+use crate::env::home_dir;
 use crate::services::GitWorkspaceService;
 use anyhow::{Context as _, anyhow};
 use luban_domain::ProjectWorkspaceService;
@@ -79,8 +80,7 @@ fn looks_like_local_path(token: &str) -> bool {
 
 fn expand_tilde(path: &str) -> anyhow::Result<PathBuf> {
     if let Some(rest) = path.strip_prefix("~/") {
-        let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-        return Ok(PathBuf::from(home).join(rest));
+        return Ok(home_dir()?.join(rest));
     }
     Ok(PathBuf::from(path))
 }


### PR DESCRIPTION
## Summary
- Add a small `home_dir()` helper in backend env utilities.
- Reuse it from `services.rs` and task path expansion.

## Rationale
- Removes repeated `HOME` lookup + error handling while keeping the error message consistent.

## Verification
- `just fmt && just lint && just test`

## Risk
- Low: refactor-only; behavior covered by unit tests.
