### PR TITLE
refactor(backend): dedupe roots and unify env test lock

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -2515,10 +2515,8 @@ mod tests {
     use luban_domain::{PersistedProject, PersistedWorkspace, WorkspaceStatus};
     use std::path::{Path, PathBuf};
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+        crate::env::lock_env_for_tests()
     }
 
     fn run_git(repo_path: &Path, args: &[&str]) -> std::process::Output {

--- a/crates/luban_backend/src/services/roots.rs
+++ b/crates/luban_backend/src/services/roots.rs
@@ -4,60 +4,189 @@ use std::path::PathBuf;
 use crate::env::{home_dir, optional_trimmed_path_from_env};
 use crate::time::unix_epoch_nanos_now;
 
-pub(super) fn resolve_luban_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_ROOT_ENV)? {
+fn resolve_root_from_env_or_default(
+    env_name: &str,
+    default: impl FnOnce() -> anyhow::Result<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    if let Some(root) = optional_trimmed_path_from_env(env_name)? {
         return Ok(root);
     }
 
-    if cfg!(test) {
-        let nanos = unix_epoch_nanos_now();
-        let pid = std::process::id();
-        return Ok(std::env::temp_dir().join(format!("luban-test-{pid}-{nanos}")));
-    }
+    default()
+}
 
-    Ok(home_dir()?.join("luban"))
+pub(super) fn resolve_luban_root() -> anyhow::Result<PathBuf> {
+    resolve_root_from_env_or_default(paths::LUBAN_ROOT_ENV, || {
+        if cfg!(test) {
+            let nanos = unix_epoch_nanos_now();
+            let pid = std::process::id();
+            return Ok(std::env::temp_dir().join(format!("luban-test-{pid}-{nanos}")));
+        }
+
+        Ok(home_dir()?.join("luban"))
+    })
 }
 
 pub(super) fn resolve_codex_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CODEX_ROOT_ENV)? {
-        return Ok(root);
-    }
+    resolve_root_from_env_or_default(paths::LUBAN_CODEX_ROOT_ENV, || {
+        if cfg!(test) {
+            return Ok(PathBuf::from(".codex"));
+        }
 
-    if cfg!(test) {
-        return Ok(PathBuf::from(".codex"));
-    }
-
-    Ok(home_dir()?.join(".codex"))
+        Ok(home_dir()?.join(".codex"))
+    })
 }
 
 pub(super) fn resolve_amp_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_AMP_ROOT_ENV)? {
-        return Ok(root);
-    }
-
-    if cfg!(test) {
-        return Ok(PathBuf::from(".amp"));
-    }
-
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        let xdg = xdg.to_string_lossy();
-        let trimmed = xdg.trim();
-        if !trimmed.is_empty() {
-            return Ok(PathBuf::from(trimmed).join("amp"));
+    resolve_root_from_env_or_default(paths::LUBAN_AMP_ROOT_ENV, || {
+        if cfg!(test) {
+            return Ok(PathBuf::from(".amp"));
         }
-    }
 
-    Ok(home_dir()?.join(".config").join("amp"))
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            let xdg = xdg.to_string_lossy();
+            let trimmed = xdg.trim();
+            if !trimmed.is_empty() {
+                return Ok(PathBuf::from(trimmed).join("amp"));
+            }
+        }
+
+        Ok(home_dir()?.join(".config").join("amp"))
+    })
 }
 
 pub(super) fn resolve_claude_root() -> anyhow::Result<PathBuf> {
-    if let Some(root) = optional_trimmed_path_from_env(paths::LUBAN_CLAUDE_ROOT_ENV)? {
-        return Ok(root);
+    resolve_root_from_env_or_default(paths::LUBAN_CLAUDE_ROOT_ENV, || {
+        if cfg!(test) {
+            return Ok(PathBuf::from(".claude"));
+        }
+
+        Ok(home_dir()?.join(".claude"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_amp_root, resolve_claude_root, resolve_codex_root, resolve_luban_root};
+    use luban_domain::paths;
+    use std::path::PathBuf;
+
+    fn set_env(name: &str, value: &str) -> Option<std::ffi::OsString> {
+        let prev = std::env::var_os(name);
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        prev
     }
 
-    if cfg!(test) {
-        return Ok(PathBuf::from(".claude"));
+    fn unset_env(name: &str) -> Option<std::ffi::OsString> {
+        let prev = std::env::var_os(name);
+        unsafe {
+            std::env::remove_var(name);
+        }
+        prev
     }
 
-    Ok(home_dir()?.join(".claude"))
+    fn restore_env(name: &str, prev: Option<std::ffi::OsString>) {
+        if let Some(value) = prev {
+            unsafe {
+                std::env::set_var(name, value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var(name);
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_codex_root_uses_env_override() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = set_env(paths::LUBAN_CODEX_ROOT_ENV, " codex ");
+        let loaded = resolve_codex_root().expect("codex root should resolve");
+        assert_eq!(loaded, PathBuf::from("codex"));
+        restore_env(paths::LUBAN_CODEX_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_codex_root_defaults_in_tests() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = unset_env(paths::LUBAN_CODEX_ROOT_ENV);
+        let loaded = resolve_codex_root().expect("codex root should resolve");
+        assert_eq!(loaded, PathBuf::from(".codex"));
+        restore_env(paths::LUBAN_CODEX_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_amp_root_uses_env_override() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = set_env(paths::LUBAN_AMP_ROOT_ENV, " amp-root ");
+        let loaded = resolve_amp_root().expect("amp root should resolve");
+        assert_eq!(loaded, PathBuf::from("amp-root"));
+        restore_env(paths::LUBAN_AMP_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_amp_root_defaults_in_tests() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = unset_env(paths::LUBAN_AMP_ROOT_ENV);
+        let loaded = resolve_amp_root().expect("amp root should resolve");
+        assert_eq!(loaded, PathBuf::from(".amp"));
+        restore_env(paths::LUBAN_AMP_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_claude_root_uses_env_override() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = set_env(paths::LUBAN_CLAUDE_ROOT_ENV, " claude-root ");
+        let loaded = resolve_claude_root().expect("claude root should resolve");
+        assert_eq!(loaded, PathBuf::from("claude-root"));
+        restore_env(paths::LUBAN_CLAUDE_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_claude_root_defaults_in_tests() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = unset_env(paths::LUBAN_CLAUDE_ROOT_ENV);
+        let loaded = resolve_claude_root().expect("claude root should resolve");
+        assert_eq!(loaded, PathBuf::from(".claude"));
+        restore_env(paths::LUBAN_CLAUDE_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_luban_root_uses_env_override() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = set_env(paths::LUBAN_ROOT_ENV, " luban-root ");
+        let loaded = resolve_luban_root().expect("luban root should resolve");
+        assert_eq!(loaded, PathBuf::from("luban-root"));
+        restore_env(paths::LUBAN_ROOT_ENV, prev);
+    }
+
+    #[test]
+    fn resolve_luban_root_defaults_in_tests() {
+        let _guard = crate::env::lock_env_for_tests();
+
+        let prev = unset_env(paths::LUBAN_ROOT_ENV);
+        let loaded = resolve_luban_root().expect("luban root should resolve");
+
+        assert!(loaded.starts_with(std::env::temp_dir()));
+        let pid = std::process::id();
+        let file_name = loaded
+            .file_name()
+            .expect("temp root should have a file name")
+            .to_string_lossy();
+        assert!(
+            file_name.starts_with(&format!("luban-test-{pid}-")),
+            "unexpected file name: {file_name}"
+        );
+
+        restore_env(paths::LUBAN_ROOT_ENV, prev);
+    }
 }


### PR DESCRIPTION
## Summary
Refactor-only cleanup around root resolution helpers.

## Changes
- Deduped env-override + default logic in `crates/luban_backend/src/services/roots.rs` via a small helper.
- Added focused unit tests for root resolution behavior in test builds.
- Centralized env var test locking with `crate::env::lock_env_for_tests()` and reused it from existing test modules.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. Run the backend in dev mode.
2. Verify Codex/Amp/Claude roots still resolve as expected with and without env overrides.
3. Run a task end-to-end (create workspace -> run agent turn) to confirm no regressions.

## Risk / Rollback
- Low risk (refactor + tests only). Roll back by reverting this commit.
