### PR TITLE
refactor(backend): dedupe config file path parsing

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -2240,24 +2240,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<String> = (|| {
             let root = resolve_codex_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let meta = std::fs::metadata(&abs)
@@ -2282,24 +2265,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<()> = (|| {
             let root = resolve_codex_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let parent = abs
@@ -2471,24 +2437,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<String> = (|| {
             let root = resolve_amp_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let meta = std::fs::metadata(&abs)
@@ -2513,24 +2462,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<()> = (|| {
             let root = resolve_amp_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let parent = abs
@@ -2690,24 +2622,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<String> = (|| {
             let root = resolve_claude_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let meta = std::fs::metadata(&abs)
@@ -2732,24 +2647,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         let result: anyhow::Result<()> = (|| {
             let root = resolve_claude_root()?;
 
-            let rel = path.trim();
-            if rel.is_empty() {
-                return Err(anyhow!("path is empty"));
-            }
-            if rel.starts_with('/') {
-                return Err(anyhow!("path must be relative"));
-            }
-            if rel.contains('\\') {
-                return Err(anyhow!("invalid path separator"));
-            }
-
-            let mut rel_path = PathBuf::new();
-            for segment in rel.split('/') {
-                if segment.is_empty() || segment == "." || segment == ".." {
-                    return Err(anyhow!("invalid path segment"));
-                }
-                rel_path.push(segment);
-            }
+            let rel_path = config_path::parse_strict_relative_file_path(&path)?;
 
             let abs = root.join(rel_path);
             let parent = abs

--- a/crates/luban_backend/src/services/config_path.rs
+++ b/crates/luban_backend/src/services/config_path.rs
@@ -44,9 +44,20 @@ pub(super) fn parse_lenient_relative_list_dir_path(path: &str) -> anyhow::Result
     Ok(rel_path)
 }
 
+pub(super) fn parse_strict_relative_file_path(path: &str) -> anyhow::Result<PathBuf> {
+    let rel = path.trim();
+    if rel.is_empty() {
+        return Err(anyhow!("path is empty"));
+    }
+    parse_strict_relative_list_dir_path(rel)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_lenient_relative_list_dir_path, parse_strict_relative_list_dir_path};
+    use super::{
+        parse_lenient_relative_list_dir_path, parse_strict_relative_file_path,
+        parse_strict_relative_list_dir_path,
+    };
 
     #[test]
     fn strict_accepts_empty_as_root() {
@@ -137,6 +148,20 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "invalid path separator"
+        );
+    }
+
+    #[test]
+    fn file_path_requires_non_empty() {
+        assert_eq!(
+            parse_strict_relative_file_path("").unwrap_err().to_string(),
+            "path is empty"
+        );
+        assert_eq!(
+            parse_strict_relative_file_path("   ")
+                .unwrap_err()
+                .to_string(),
+            "path is empty"
         );
     }
 }


### PR DESCRIPTION
Summary
- Deduplicate relative path parsing/validation for config read/write file endpoints.
- Preserve existing behavior and error messages.

Changes
- Add `parse_strict_relative_file_path` to `crates/luban_backend/src/services/config_path.rs`.
- Use it from `codex_config_{read,write}_file`, `amp_config_{read,write}_file`, `claude_config_{read,write}_file`.

Verification
- `just fmt && just lint && just test`

Risk
- Low: refactor-only; error strings are covered by unit tests.
