### PR TITLE
refactor(backend): extract prompt helpers

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -32,71 +32,12 @@ mod context_blobs;
 mod conversations;
 mod feedback;
 mod git;
+mod prompt;
 mod task;
 use amp_cli::AmpTurnParams;
 use claude_cli::ClaudeTurnParams;
 use codex_cli::CodexTurnParams;
-
-#[derive(Clone, Debug)]
-struct PromptAttachment {
-    kind: AttachmentKind,
-    name: String,
-    path: PathBuf,
-}
-
-fn resolve_prompt_attachments(
-    blobs_dir: &Path,
-    attachments: &[AttachmentRef],
-) -> Vec<PromptAttachment> {
-    attachments
-        .iter()
-        .map(|attachment| PromptAttachment {
-            kind: attachment.kind,
-            name: attachment.name.clone(),
-            path: blobs_dir.join(format!("{}.{}", attachment.id, attachment.extension)),
-        })
-        .collect()
-}
-
-fn format_prompt(
-    prompt: &str,
-    attachments: &[PromptAttachment],
-    attachment_path_prefix: &str,
-) -> String {
-    if attachments.is_empty() {
-        return prompt.to_owned();
-    }
-
-    let mut out = String::with_capacity(prompt.len() + attachments.len() * 96);
-    out.push_str(prompt.trim_end());
-    out.push_str("\n\nAttached files:\n");
-    for attachment in attachments {
-        out.push_str("- ");
-        let name = attachment.name.trim();
-        if name.is_empty() {
-            out.push_str(match attachment.kind {
-                AttachmentKind::Image => "image",
-                AttachmentKind::Text => "text",
-                AttachmentKind::File => "file",
-            });
-        } else {
-            out.push_str(name);
-        }
-        out.push_str(": ");
-        out.push_str(attachment_path_prefix);
-        out.push_str(&attachment.path.to_string_lossy());
-        out.push('\n');
-    }
-    out
-}
-
-fn format_amp_prompt(prompt: &str, attachments: &[PromptAttachment]) -> String {
-    format_prompt(prompt, attachments, "@")
-}
-
-fn format_codex_prompt(prompt: &str, attachments: &[PromptAttachment]) -> String {
-    format_prompt(prompt, attachments, "")
-}
+use prompt::{format_amp_prompt, format_codex_prompt, resolve_prompt_attachments};
 
 fn contains_attempt_fraction(text: &str) -> bool {
     let mut chars = text.chars().peekable();
@@ -3554,6 +3495,7 @@ impl GitWorkspaceService {
 
 #[cfg(test)]
 mod tests {
+    use super::prompt::PromptAttachment;
     use super::*;
     use luban_domain::{PersistedProject, PersistedWorkspace, WorkspaceStatus};
     use std::path::{Path, PathBuf};

--- a/crates/luban_backend/src/services/prompt.rs
+++ b/crates/luban_backend/src/services/prompt.rs
@@ -1,0 +1,63 @@
+use luban_domain::{AttachmentKind, AttachmentRef};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug)]
+pub(super) struct PromptAttachment {
+    pub(super) kind: AttachmentKind,
+    pub(super) name: String,
+    pub(super) path: PathBuf,
+}
+
+pub(super) fn resolve_prompt_attachments(
+    blobs_dir: &Path,
+    attachments: &[AttachmentRef],
+) -> Vec<PromptAttachment> {
+    attachments
+        .iter()
+        .map(|attachment| PromptAttachment {
+            kind: attachment.kind,
+            name: attachment.name.clone(),
+            path: blobs_dir.join(format!("{}.{}", attachment.id, attachment.extension)),
+        })
+        .collect()
+}
+
+fn format_prompt(
+    prompt: &str,
+    attachments: &[PromptAttachment],
+    attachment_path_prefix: &str,
+) -> String {
+    if attachments.is_empty() {
+        return prompt.to_owned();
+    }
+
+    let mut out = String::with_capacity(prompt.len() + attachments.len() * 96);
+    out.push_str(prompt.trim_end());
+    out.push_str("\n\nAttached files:\n");
+    for attachment in attachments {
+        out.push_str("- ");
+        let name = attachment.name.trim();
+        if name.is_empty() {
+            out.push_str(match attachment.kind {
+                AttachmentKind::Image => "image",
+                AttachmentKind::Text => "text",
+                AttachmentKind::File => "file",
+            });
+        } else {
+            out.push_str(name);
+        }
+        out.push_str(": ");
+        out.push_str(attachment_path_prefix);
+        out.push_str(&attachment.path.to_string_lossy());
+        out.push('\n');
+    }
+    out
+}
+
+pub(super) fn format_amp_prompt(prompt: &str, attachments: &[PromptAttachment]) -> String {
+    format_prompt(prompt, attachments, "@")
+}
+
+pub(super) fn format_codex_prompt(prompt: &str, attachments: &[PromptAttachment]) -> String {
+    format_prompt(prompt, attachments, "")
+}


### PR DESCRIPTION
Summary:
- Extract prompt formatting and attachment resolution helpers from `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/prompt.rs`.
- Keep behavior byte-for-byte identical; only module boundaries changed.

Changed:
- `crates/luban_backend/src/services.rs`
- `crates/luban_backend/src/services/prompt.rs`

Verification:
- `just fmt && just lint && just test`

Manual verification:
1. Run `just test-fast` (or `just test`) and confirm `services::tests::amp_prompt_includes_image_paths` and `services::tests::codex_prompt_includes_attachment_paths_without_amp_marker` pass.
2. Run `just run` and start a task with attachments (image + file) to confirm prompts include the expected attachment lines.

Risk and rollback:
- Low risk refactor (module extraction only).
- Rollback by reverting this commit / PR.
