### PR TITLE
refactor(backend): share stderr reader thread helper

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -43,6 +43,7 @@ mod reconnect_notice;
 mod roots;
 mod stream_json;
 mod task;
+mod thread_io;
 mod workspace_name;
 use amp_cli::AmpTurnParams;
 use amp_mode::detect_amp_mode_from_config_root;

--- a/crates/luban_backend/src/services/amp_cli.rs
+++ b/crates/luban_backend/src/services/amp_cli.rs
@@ -6,7 +6,7 @@ use luban_domain::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::io::{BufRead as _, BufReader, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -18,6 +18,7 @@ use super::stream_json::{
     extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
     value_as_string,
 };
+use super::thread_io::spawn_read_to_string;
 
 pub(super) struct AmpTurnParams {
     pub(super) thread_id: Option<String>,
@@ -637,12 +638,7 @@ pub(super) fn run_amp_turn_streamed_via_cli(
         })
     };
 
-    let stderr_handle = std::thread::spawn(move || -> String {
-        let mut buf = Vec::new();
-        let mut reader = BufReader::new(stderr);
-        let _ = reader.read_to_end(&mut buf);
-        String::from_utf8_lossy(&buf).to_string()
-    });
+    let stderr_handle = spawn_read_to_string(stderr);
 
     let mut state = AmpStreamState::new();
     let stdout_reader = BufReader::new(stdout);

--- a/crates/luban_backend/src/services/claude_cli.rs
+++ b/crates/luban_backend/src/services/claude_cli.rs
@@ -7,7 +7,7 @@ use luban_domain::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::io::{BufRead as _, BufReader, Write as _};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -19,6 +19,7 @@ use super::stream_json::{
     extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
     value_as_string,
 };
+use super::thread_io::spawn_read_to_string;
 
 pub(super) struct ClaudeTurnParams {
     pub(super) thread_id: Option<String>,
@@ -663,12 +664,7 @@ pub(super) fn run_claude_turn_streamed_via_cli(
         })
     };
 
-    let stderr_handle = std::thread::spawn(move || -> String {
-        let mut buf = Vec::new();
-        let mut reader = BufReader::new(stderr);
-        let _ = reader.read_to_end(&mut buf);
-        String::from_utf8_lossy(&buf).to_string()
-    });
+    let stderr_handle = spawn_read_to_string(stderr);
 
     let mut state = ClaudeStreamState::new();
     let stdout_reader = BufReader::new(stdout);

--- a/crates/luban_backend/src/services/codex_cli.rs
+++ b/crates/luban_backend/src/services/codex_cli.rs
@@ -1,8 +1,9 @@
+use super::thread_io::spawn_read_to_string;
 use anyhow::{Context as _, anyhow};
 use luban_domain::CodexThreadEvent;
 use std::{
     ffi::OsString,
-    io::{BufRead as _, BufReader, Read as _, Write as _},
+    io::{BufRead as _, BufReader, Write as _},
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
@@ -217,12 +218,7 @@ pub(super) fn run_codex_turn_streamed_via_cli(
         })
     };
 
-    let stderr_handle = std::thread::spawn(move || -> String {
-        let mut buf = Vec::new();
-        let mut reader = BufReader::new(stderr);
-        let _ = reader.read_to_end(&mut buf);
-        String::from_utf8_lossy(&buf).to_string()
-    });
+    let stderr_handle = spawn_read_to_string(stderr);
 
     let stdout_reader = BufReader::new(stdout);
     let mut stdout_noise: Vec<String> = Vec::new();

--- a/crates/luban_backend/src/services/thread_io.rs
+++ b/crates/luban_backend/src/services/thread_io.rs
@@ -1,0 +1,11 @@
+use std::io::{BufReader, Read};
+use std::thread::{self, JoinHandle};
+
+pub(super) fn spawn_read_to_string<R: Read + Send + 'static>(input: R) -> JoinHandle<String> {
+    thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut reader = BufReader::new(input);
+        let _ = reader.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).to_string()
+    })
+}


### PR DESCRIPTION
## Summary
- Add an internal `thread_io::spawn_read_to_string` helper.
- Use it in `amp_cli`, `claude_cli`, and `codex_cli` to read child `stderr` into a `String`.

## Testing
- `just fmt && just lint && just test`

## Risk
- Low: refactor-only dedupe, no behavior or API changes.
