### PR TITLE
refactor(backend): dedupe config list_dir path parsing

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -28,6 +28,7 @@ pub mod claude_process;
 mod codex_bin;
 mod codex_cli;
 mod codex_thread;
+mod config_path;
 mod config_tree;
 mod context_blobs;
 mod conversations;
@@ -2157,23 +2158,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 return Ok(Vec::new());
             }
 
-            let rel = path.trim();
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            if !rel.is_empty() {
-                for segment in rel.split('/') {
-                    if segment.is_empty() || segment == "." || segment == ".." {
-                        return Err(anyhow!("invalid path segment"));
-                    }
-                    rel_path.push(segment);
-                }
-            }
+            let rel_path = config_path::parse_strict_relative_list_dir_path(&path)?;
 
             let abs = root.join(&rel_path);
             let meta = std::fs::metadata(&abs)
@@ -2402,23 +2387,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 return Ok(Vec::new());
             }
 
-            let rel = path.trim();
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            if !rel.is_empty() {
-                for segment in rel.split('/') {
-                    if segment.is_empty() || segment == "." || segment == ".." {
-                        return Err(anyhow!("invalid path segment"));
-                    }
-                    rel_path.push(segment);
-                }
-            }
+            let rel_path = config_path::parse_strict_relative_list_dir_path(&path)?;
 
             let abs = root.join(&rel_path);
             let meta = std::fs::metadata(&abs)
@@ -2642,24 +2611,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 return Ok(Vec::new());
             }
 
-            let rel = path.trim();
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() {
-                    continue;
-                }
-                if segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_lenient_relative_list_dir_path(&path)?;
 
             let abs = root.join(&rel_path);
             let meta = std::fs::metadata(&abs)

--- a/crates/luban_backend/src/services/config_path.rs
+++ b/crates/luban_backend/src/services/config_path.rs
@@ -1,0 +1,142 @@
+use anyhow::anyhow;
+use std::path::PathBuf;
+
+pub(super) fn parse_strict_relative_list_dir_path(path: &str) -> anyhow::Result<PathBuf> {
+    let rel = path.trim();
+    if rel.starts_with('/') {
+        return Err(anyhow!("path must be relative"));
+    }
+    if rel.contains('\\') {
+        return Err(anyhow!("invalid path separator"));
+    }
+
+    let mut rel_path = PathBuf::new();
+    if !rel.is_empty() {
+        for segment in rel.split('/') {
+            if segment.is_empty() || segment == "." || segment == ".." {
+                return Err(anyhow!("invalid path segment"));
+            }
+            rel_path.push(segment);
+        }
+    }
+    Ok(rel_path)
+}
+
+pub(super) fn parse_lenient_relative_list_dir_path(path: &str) -> anyhow::Result<PathBuf> {
+    let rel = path.trim();
+    if rel.starts_with('/') {
+        return Err(anyhow!("path must be relative"));
+    }
+    if rel.contains('\\') {
+        return Err(anyhow!("invalid path separator"));
+    }
+
+    let mut rel_path = PathBuf::new();
+    for segment in rel.split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+        if segment == "." || segment == ".." {
+            return Err(anyhow!("invalid path segment"));
+        }
+        rel_path.push(segment);
+    }
+    Ok(rel_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_lenient_relative_list_dir_path, parse_strict_relative_list_dir_path};
+
+    #[test]
+    fn strict_accepts_empty_as_root() {
+        assert_eq!(
+            parse_strict_relative_list_dir_path("").unwrap().as_os_str(),
+            ""
+        );
+        assert_eq!(
+            parse_strict_relative_list_dir_path("   ")
+                .unwrap()
+                .as_os_str(),
+            ""
+        );
+    }
+
+    #[test]
+    fn strict_rejects_empty_segments() {
+        assert_eq!(
+            parse_strict_relative_list_dir_path("a/")
+                .unwrap_err()
+                .to_string(),
+            "invalid path segment"
+        );
+        assert_eq!(
+            parse_strict_relative_list_dir_path("a//b")
+                .unwrap_err()
+                .to_string(),
+            "invalid path segment"
+        );
+    }
+
+    #[test]
+    fn strict_rejects_dot_and_dotdot_segments() {
+        assert_eq!(
+            parse_strict_relative_list_dir_path(".")
+                .unwrap_err()
+                .to_string(),
+            "invalid path segment"
+        );
+        assert_eq!(
+            parse_strict_relative_list_dir_path("..")
+                .unwrap_err()
+                .to_string(),
+            "invalid path segment"
+        );
+        assert_eq!(
+            parse_strict_relative_list_dir_path("a/../b")
+                .unwrap_err()
+                .to_string(),
+            "invalid path segment"
+        );
+    }
+
+    #[test]
+    fn lenient_skips_empty_segments() {
+        assert_eq!(
+            parse_lenient_relative_list_dir_path("a/").unwrap(),
+            std::path::PathBuf::from("a")
+        );
+        assert_eq!(
+            parse_lenient_relative_list_dir_path("a//b").unwrap(),
+            std::path::PathBuf::from("a/b")
+        );
+    }
+
+    #[test]
+    fn both_reject_absolute_paths_and_backslashes() {
+        assert_eq!(
+            parse_strict_relative_list_dir_path("/a")
+                .unwrap_err()
+                .to_string(),
+            "path must be relative"
+        );
+        assert_eq!(
+            parse_lenient_relative_list_dir_path("/a")
+                .unwrap_err()
+                .to_string(),
+            "path must be relative"
+        );
+        assert_eq!(
+            parse_strict_relative_list_dir_path("a\\\\b")
+                .unwrap_err()
+                .to_string(),
+            "invalid path separator"
+        );
+        assert_eq!(
+            parse_lenient_relative_list_dir_path("a\\\\b")
+                .unwrap_err()
+                .to_string(),
+            "invalid path separator"
+        );
+    }
+}


### PR DESCRIPTION
Summary
- Extract shared relative path parsing/validation for config list_dir endpoints.
- Preserve existing behavior and error messages for Codex/Amp (strict) and Claude (lenient empty-segment handling).

Changes
- Add `crates/luban_backend/src/services/config_path.rs` with strict/lenient parsers (+ unit tests).
- Use shared helpers from `crates/luban_backend/src/services.rs` for `*_config_list_dir`.

Verification
- `just fmt && just lint && just test`

Risk
- Low: refactor-only; path parsing is covered by new unit tests.
