### PR TITLE
refactor(backend): extract reconnect notice detection

### DIFF
--- a/crates/luban_backend/src/services/reconnect_notice.rs
+++ b/crates/luban_backend/src/services/reconnect_notice.rs
@@ -1,0 +1,38 @@
+fn contains_attempt_fraction(text: &str) -> bool {
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if !ch.is_ascii_digit() {
+            continue;
+        }
+
+        while matches!(chars.peek(), Some(next) if next.is_ascii_digit()) {
+            let _ = chars.next();
+        }
+
+        if !matches!(chars.peek(), Some('/')) {
+            continue;
+        }
+        let _ = chars.next();
+
+        if !matches!(chars.peek(), Some(next) if next.is_ascii_digit()) {
+            continue;
+        }
+        return true;
+    }
+
+    false
+}
+
+pub(super) fn is_transient_reconnect_notice(message: &str) -> bool {
+    let message = message.trim();
+    if message.is_empty() {
+        return false;
+    }
+
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("reconnecting") {
+        return false;
+    }
+
+    contains_attempt_fraction(&lower)
+}


### PR DESCRIPTION
## Summary
- No behavior change; refactor only.
- Move transient reconnect notice detection helpers out of `crates/luban_backend/src/services.rs` into `crates/luban_backend/src/services/reconnect_notice.rs`.

## Behavior Changes
- None.

## Verification
- `just fmt`
- `just lint`
- `just test`

## Manual Checks
1. Run an Amp/Codex/Claude turn.
2. Observe that reconnect warnings like `reconnecting ...1/5` are still classified as transient and rendered as scoped error items.

## Risk / Rollback
- Low risk (pure refactor).
- Rollback by reverting this commit.
