### PR TITLE
refactor(sidebar): remove pin project/worktree

### DIFF
--- a/web/lib/ui-prefs.ts
+++ b/web/lib/ui-prefs.ts
@@ -7,8 +7,6 @@ export const VIEW_MODE_KEY = "luban:ui:view_mode"
 export const SIDEBAR_WIDTH_KEY = "luban:ui:sidebar_width_px"
 export const RIGHT_SIDEBAR_WIDTH_KEY = "luban:ui:right_sidebar_width_px"
 export const GLOBAL_ZOOM_KEY = "luban:ui:global_zoom"
-export const PINNED_PROJECTS_KEY = "luban:ui:pinned_projects"
-export const PINNED_WORKTREES_KEY = "luban:ui:pinned_worktrees"
 export const PROJECT_ORDER_KEY = "luban:ui:project_order"
 export const WORKTREE_ORDER_KEY = "luban:ui:worktree_order"
 

--- a/web/tests/e2e/chat-ui.spec.ts
+++ b/web/tests/e2e/chat-ui.spec.ts
@@ -87,7 +87,8 @@ test("user messages can be copied", async ({ page }) => {
   await expect(bubble).toBeVisible({ timeout: 20_000 })
 
   await bubble.hover()
-  await bubble.getByTestId("user-message-copy").click()
+  const messageContainer = bubble.locator("..")
+  await messageContainer.getByTestId("user-message-copy").click()
 
   await expect
     .poll(async () => await page.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 })
@@ -112,7 +113,9 @@ test("selected text can be copied while an agent turn is running", async ({ page
   const bubble = page.getByTestId("user-message-bubble").filter({ hasText: marker }).first()
   await expect(bubble).toBeVisible({ timeout: 20_000 })
 
-  await expect(page.getByText("echo 1")).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByRole("button", { name: /Completed \d+ steps|Cancelled after \d+ steps/ }).first()).toBeVisible({
+    timeout: 20_000,
+  })
 
   await bubble.evaluate(
     (el, needle) => {

--- a/web/tests/e2e/helpers.ts
+++ b/web/tests/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test"
+import fs from "node:fs"
 import { requireEnv } from "./env"
 
 export async function fetchAppSnapshot(page: Page): Promise<any> {
@@ -63,11 +64,11 @@ export async function sendWsAction<TAction extends Record<string, unknown>>(
 export async function ensureWorkspace(page: Page) {
   await page.goto("/")
 
-  const projectDir = requireEnv("LUBAN_E2E_PROJECT_DIR")
+  const projectDir = fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR"))
 
   await sendWsAction(page, { type: "add_project", path: projectDir })
 
-  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  const projectToggle = page.getByTitle(projectDir, { exact: true }).locator("..")
   await projectToggle.waitFor({ timeout: 15_000 })
   const projectContainer = projectToggle.locator("..").locator("..")
 

--- a/web/tests/e2e/project-ui.spec.ts
+++ b/web/tests/e2e/project-ui.spec.ts
@@ -59,6 +59,7 @@ test("project can be deleted via sidebar confirmation dialog", async ({ page }) 
   const projectContainer = projectToggle.locator("..").locator("..")
 
   await projectContainer.hover()
+  await expect(projectContainer.getByTestId("project-pin-button")).toHaveCount(0)
   await expect(projectContainer.getByTestId("project-delete-button")).toBeVisible()
   const sidebarBox = await page.getByTestId("left-sidebar").boundingBox()
   const deleteButtonBox = await projectContainer.getByTestId("project-delete-button").boundingBox()

--- a/web/tests/e2e/worktree-ui.spec.ts
+++ b/web/tests/e2e/worktree-ui.spec.ts
@@ -32,6 +32,8 @@ function samplePixel(png: PNG, x: number, y: number): { r: number; g: number; b:
 test("worktree item shows branch name above worktree name", async ({ page }) => {
   await ensureWorkspace(page)
 
+  await expect(page.getByTestId("worktree-pin-button")).toHaveCount(0)
+
   const worktreeName = page.getByTestId("worktree-worktree-name").first()
   const branchName = page.getByTestId("worktree-branch-name").first()
 
@@ -52,7 +54,7 @@ test("switching between worktrees keeps chat content stable (no flash)", async (
     requireEnv("LUBAN_E2E_PROJECT_DIR")
   const tidA = Number(snapA?.ui?.active_thread_id ?? NaN)
   if (!Number.isFinite(tidA)) throw new Error("missing active_thread_id")
-  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  const projectToggle = projectToggleByPath(page, fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR")))
   await projectToggle.waitFor({ timeout: 15_000 })
   const projectContainer = projectToggle.locator("..").locator("..")
   const branchEntries = projectContainer.getByTestId("worktree-branch-name")
@@ -123,7 +125,7 @@ test("switching between worktrees keeps chat content stable (no flash)", async (
   await expect(page.getByText(tokenA).first()).toBeVisible({ timeout: 20_000 })
   {
     const row = projectContainer.getByTestId("worktree-row").filter({ hasText: nameA }).first()
-    await expect(row.getByTestId("worktree-active-underline")).toHaveCount(1, { timeout: 10_000 })
+    await expect(row.getByTestId("worktree-active-indicator")).toHaveCount(1, { timeout: 10_000 })
   }
 
   const nameB = await page.evaluate(async (workspaceId) => {
@@ -142,7 +144,7 @@ test("switching between worktrees keeps chat content stable (no flash)", async (
   await expect(page.getByText(tokenB).first()).toBeVisible({ timeout: 20_000 })
   {
     const row = projectContainer.getByTestId("worktree-row").filter({ hasText: String(nameB) }).first()
-    await expect(row.getByTestId("worktree-active-underline")).toHaveCount(1, { timeout: 10_000 })
+    await expect(row.getByTestId("worktree-active-indicator")).toHaveCount(1, { timeout: 10_000 })
   }
 
   const sawEmptyState = await page.evaluate(() => Boolean((window as any).__e2eSawChatEmptyState))
@@ -167,7 +169,7 @@ test("draft attachments persist across worktree switches", async ({ page }) => {
   })()
   if (!nameA) throw new Error("missing branch name for workspace A")
 
-  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  const projectToggle = projectToggleByPath(page, fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR")))
   await projectToggle.waitFor({ timeout: 15_000 })
   const projectContainer = projectToggle.locator("..").locator("..")
   const branchEntries = projectContainer.getByTestId("worktree-branch-name")
@@ -212,7 +214,7 @@ test("new worktree highlight clears after a short delay", async ({ page }) => {
     snap.projects.find((p: any) => p.name === "e2e-project")?.path ??
     requireEnv("LUBAN_E2E_PROJECT_DIR")
 
-  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  const projectToggle = projectToggleByPath(page, fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR")))
   await projectToggle.waitFor({ timeout: 15_000 })
   const projectContainer = projectToggle.locator("..").locator("..")
   const branchEntries = projectContainer.getByTestId("worktree-branch-name")
@@ -371,7 +373,7 @@ test("running status spinner stays centered", async ({ page }) => {
     attachments: [],
   })
 
-  const row = page.getByTestId("worktree-row").filter({ has: page.getByTestId("worktree-active-underline") }).first()
+  const row = page.getByTestId("worktree-row").filter({ has: page.getByTestId("worktree-active-indicator") }).first()
   const spinner = row.locator("svg.animate-spin").first()
   await spinner.waitFor({ state: "visible", timeout: 10_000 })
 
@@ -399,7 +401,7 @@ test("creating a worktree auto-opens its conversation", async ({ page }) => {
 
   const beforeWorkspaceId = await activeWorkspaceId(page)
 
-  const projectToggle = page.getByRole("button", { name: "e2e-project", exact: true })
+  const projectToggle = projectToggleByPath(page, fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR")))
   const projectContainer = projectToggle.locator("..").locator("..")
 
   const addWorktree = projectContainer.getByTitle("Add worktree")


### PR DESCRIPTION
## What changed
- Removed project/worktree pin UI and local persistence; sidebar ordering is now solely driven by drag-and-drop order.
- Removed pinned-first sorting behavior in the sidebar view model.

## Why
- Drag-and-drop ordering makes pin redundant and removes a second, competing ordering rule.

## Verification
- `just fmt && just lint && just test`
- `pnpm -C web typecheck`

## Manual checks
1. Open the workspace sidebar.
2. Hover a project row: no pin button is shown.
3. Expand a project and hover a worktree row: no pin button is shown.
4. Drag projects/worktrees to reorder; refresh and confirm the order persists.

## Risk and rollback
- Risk: existing localStorage keys (`luban:ui:pinned_projects`, `luban:ui:pinned_worktrees`) become ignored.
- Rollback: revert commit `bdda778`.

## Contracts
- No changes to `/api/*` or WebSocket schemas; contracts are unchanged.
