### PR TITLE
refactor: qualify codex item id in place

### DIFF
--- a/crates/luban_backend/src/services/codex_thread.rs
+++ b/crates/luban_backend/src/services/codex_thread.rs
@@ -22,74 +22,34 @@ pub(super) fn codex_item_id(item: &CodexThreadItem) -> &str {
     }
 }
 
-pub(super) fn qualify_codex_item(turn_scope_id: &str, item: CodexThreadItem) -> CodexThreadItem {
-    let raw_id = codex_item_id(&item);
-    if raw_id.starts_with(turn_scope_id) {
+fn codex_item_id_mut(item: &mut CodexThreadItem) -> &mut String {
+    match item {
+        CodexThreadItem::AgentMessage { id, .. } => id,
+        CodexThreadItem::Reasoning { id, .. } => id,
+        CodexThreadItem::CommandExecution { id, .. } => id,
+        CodexThreadItem::FileChange { id, .. } => id,
+        CodexThreadItem::McpToolCall { id, .. } => id,
+        CodexThreadItem::WebSearch { id, .. } => id,
+        CodexThreadItem::TodoList { id, .. } => id,
+        CodexThreadItem::Error { id, .. } => id,
+    }
+}
+
+pub(super) fn qualify_codex_item(
+    turn_scope_id: &str,
+    mut item: CodexThreadItem,
+) -> CodexThreadItem {
+    let id = codex_item_id_mut(&mut item);
+    if id.starts_with(turn_scope_id) {
         return item;
     }
 
-    let qualified_id = format!("{turn_scope_id}/{raw_id}");
-    match item {
-        CodexThreadItem::AgentMessage { id: _, text } => CodexThreadItem::AgentMessage {
-            id: qualified_id,
-            text,
-        },
-        CodexThreadItem::Reasoning { id: _, text } => CodexThreadItem::Reasoning {
-            id: qualified_id,
-            text,
-        },
-        CodexThreadItem::CommandExecution {
-            id: _,
-            command,
-            aggregated_output,
-            exit_code,
-            status,
-        } => CodexThreadItem::CommandExecution {
-            id: qualified_id,
-            command,
-            aggregated_output,
-            exit_code,
-            status,
-        },
-        CodexThreadItem::FileChange {
-            id: _,
-            changes,
-            status,
-        } => CodexThreadItem::FileChange {
-            id: qualified_id,
-            changes,
-            status,
-        },
-        CodexThreadItem::McpToolCall {
-            id: _,
-            server,
-            tool,
-            arguments,
-            result,
-            error,
-            status,
-        } => CodexThreadItem::McpToolCall {
-            id: qualified_id,
-            server,
-            tool,
-            arguments,
-            result,
-            error,
-            status,
-        },
-        CodexThreadItem::WebSearch { id: _, query } => CodexThreadItem::WebSearch {
-            id: qualified_id,
-            query,
-        },
-        CodexThreadItem::TodoList { id: _, items } => CodexThreadItem::TodoList {
-            id: qualified_id,
-            items,
-        },
-        CodexThreadItem::Error { id: _, message } => CodexThreadItem::Error {
-            id: qualified_id,
-            message,
-        },
-    }
+    let qualified_id = {
+        let raw_id = id.as_str();
+        format!("{turn_scope_id}/{raw_id}")
+    };
+    *id = qualified_id;
+    item
 }
 
 pub(super) fn qualify_event(turn_scope_id: &str, event: CodexThreadEvent) -> CodexThreadEvent {


### PR DESCRIPTION
## Summary
- Refactor `qualify_codex_item` to update `CodexThreadItem.id` in place instead of reconstructing enum variants.

## Motivation
- Reduce boilerplate and avoid unnecessary moves while keeping behavior identical.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. Start the app in mock mode.
2. Trigger a Codex turn that emits multiple items.
3. Verify item IDs are scoped as `turn-*/<raw_id>`.
4. Verify repeated qualification does not double-prefix IDs.

## Risk
- Low: refactor-only change in ID qualification logic.

## Rollback
- Revert the squash-merge commit.
