### PR TITLE
refactor(backend): centralize GitHub URL extraction

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -39,6 +39,7 @@ mod conversations;
 mod feedback;
 mod gh_cli;
 mod git;
+mod github_url;
 mod prompt;
 mod pull_request;
 mod reconnect_notice;

--- a/crates/luban_backend/src/services/feedback.rs
+++ b/crates/luban_backend/src/services/feedback.rs
@@ -1,5 +1,6 @@
 use super::GitWorkspaceService;
 use super::gh_cli::{ensure_gh_cli, run_gh_json};
+use super::github_url::extract_first_github_url;
 use anyhow::{Context as _, anyhow};
 use luban_domain::{
     ProjectWorkspaceService, TaskDraft, TaskIntentKind, TaskIssueInfo, TaskProjectSpec,
@@ -23,19 +24,6 @@ fn write_temp_file(prefix: &str, suffix: &str, contents: &str) -> anyhow::Result
     std::fs::write(&path, contents.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
     Ok(path)
-}
-
-fn extract_first_github_url(input: &str) -> Option<String> {
-    let needle = "https://github.com/";
-    let start = input.find(needle)?;
-    let rest = &input[start..];
-    let end = rest
-        .find(|c: char| {
-            c.is_whitespace() || c == '"' || c == '\'' || c == ')' || c == ']' || c == '>'
-        })
-        .unwrap_or(rest.len());
-    let url = rest[..end].trim_end_matches('/').to_owned();
-    Some(url)
 }
 
 #[derive(Deserialize)]

--- a/crates/luban_backend/src/services/github_url.rs
+++ b/crates/luban_backend/src/services/github_url.rs
@@ -1,0 +1,12 @@
+pub(super) fn extract_first_github_url(input: &str) -> Option<String> {
+    let needle = "https://github.com/";
+    let start = input.find(needle)?;
+    let rest = &input[start..];
+    let end = rest
+        .find(|c: char| {
+            c.is_whitespace() || c == '"' || c == '\'' || c == ')' || c == ']' || c == '>'
+        })
+        .unwrap_or(rest.len());
+    let url = rest[..end].trim_end_matches('/').to_owned();
+    Some(url)
+}

--- a/crates/luban_backend/src/services/task.rs
+++ b/crates/luban_backend/src/services/task.rs
@@ -1,4 +1,5 @@
 use super::gh_cli::{ensure_gh_cli, run_gh_json};
+use super::github_url::extract_first_github_url;
 use crate::env::home_dir;
 use crate::services::GitWorkspaceService;
 use anyhow::{Context as _, anyhow};
@@ -21,19 +22,6 @@ enum ParsedTaskInput {
     GitHubRepo { full_name: String },
     GitHubIssue { full_name: String, number: u64 },
     GitHubPullRequest { full_name: String, number: u64 },
-}
-
-fn extract_first_github_url(input: &str) -> Option<String> {
-    let needle = "https://github.com/";
-    let start = input.find(needle)?;
-    let rest = &input[start..];
-    let end = rest
-        .find(|c: char| {
-            c.is_whitespace() || c == '"' || c == '\'' || c == ')' || c == ']' || c == '>'
-        })
-        .unwrap_or(rest.len());
-    let url = rest[..end].trim_end_matches('/').to_owned();
-    Some(url)
 }
 
 fn parse_github_url(url: &str) -> Option<ParsedTaskInput> {


### PR DESCRIPTION
Summary:
- Deduplicate GitHub URL extraction helper used across services.

Changes:
- Add `crates/luban_backend/src/services/github_url.rs` with `extract_first_github_url`.
- Update `crates/luban_backend/src/services/task.rs` and `crates/luban_backend/src/services/feedback.rs` to reuse it.

Verification:
- `just fmt && just lint && just test`

Risk:
- Low (refactor only; shared helper extracted without behavior changes).
