### PR TITLE
refactor: extract config entry mapping helpers

### DIFF
--- a/crates/luban_backend/src/services/config_entries.rs
+++ b/crates/luban_backend/src/services/config_entries.rs
@@ -1,0 +1,55 @@
+use super::config_tree;
+use luban_domain::{
+    ClaudeConfigEntry, ClaudeConfigEntryKind, CodexConfigEntry, CodexConfigEntryKind,
+};
+
+pub(super) fn codex_entries_from_shallow(
+    entries: Vec<config_tree::ShallowEntry>,
+) -> Vec<CodexConfigEntry> {
+    entries
+        .into_iter()
+        .map(|entry| CodexConfigEntry {
+            path: entry.path,
+            name: entry.name,
+            kind: match entry.kind {
+                config_tree::ShallowEntryKind::Folder => CodexConfigEntryKind::Folder,
+                config_tree::ShallowEntryKind::File => CodexConfigEntryKind::File,
+            },
+            children: Vec::new(),
+        })
+        .collect()
+}
+
+pub(super) fn amp_entries_from_shallow(
+    entries: Vec<config_tree::ShallowEntry>,
+) -> Vec<luban_domain::AmpConfigEntry> {
+    entries
+        .into_iter()
+        .map(|entry| luban_domain::AmpConfigEntry {
+            path: entry.path,
+            name: entry.name,
+            kind: match entry.kind {
+                config_tree::ShallowEntryKind::Folder => luban_domain::AmpConfigEntryKind::Folder,
+                config_tree::ShallowEntryKind::File => luban_domain::AmpConfigEntryKind::File,
+            },
+            children: Vec::new(),
+        })
+        .collect()
+}
+
+pub(super) fn claude_entries_from_shallow(
+    entries: Vec<config_tree::ShallowEntry>,
+) -> Vec<ClaudeConfigEntry> {
+    entries
+        .into_iter()
+        .map(|entry| ClaudeConfigEntry {
+            path: entry.path,
+            name: entry.name,
+            kind: match entry.kind {
+                config_tree::ShallowEntryKind::Folder => ClaudeConfigEntryKind::Folder,
+                config_tree::ShallowEntryKind::File => ClaudeConfigEntryKind::File,
+            },
+            children: Vec::new(),
+        })
+        .collect()
+}


### PR DESCRIPTION
This refactor moves config entry mapping helpers out of `crates/luban_backend/src/services.rs` into a dedicated module.

## Changes
- Add `crates/luban_backend/src/services/config_entries.rs`.
- Move `codex_entries_from_shallow`, `amp_entries_from_shallow`, and `claude_entries_from_shallow` into the new module.
- Update `crates/luban_backend/src/services.rs` to import and use the extracted helpers.

## Behavior changes
- None intended.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. Run `just run`.
2. Verify config tree/list-dir endpoints still work for Codex/Amp/Claude.

## Risks / Rollback
- Low risk; pure refactor.
- Rollback by reverting this PR.
