### PR TITLE
refactor(backend): extract workspace name helper

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context as _, anyhow};
-use bip39::Language;
 use luban_domain::paths;
 use luban_domain::{
     AgentThreadEvent, AttachmentKind, AttachmentRef, ClaudeConfigEntry, ClaudeConfigEntryKind,
@@ -8,7 +7,6 @@ use luban_domain::{
     ProjectWorkspaceService, PullRequestCiState, PullRequestInfo, PullRequestState,
     RunAgentTurnRequest, SystemTaskKind, TaskIntentKind,
 };
-use rand::{Rng as _, rngs::OsRng};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -39,6 +37,7 @@ mod pull_request;
 mod reconnect_notice;
 mod roots;
 mod task;
+mod workspace_name;
 use amp_cli::AmpTurnParams;
 use amp_mode::detect_amp_mode_from_config_root;
 use claude_cli::ClaudeTurnParams;
@@ -98,11 +97,7 @@ impl GitWorkspaceService {
     }
 
     fn generate_workspace_name(&self) -> anyhow::Result<String> {
-        let words = Language::English.word_list();
-        let mut rng = OsRng;
-        let w1 = words[rng.gen_range(0..words.len())];
-        let w2 = words[rng.gen_range(0..words.len())];
-        Ok(format!("{w1}-{w2}"))
+        workspace_name::generate_workspace_name()
     }
 
     fn worktree_path(&self, project_slug: &str, workspace_name: &str) -> PathBuf {

--- a/crates/luban_backend/src/services/workspace_name.rs
+++ b/crates/luban_backend/src/services/workspace_name.rs
@@ -1,0 +1,10 @@
+use bip39::Language;
+use rand::{Rng as _, rngs::OsRng};
+
+pub fn generate_workspace_name() -> anyhow::Result<String> {
+    let words = Language::English.word_list();
+    let mut rng = OsRng;
+    let w1 = words[rng.gen_range(0..words.len())];
+    let w2 = words[rng.gen_range(0..words.len())];
+    Ok(format!("{w1}-{w2}"))
+}


### PR DESCRIPTION
## Summary
- Extract workspace name generation into `crates/luban_backend/src/services/workspace_name.rs`.

## Behavior
- No user-visible behavior changes.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. Launch the app (`just run`).
2. Create a new workspace.
3. Confirm the generated workspace name format is still `<word>-<word>`.
