### PR TITLE
refactor(backend): extract pull request helpers

### DIFF
--- a/crates/luban_backend/src/services/pull_request.rs
+++ b/crates/luban_backend/src/services/pull_request.rs
@@ -1,0 +1,53 @@
+use luban_domain::{PullRequestCiState, PullRequestState};
+
+pub(super) fn pull_request_ci_state_from_check_buckets<'a>(
+    buckets: impl IntoIterator<Item = &'a str>,
+) -> Option<PullRequestCiState> {
+    let mut any_pending = false;
+    let mut any_fail = false;
+    let mut any_pass = false;
+    let mut any_skip = false;
+
+    for bucket in buckets {
+        match bucket {
+            "fail" | "cancel" => any_fail = true,
+            "pending" => any_pending = true,
+            "pass" => any_pass = true,
+            "skipping" => any_skip = true,
+            _ => {}
+        }
+    }
+
+    if any_fail {
+        return Some(PullRequestCiState::Failure);
+    }
+    if any_pending {
+        return Some(PullRequestCiState::Pending);
+    }
+    if any_pass || any_skip {
+        return Some(PullRequestCiState::Success);
+    }
+    None
+}
+
+pub(super) fn is_merge_ready(
+    pr_state: PullRequestState,
+    is_draft: bool,
+    merge_state_status: &str,
+    review_decision: &str,
+    ci_state: Option<PullRequestCiState>,
+) -> bool {
+    if pr_state != PullRequestState::Open {
+        return false;
+    }
+    if is_draft {
+        return false;
+    }
+    if review_decision != "APPROVED" {
+        return false;
+    }
+    if ci_state != Some(PullRequestCiState::Success) {
+        return false;
+    }
+    matches!(merge_state_status, "CLEAN" | "HAS_HOOKS")
+}


### PR DESCRIPTION
Summary:
- Extract deterministic pull request helper logic from `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/pull_request.rs`.
- Keep behavior unchanged; add unit tests to lock the merge-ready decision matrix.

Changed:
- `crates/luban_backend/src/services.rs`
- `crates/luban_backend/src/services/pull_request.rs`

Verification:
- `just fmt && just lint && just test`

Manual verification:
1. Run `just test-fast` and confirm `services::tests::gh_pr_check_bucket_ci_state_mapping` and `services::tests::gh_pr_merge_ready_logic_is_stable` pass.
2. With `gh` authenticated, run the app and verify pull request info still shows CI state and merge readiness as before.

Risk and rollback:
- Low risk refactor (pure logic extraction).
- Rollback by reverting the squash commit.
