### PR TITLE
refactor: share ANSI stripping

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -23,6 +23,7 @@ use crate::time::unix_epoch_nanos_now;
 
 mod amp_cli;
 mod amp_mode;
+mod ansi;
 mod claude_cli;
 pub mod claude_process;
 mod cli_check;

--- a/crates/luban_backend/src/services/amp_cli.rs
+++ b/crates/luban_backend/src/services/amp_cli.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use super::ansi::strip_ansi_control_sequences;
 use super::stream_json::{
     extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
     value_as_string,
@@ -23,32 +24,6 @@ pub(super) struct AmpTurnParams {
     pub(super) worktree_path: PathBuf,
     pub(super) prompt: String,
     pub(super) mode: Option<String>,
-}
-
-fn strip_ansi_control_sequences(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch != '\u{1b}' {
-            out.push(ch);
-            continue;
-        }
-
-        // Skip CSI and other escape sequences: ESC [ ... <final byte>
-        if matches!(chars.peek(), Some('[')) {
-            let _ = chars.next();
-            for next in chars.by_ref() {
-                if next.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-            continue;
-        }
-
-        // Skip the next character for non-CSI sequences.
-        let _ = chars.next();
-    }
-    out
 }
 
 fn resolve_amp_exec() -> PathBuf {

--- a/crates/luban_backend/src/services/ansi.rs
+++ b/crates/luban_backend/src/services/ansi.rs
@@ -1,0 +1,23 @@
+pub(super) fn strip_ansi_control_sequences(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            out.push(ch);
+            continue;
+        }
+
+        if matches!(chars.peek(), Some('[')) {
+            let _ = chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        let _ = chars.next();
+    }
+    out
+}

--- a/crates/luban_backend/src/services/claude_cli.rs
+++ b/crates/luban_backend/src/services/claude_cli.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use super::ansi::strip_ansi_control_sequences;
 use super::stream_json::{
     extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
     value_as_string,
@@ -24,30 +25,6 @@ pub(super) struct ClaudeTurnParams {
     pub(super) worktree_path: PathBuf,
     pub(super) prompt: String,
     pub(super) add_dirs: Vec<PathBuf>,
-}
-
-fn strip_ansi_control_sequences(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch != '\u{1b}' {
-            out.push(ch);
-            continue;
-        }
-
-        if matches!(chars.peek(), Some('[')) {
-            let _ = chars.next();
-            for next in chars.by_ref() {
-                if next.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-            continue;
-        }
-
-        let _ = chars.next();
-    }
-    out
 }
 
 fn resolve_claude_exec() -> PathBuf {


### PR DESCRIPTION
Summary
- Extract shared ANSI control sequence stripping into `crates/luban_backend/src/services/ansi.rs`.
- Reuse helper from `amp_cli` and `claude_cli` without behavior changes.

Verification
- `just fmt`
- `just lint`
- `just test`

Notes
- No contract or external API surface changes.
