### PR TITLE
refactor(backend): extract amp mode detection

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -24,6 +24,7 @@ use crate::sqlite_store::{SqliteStore, SqliteStoreOptions};
 use crate::time::{unix_epoch_micros_now, unix_epoch_nanos_now};
 
 mod amp_cli;
+mod amp_mode;
 mod claude_cli;
 pub mod claude_process;
 mod codex_bin;
@@ -38,6 +39,7 @@ mod pull_request;
 mod roots;
 mod task;
 use amp_cli::AmpTurnParams;
+use amp_mode::detect_amp_mode_from_config_root;
 use claude_cli::ClaudeTurnParams;
 use codex_cli::CodexTurnParams;
 use codex_thread::{codex_item_id, qualify_codex_item, qualify_event};
@@ -88,92 +90,6 @@ fn generate_turn_scope_id() -> String {
     let micros = unix_epoch_micros_now();
     let rand: u64 = OsRng.r#gen();
     format!("turn-{micros:x}-{rand:x}")
-}
-
-fn parse_amp_mode_from_config_text(contents: &str) -> Option<String> {
-    for raw_line in contents.lines() {
-        let line = raw_line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if line.starts_with('#') || line.starts_with("//") {
-            continue;
-        }
-
-        let lowered = line.to_ascii_lowercase();
-
-        let value = if let Some(rest) = lowered.strip_prefix("mode") {
-            let rest = rest.trim_start();
-            let rest = rest.strip_prefix(':').or_else(|| rest.strip_prefix('='));
-            rest.map(str::trim)
-        } else if let Some(rest) = lowered.strip_prefix("\"mode\"") {
-            let rest = rest.trim_start();
-            let rest = rest.strip_prefix(':');
-            rest.map(str::trim)
-        } else {
-            None
-        };
-
-        let Some(value) = value else {
-            continue;
-        };
-
-        let value = value
-            .trim_matches('"')
-            .trim_matches('\'')
-            .split(|c: char| c.is_whitespace() || c == ',' || c == '#')
-            .next()
-            .unwrap_or("")
-            .trim();
-        if value.is_empty() {
-            continue;
-        }
-
-        if value == "smart" || value == "rush" {
-            return Some(value.to_owned());
-        }
-    }
-    None
-}
-
-fn detect_amp_mode_from_config_root(root: &Path) -> Option<String> {
-    let candidates = [
-        "config.toml",
-        "config.yaml",
-        "config.yml",
-        "config.json",
-        "amp.toml",
-        "amp.yaml",
-        "amp.yml",
-        "amp.json",
-        "settings.toml",
-        "settings.yaml",
-        "settings.yml",
-        "settings.json",
-    ];
-
-    for rel in candidates {
-        let path = root.join(rel);
-        let meta = match std::fs::metadata(&path) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if !meta.is_file() {
-            continue;
-        }
-        if meta.len() > 2 * 1024 * 1024 {
-            continue;
-        }
-        let contents = match std::fs::read_to_string(&path) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if let Some(mode) = parse_amp_mode_from_config_text(&contents) {
-            return Some(mode);
-        }
-    }
-
-    None
 }
 
 /// Git workspace service with persistent Claude process management.

--- a/crates/luban_backend/src/services/amp_mode.rs
+++ b/crates/luban_backend/src/services/amp_mode.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+
+fn parse_amp_mode_from_config_text(contents: &str) -> Option<String> {
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('#') || line.starts_with("//") {
+            continue;
+        }
+
+        let lowered = line.to_ascii_lowercase();
+
+        let value = if let Some(rest) = lowered.strip_prefix("mode") {
+            let rest = rest.trim_start();
+            let rest = rest.strip_prefix(':').or_else(|| rest.strip_prefix('='));
+            rest.map(str::trim)
+        } else if let Some(rest) = lowered.strip_prefix("\"mode\"") {
+            let rest = rest.trim_start();
+            let rest = rest.strip_prefix(':');
+            rest.map(str::trim)
+        } else {
+            None
+        };
+
+        let Some(value) = value else {
+            continue;
+        };
+
+        let value = value
+            .trim_matches('"')
+            .trim_matches('\'')
+            .split(|c: char| c.is_whitespace() || c == ',' || c == '#')
+            .next()
+            .unwrap_or("")
+            .trim();
+        if value.is_empty() {
+            continue;
+        }
+
+        if value == "smart" || value == "rush" {
+            return Some(value.to_owned());
+        }
+    }
+    None
+}
+
+pub(super) fn detect_amp_mode_from_config_root(root: &Path) -> Option<String> {
+    let candidates = [
+        "config.toml",
+        "config.yaml",
+        "config.yml",
+        "config.json",
+        "amp.toml",
+        "amp.yaml",
+        "amp.yml",
+        "amp.json",
+        "settings.toml",
+        "settings.yaml",
+        "settings.yml",
+        "settings.json",
+    ];
+
+    for rel in candidates {
+        let path = root.join(rel);
+        let meta = match std::fs::metadata(&path) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        if meta.len() > 2 * 1024 * 1024 {
+            continue;
+        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(mode) = parse_amp_mode_from_config_text(&contents) {
+            return Some(mode);
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Summary
- No behavior change; refactor only.
- Extract amp mode config parsing/detection helpers from `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/amp_mode.rs`.

## Behavior Changes
- None.

## Verification
- `just fmt`
- `just lint`
- `just test`

## Manual Checks
1. Set `LUBAN_AGENT_RUNNER=Amp`.
2. Ensure a valid amp config file exists under the amp root (e.g. `config.toml` with `mode = "smart"`).
3. Run a workspace turn and confirm the resolved amp mode matches the config.

## Risk / Rollback
- Low risk (pure refactor).
- Rollback by reverting this commit.
