### PR TITLE
refactor(backend): extract service root path helpers

### DIFF
--- a/crates/luban_backend/src/services/roots.rs
+++ b/crates/luban_backend/src/services/roots.rs
@@ -1,0 +1,63 @@
+use luban_domain::paths;
+use std::path::PathBuf;
+
+use crate::env::{home_dir, optional_trimmed_path_from_env};
+use crate::time::unix_epoch_nanos_now;
+
+pub(super) fn resolve_luban_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_ROOT_ENV)? {
+        return Ok(root);
+    }
+
+    if cfg!(test) {
+        let nanos = unix_epoch_nanos_now();
+        let pid = std::process::id();
+        return Ok(std::env::temp_dir().join(format!("luban-test-{pid}-{nanos}")));
+    }
+
+    Ok(home_dir()?.join("luban"))
+}
+
+pub(super) fn resolve_codex_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CODEX_ROOT_ENV)? {
+        return Ok(root);
+    }
+
+    if cfg!(test) {
+        return Ok(PathBuf::from(".codex"));
+    }
+
+    Ok(home_dir()?.join(".codex"))
+}
+
+pub(super) fn resolve_amp_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_AMP_ROOT_ENV)? {
+        return Ok(root);
+    }
+
+    if cfg!(test) {
+        return Ok(PathBuf::from(".amp"));
+    }
+
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        let xdg = xdg.to_string_lossy();
+        let trimmed = xdg.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed).join("amp"));
+        }
+    }
+
+    Ok(home_dir()?.join(".config").join("amp"))
+}
+
+pub(super) fn resolve_claude_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CLAUDE_ROOT_ENV)? {
+        return Ok(root);
+    }
+
+    if cfg!(test) {
+        return Ok(PathBuf::from(".claude"));
+    }
+
+    Ok(home_dir()?.join(".claude"))
+}


### PR DESCRIPTION
## Summary

- Extract service root path resolution helpers out of `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/roots.rs`.
- No behavior change intended.

## Behavior changes

- None.

## Verification

- `just fmt && just lint && just test`

## Manual verification

1. Start the app as usual.
2. Create a new workspace and confirm it initializes correctly.
3. Run a Codex/Claude/Amp turn and confirm their config roots resolve as expected.

## Risk and rollback

- Low risk (refactor-only, module extraction).
- Rollback by reverting this PR.

## Contracts

- Not applicable (no changes to web/server integration surfaces).
