### PR TITLE
refactor(backend): centralize gh CLI helpers

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -37,6 +37,7 @@ mod config_tree;
 mod context_blobs;
 mod conversations;
 mod feedback;
+mod gh_cli;
 mod git;
 mod prompt;
 mod pull_request;

--- a/crates/luban_backend/src/services/feedback.rs
+++ b/crates/luban_backend/src/services/feedback.rs
@@ -1,4 +1,5 @@
 use super::GitWorkspaceService;
+use super::gh_cli::{ensure_gh_cli, run_gh_json};
 use anyhow::{Context as _, anyhow};
 use luban_domain::{
     ProjectWorkspaceService, TaskDraft, TaskIntentKind, TaskIssueInfo, TaskProjectSpec,
@@ -10,25 +11,6 @@ use std::path::PathBuf;
 use std::process::Command;
 
 const FEEDBACK_REPO: &str = "xuanwo/luban";
-
-fn ensure_gh_cli() -> anyhow::Result<()> {
-    let status = Command::new("gh")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|err| {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                anyhow!("missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH")
-            } else {
-                anyhow!(err).context("failed to spawn gh")
-            }
-        })?;
-    if !status.success() {
-        return Err(anyhow!("gh --version failed with status: {status}"));
-    }
-    Ok(())
-}
 
 fn write_temp_file(prefix: &str, suffix: &str, contents: &str) -> anyhow::Result<PathBuf> {
     let dir = std::env::temp_dir();
@@ -54,26 +36,6 @@ fn extract_first_github_url(input: &str) -> Option<String> {
         .unwrap_or(rest.len());
     let url = rest[..end].trim_end_matches('/').to_owned();
     Some(url)
-}
-
-fn run_gh_json<T: for<'de> Deserialize<'de>>(args: &[&str]) -> anyhow::Result<T> {
-    let out = Command::new("gh").args(args).output().map_err(|err| {
-        if err.kind() == std::io::ErrorKind::NotFound {
-            anyhow!(
-                "missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH"
-            )
-        } else {
-            anyhow!(err).context("failed to spawn gh")
-        }
-    })?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(anyhow!("gh failed ({}): {}", out.status, stderr.trim()));
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let parsed = serde_json::from_str::<T>(stdout.trim())
-        .with_context(|| format!("failed to parse gh json for args: {}", args.join(" ")))?;
-    Ok(parsed)
 }
 
 #[derive(Deserialize)]

--- a/crates/luban_backend/src/services/gh_cli.rs
+++ b/crates/luban_backend/src/services/gh_cli.rs
@@ -1,0 +1,42 @@
+use anyhow::{Context as _, anyhow};
+use serde::Deserialize;
+use std::process::Command;
+
+pub(super) fn ensure_gh_cli() -> anyhow::Result<()> {
+    let status = Command::new("gh")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                anyhow!("missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH")
+            } else {
+                anyhow!(err).context("failed to spawn gh")
+            }
+        })?;
+    if !status.success() {
+        return Err(anyhow!("gh --version failed with status: {status}"));
+    }
+    Ok(())
+}
+
+pub(super) fn run_gh_json<T: for<'de> Deserialize<'de>>(args: &[&str]) -> anyhow::Result<T> {
+    let out = Command::new("gh").args(args).output().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH"
+            )
+        } else {
+            anyhow!(err).context("failed to spawn gh")
+        }
+    })?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(anyhow!("gh failed ({}): {}", out.status, stderr.trim()));
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed = serde_json::from_str::<T>(stdout.trim())
+        .with_context(|| format!("failed to parse gh json for args: {}", args.join(" ")))?;
+    Ok(parsed)
+}

--- a/crates/luban_backend/src/services/task.rs
+++ b/crates/luban_backend/src/services/task.rs
@@ -1,3 +1,4 @@
+use super::gh_cli::{ensure_gh_cli, run_gh_json};
 use crate::env::home_dir;
 use crate::services::GitWorkspaceService;
 use anyhow::{Context as _, anyhow};
@@ -124,45 +125,6 @@ fn parse_task_input(input: &str) -> anyhow::Result<ParsedTaskInput> {
     }
 
     Ok(ParsedTaskInput::Unspecified)
-}
-
-fn ensure_gh_cli() -> anyhow::Result<()> {
-    let status = Command::new("gh")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|err| {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                anyhow!("missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH")
-            } else {
-                anyhow!(err).context("failed to spawn gh")
-            }
-        })?;
-    if !status.success() {
-        return Err(anyhow!("gh --version failed with status: {status}"));
-    }
-    Ok(())
-}
-
-fn run_gh_json<T: for<'de> Deserialize<'de>>(args: &[&str]) -> anyhow::Result<T> {
-    let out = Command::new("gh").args(args).output().map_err(|err| {
-        if err.kind() == std::io::ErrorKind::NotFound {
-            anyhow!(
-                "missing gh executable: install GitHub CLI (gh) and ensure it is available on PATH"
-            )
-        } else {
-            anyhow!(err).context("failed to spawn gh")
-        }
-    })?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(anyhow!("gh failed ({}): {}", out.status, stderr.trim()));
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let parsed = serde_json::from_str::<T>(stdout.trim())
-        .with_context(|| format!("failed to parse gh json for args: {}", args.join(" ")))?;
-    Ok(parsed)
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Summary:
- Deduplicate `gh` command helpers used by services.

Changes:
- Add `crates/luban_backend/src/services/gh_cli.rs` with `ensure_gh_cli` and `run_gh_json`.
- Update `crates/luban_backend/src/services/feedback.rs` and `crates/luban_backend/src/services/task.rs` to reuse helpers.

Verification:
- `just fmt && just lint && just test`

Risk:
- Low (refactor only; shared helper extracted without behavior changes).
