### PR TITLE
refactor: share stream-json helpers

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -40,6 +40,7 @@ mod prompt;
 mod pull_request;
 mod reconnect_notice;
 mod roots;
+mod stream_json;
 mod task;
 mod workspace_name;
 use amp_cli::AmpTurnParams;

--- a/crates/luban_backend/src/services/claude_cli.rs
+++ b/crates/luban_backend/src/services/claude_cli.rs
@@ -14,6 +14,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use super::stream_json::{
+    extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
+    value_as_string,
+};
+
 pub(super) struct ClaudeTurnParams {
     pub(super) thread_id: Option<String>,
     pub(super) worktree_path: PathBuf,
@@ -113,48 +118,6 @@ enum ClaudeToolSummary {
     Command { command: String },
     FileChange { changes: Vec<(String, String)> },
     WebSearch { query: String },
-}
-
-fn value_as_string(value: &Value) -> Option<String> {
-    match value {
-        Value::String(s) => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
-        Value::Null => None,
-        other => Some(other.to_string()),
-    }
-}
-
-fn extract_content_array(value: &Value) -> Option<&Vec<Value>> {
-    value
-        .pointer("/message/content")
-        .and_then(|v| v.as_array())
-        .or_else(|| value.get("content").and_then(|v| v.as_array()))
-}
-
-fn parse_tool_result_content(content: &Value) -> Value {
-    if let Some(s) = content.as_str() {
-        return Value::String(s.to_owned());
-    }
-    content.clone()
-}
-
-fn tool_name_key(name: &str) -> String {
-    name.trim().to_ascii_lowercase()
-}
-
-fn extract_string_field(value: &Value, keys: &[&str]) -> Option<String> {
-    for key in keys {
-        if let Some(v) = value.get(*key)
-            && let Some(s) = v.as_str()
-        {
-            let trimmed = s.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_owned());
-            }
-        }
-    }
-    None
 }
 
 fn summarize_tool_use(name: &str, input: &Value) -> (ClaudeToolKind, ClaudeToolSummary) {

--- a/crates/luban_backend/src/services/stream_json.rs
+++ b/crates/luban_backend/src/services/stream_json.rs
@@ -1,0 +1,43 @@
+use serde_json::Value;
+
+pub(super) fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
+pub(super) fn extract_content_array(value: &Value) -> Option<&Vec<Value>> {
+    value
+        .pointer("/message/content")
+        .and_then(|v| v.as_array())
+        .or_else(|| value.get("content").and_then(|v| v.as_array()))
+}
+
+pub(super) fn parse_tool_result_content(content: &Value) -> Value {
+    if let Some(s) = content.as_str() {
+        return Value::String(s.to_owned());
+    }
+    content.clone()
+}
+
+pub(super) fn tool_name_key(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+pub(super) fn extract_string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(v) = value.get(*key)
+            && let Some(s) = v.as_str()
+        {
+            let trimmed = s.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_owned());
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
Summary
- Extract shared stream-json helper functions into `crates/luban_backend/src/services/stream_json.rs`.
- Reuse helpers from `amp_cli` and `claude_cli` without behavior changes.

Verification
- `just fmt`
- `just lint`
- `just test`

Notes
- No contract or external API surface changes.
