### PR TITLE
refactor(backend): share cancel killer thread helper

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -24,6 +24,7 @@ use crate::time::unix_epoch_nanos_now;
 mod amp_cli;
 mod amp_mode;
 mod ansi;
+mod cancel_killer;
 mod claude_cli;
 pub mod claude_process;
 mod cli_check;

--- a/crates/luban_backend/src/services/cancel_killer.rs
+++ b/crates/luban_backend/src/services/cancel_killer.rs
@@ -1,0 +1,22 @@
+use std::process::Child;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+pub(super) fn spawn_cancel_killer(
+    child: Arc<std::sync::Mutex<Child>>,
+    cancel: Arc<AtomicBool>,
+    finished: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        while !finished.load(Ordering::SeqCst) && !cancel.load(Ordering::SeqCst) {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if cancel.load(Ordering::SeqCst)
+            && let Ok(mut child) = child.lock()
+        {
+            let _ = child.kill();
+        }
+    })
+}

--- a/crates/luban_backend/src/services/claude_cli.rs
+++ b/crates/luban_backend/src/services/claude_cli.rs
@@ -12,9 +12,9 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use super::ansi::strip_ansi_control_sequences;
+use super::cancel_killer::spawn_cancel_killer;
 use super::stream_json::{
     extract_content_array, extract_string_field, parse_tool_result_content, tool_name_key,
     value_as_string,
@@ -648,21 +648,7 @@ pub(super) fn run_claude_turn_streamed_via_cli(
 
     let finished = Arc::new(AtomicBool::new(false));
     let child = Arc::new(std::sync::Mutex::new(child));
-    let killer = {
-        let child = child.clone();
-        let cancel = cancel.clone();
-        let finished = finished.clone();
-        std::thread::spawn(move || {
-            while !finished.load(Ordering::SeqCst) && !cancel.load(Ordering::SeqCst) {
-                std::thread::sleep(Duration::from_millis(25));
-            }
-            if cancel.load(Ordering::SeqCst)
-                && let Ok(mut child) = child.lock()
-            {
-                let _ = child.kill();
-            }
-        })
-    };
+    let killer = spawn_cancel_killer(child.clone(), cancel.clone(), finished.clone());
 
     let stderr_handle = spawn_read_to_string(stderr);
 


### PR DESCRIPTION
## Summary
- Add an internal `cancel_killer::spawn_cancel_killer` helper.
- Use it in `amp_cli`, `claude_cli`, and `codex_cli` to dedupe the cancel-driven child kill thread.

## Testing
- `just fmt && just lint && just test`

## Risk
- Low: refactor-only dedupe, no behavior or API changes.
