### PR TITLE
refactor(backend): extract codex thread scoping helpers

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -29,6 +29,7 @@ mod claude_cli;
 pub mod claude_process;
 mod codex_bin;
 mod codex_cli;
+mod codex_thread;
 mod context_blobs;
 mod conversations;
 mod feedback;
@@ -39,6 +40,7 @@ mod task;
 use amp_cli::AmpTurnParams;
 use claude_cli::ClaudeTurnParams;
 use codex_cli::CodexTurnParams;
+use codex_thread::{codex_item_id, qualify_codex_item, qualify_event};
 use prompt::{format_amp_prompt, format_codex_prompt, resolve_prompt_attachments};
 use pull_request::pull_request_ci_state_from_check_buckets;
 
@@ -79,104 +81,6 @@ fn is_transient_reconnect_notice(message: &str) -> bool {
     }
 
     contains_attempt_fraction(&lower)
-}
-
-fn codex_item_id(item: &CodexThreadItem) -> &str {
-    match item {
-        CodexThreadItem::AgentMessage { id, .. } => id,
-        CodexThreadItem::Reasoning { id, .. } => id,
-        CodexThreadItem::CommandExecution { id, .. } => id,
-        CodexThreadItem::FileChange { id, .. } => id,
-        CodexThreadItem::McpToolCall { id, .. } => id,
-        CodexThreadItem::WebSearch { id, .. } => id,
-        CodexThreadItem::TodoList { id, .. } => id,
-        CodexThreadItem::Error { id, .. } => id,
-    }
-}
-
-fn qualify_codex_item(turn_scope_id: &str, item: CodexThreadItem) -> CodexThreadItem {
-    let raw_id = codex_item_id(&item);
-    if raw_id.starts_with(turn_scope_id) {
-        return item;
-    }
-
-    let qualified_id = format!("{turn_scope_id}/{raw_id}");
-    match item {
-        CodexThreadItem::AgentMessage { id: _, text } => CodexThreadItem::AgentMessage {
-            id: qualified_id,
-            text,
-        },
-        CodexThreadItem::Reasoning { id: _, text } => CodexThreadItem::Reasoning {
-            id: qualified_id,
-            text,
-        },
-        CodexThreadItem::CommandExecution {
-            id: _,
-            command,
-            aggregated_output,
-            exit_code,
-            status,
-        } => CodexThreadItem::CommandExecution {
-            id: qualified_id,
-            command,
-            aggregated_output,
-            exit_code,
-            status,
-        },
-        CodexThreadItem::FileChange {
-            id: _,
-            changes,
-            status,
-        } => CodexThreadItem::FileChange {
-            id: qualified_id,
-            changes,
-            status,
-        },
-        CodexThreadItem::McpToolCall {
-            id: _,
-            server,
-            tool,
-            arguments,
-            result,
-            error,
-            status,
-        } => CodexThreadItem::McpToolCall {
-            id: qualified_id,
-            server,
-            tool,
-            arguments,
-            result,
-            error,
-            status,
-        },
-        CodexThreadItem::WebSearch { id: _, query } => CodexThreadItem::WebSearch {
-            id: qualified_id,
-            query,
-        },
-        CodexThreadItem::TodoList { id: _, items } => CodexThreadItem::TodoList {
-            id: qualified_id,
-            items,
-        },
-        CodexThreadItem::Error { id: _, message } => CodexThreadItem::Error {
-            id: qualified_id,
-            message,
-        },
-    }
-}
-
-fn qualify_event(turn_scope_id: &str, event: CodexThreadEvent) -> CodexThreadEvent {
-    match event {
-        CodexThreadEvent::ItemStarted { item } => CodexThreadEvent::ItemStarted {
-            item: qualify_codex_item(turn_scope_id, item),
-        },
-        CodexThreadEvent::ItemUpdated { item } => CodexThreadEvent::ItemUpdated {
-            item: qualify_codex_item(turn_scope_id, item),
-        },
-        CodexThreadEvent::ItemCompleted { item } => CodexThreadEvent::ItemCompleted {
-            item: qualify_codex_item(turn_scope_id, item),
-        },
-        other => other,
-    }
 }
 
 fn generate_turn_scope_id() -> String {

--- a/crates/luban_backend/src/services/codex_thread.rs
+++ b/crates/luban_backend/src/services/codex_thread.rs
@@ -1,0 +1,99 @@
+use luban_domain::{CodexThreadEvent, CodexThreadItem};
+
+pub(super) fn codex_item_id(item: &CodexThreadItem) -> &str {
+    match item {
+        CodexThreadItem::AgentMessage { id, .. } => id,
+        CodexThreadItem::Reasoning { id, .. } => id,
+        CodexThreadItem::CommandExecution { id, .. } => id,
+        CodexThreadItem::FileChange { id, .. } => id,
+        CodexThreadItem::McpToolCall { id, .. } => id,
+        CodexThreadItem::WebSearch { id, .. } => id,
+        CodexThreadItem::TodoList { id, .. } => id,
+        CodexThreadItem::Error { id, .. } => id,
+    }
+}
+
+pub(super) fn qualify_codex_item(turn_scope_id: &str, item: CodexThreadItem) -> CodexThreadItem {
+    let raw_id = codex_item_id(&item);
+    if raw_id.starts_with(turn_scope_id) {
+        return item;
+    }
+
+    let qualified_id = format!("{turn_scope_id}/{raw_id}");
+    match item {
+        CodexThreadItem::AgentMessage { id: _, text } => CodexThreadItem::AgentMessage {
+            id: qualified_id,
+            text,
+        },
+        CodexThreadItem::Reasoning { id: _, text } => CodexThreadItem::Reasoning {
+            id: qualified_id,
+            text,
+        },
+        CodexThreadItem::CommandExecution {
+            id: _,
+            command,
+            aggregated_output,
+            exit_code,
+            status,
+        } => CodexThreadItem::CommandExecution {
+            id: qualified_id,
+            command,
+            aggregated_output,
+            exit_code,
+            status,
+        },
+        CodexThreadItem::FileChange {
+            id: _,
+            changes,
+            status,
+        } => CodexThreadItem::FileChange {
+            id: qualified_id,
+            changes,
+            status,
+        },
+        CodexThreadItem::McpToolCall {
+            id: _,
+            server,
+            tool,
+            arguments,
+            result,
+            error,
+            status,
+        } => CodexThreadItem::McpToolCall {
+            id: qualified_id,
+            server,
+            tool,
+            arguments,
+            result,
+            error,
+            status,
+        },
+        CodexThreadItem::WebSearch { id: _, query } => CodexThreadItem::WebSearch {
+            id: qualified_id,
+            query,
+        },
+        CodexThreadItem::TodoList { id: _, items } => CodexThreadItem::TodoList {
+            id: qualified_id,
+            items,
+        },
+        CodexThreadItem::Error { id: _, message } => CodexThreadItem::Error {
+            id: qualified_id,
+            message,
+        },
+    }
+}
+
+pub(super) fn qualify_event(turn_scope_id: &str, event: CodexThreadEvent) -> CodexThreadEvent {
+    match event {
+        CodexThreadEvent::ItemStarted { item } => CodexThreadEvent::ItemStarted {
+            item: qualify_codex_item(turn_scope_id, item),
+        },
+        CodexThreadEvent::ItemUpdated { item } => CodexThreadEvent::ItemUpdated {
+            item: qualify_codex_item(turn_scope_id, item),
+        },
+        CodexThreadEvent::ItemCompleted { item } => CodexThreadEvent::ItemCompleted {
+            item: qualify_codex_item(turn_scope_id, item),
+        },
+        other => other,
+    }
+}


### PR DESCRIPTION
## Summary

- Extract Codex thread item/event scoping helpers out of `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/codex_thread.rs`.
- No behavior change intended.

## Behavior changes

- None.

## Verification

- `just fmt && just lint && just test`

## Manual verification

1. Start the app as usual.
2. Run a Codex turn and confirm streamed items/events render as expected.
3. Start a second turn in the same thread and confirm item IDs remain scoped per turn.

## Risk and rollback

- Low risk (refactor-only, module extraction).
- Rollback by reverting this PR.

## Contracts

- Not applicable (no changes to web/server integration surfaces).
