### PR TITLE
refactor(backend): extract codex executable resolution

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -27,6 +27,7 @@ use crate::time::{unix_epoch_micros_now, unix_epoch_nanos_now};
 mod amp_cli;
 mod claude_cli;
 pub mod claude_process;
+mod codex_bin;
 mod codex_cli;
 mod context_blobs;
 mod conversations;
@@ -400,17 +401,7 @@ impl GitWorkspaceService {
     }
 
     fn codex_executable(&self) -> PathBuf {
-        if let Some(explicit) = std::env::var_os(paths::LUBAN_CODEX_BIN_ENV).map(PathBuf::from) {
-            return explicit;
-        }
-
-        for candidate in default_codex_candidates() {
-            if let Some(found) = canonicalize_executable(&candidate) {
-                return found;
-            }
-        }
-
-        PathBuf::from("codex")
+        codex_bin::codex_executable()
     }
 
     // ========================================================================
@@ -636,58 +627,6 @@ impl GitWorkspaceService {
         }
 
         Ok(())
-    }
-}
-
-fn default_codex_candidates() -> Vec<PathBuf> {
-    if cfg!(test) {
-        // Avoid depending on developer machine installation paths during unit tests.
-        return Vec::new();
-    }
-
-    let mut out = Vec::new();
-
-    // Homebrew (Apple Silicon / Intel)
-    out.push(PathBuf::from("/opt/homebrew/bin/codex"));
-    out.push(PathBuf::from("/usr/local/bin/codex"));
-
-    // Rust/Cargo installs (less common, but cheap to check).
-    if let Some(home) = std::env::var_os("HOME") {
-        out.push(PathBuf::from(home).join(".cargo/bin/codex"));
-    }
-
-    // Last resort: rely on PATH (useful for terminal-launched dev).
-    out.push(PathBuf::from("codex"));
-
-    out
-}
-
-fn canonicalize_executable(path: &Path) -> Option<PathBuf> {
-    let resolved = std::fs::canonicalize(path)
-        .ok()
-        .unwrap_or_else(|| path.to_path_buf());
-    if !resolved.is_file() {
-        return None;
-    }
-    if !is_executable_file(&resolved) {
-        return None;
-    }
-    Some(resolved)
-}
-
-fn is_executable_file(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let Ok(meta) = std::fs::metadata(path) else {
-            return false;
-        };
-        let mode = meta.permissions().mode();
-        (mode & 0o111) != 0
-    }
-    #[cfg(not(unix))]
-    {
-        path.is_file()
     }
 }
 

--- a/crates/luban_backend/src/services/codex_bin.rs
+++ b/crates/luban_backend/src/services/codex_bin.rs
@@ -1,0 +1,68 @@
+use luban_domain::paths;
+use std::path::{Path, PathBuf};
+
+pub(super) fn codex_executable() -> PathBuf {
+    if let Some(explicit) = std::env::var_os(paths::LUBAN_CODEX_BIN_ENV).map(PathBuf::from) {
+        return explicit;
+    }
+
+    for candidate in default_codex_candidates() {
+        if let Some(found) = canonicalize_executable(&candidate) {
+            return found;
+        }
+    }
+
+    PathBuf::from("codex")
+}
+
+fn default_codex_candidates() -> Vec<PathBuf> {
+    if cfg!(test) {
+        // Avoid depending on developer machine installation paths during unit tests.
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+
+    // Homebrew (Apple Silicon / Intel)
+    out.push(PathBuf::from("/opt/homebrew/bin/codex"));
+    out.push(PathBuf::from("/usr/local/bin/codex"));
+
+    // Rust/Cargo installs (less common, but cheap to check).
+    if let Some(home) = std::env::var_os("HOME") {
+        out.push(PathBuf::from(home).join(".cargo/bin/codex"));
+    }
+
+    // Last resort: rely on PATH (useful for terminal-launched dev).
+    out.push(PathBuf::from("codex"));
+
+    out
+}
+
+fn canonicalize_executable(path: &Path) -> Option<PathBuf> {
+    let resolved = std::fs::canonicalize(path)
+        .ok()
+        .unwrap_or_else(|| path.to_path_buf());
+    if !resolved.is_file() {
+        return None;
+    }
+    if !is_executable_file(&resolved) {
+        return None;
+    }
+    Some(resolved)
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let Ok(meta) = std::fs::metadata(path) else {
+            return false;
+        };
+        let mode = meta.permissions().mode();
+        (mode & 0o111) != 0
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}


### PR DESCRIPTION
Summary:
- Extract Codex executable resolution helpers from `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/codex_bin.rs`.
- Keep behavior unchanged (same env var override, same candidate list, same executable checks).

Changed:
- `crates/luban_backend/src/services.rs`
- `crates/luban_backend/src/services/codex_bin.rs`

Verification:
- `just fmt && just lint && just test`

Manual verification:
1. Run `just test-fast` and confirm `services::tests::codex_runner_reports_missing_executable` still passes.
2. Set `LUBAN_CODEX_BIN` to an invalid path and confirm the UI reports the same missing executable error.

Risk and rollback:
- Low risk refactor (pure extraction).
- Rollback by reverting the squash commit.
