### PR TITLE
refactor: add temp dir helper for services tests

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -2322,7 +2322,7 @@ mod tests {
     use super::prompt::PromptAttachment;
     use super::pull_request::is_merge_ready;
     use super::test_support::{
-        assert_git_success, git_rev_parse, lock_env, run_git, stored_blob_path,
+        assert_git_success, git_rev_parse, lock_env, run_git, stored_blob_path, temp_services_dir,
     };
     use super::*;
     use luban_domain::{PersistedProject, PersistedWorkspace, WorkspaceStatus};
@@ -2532,8 +2532,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_CODEX_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
@@ -2616,8 +2615,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_CODEX_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
@@ -2694,8 +2692,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_AMP_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
@@ -2798,8 +2795,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_AMP_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
@@ -2877,8 +2873,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_CLAUDE_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
@@ -2959,8 +2954,7 @@ mod tests {
             std::env::set_var(paths::LUBAN_CLAUDE_ROOT_ENV, &root);
         }
 
-        let base_dir =
-            std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique));
+        let base_dir = temp_services_dir(unique);
         std::fs::create_dir_all(&base_dir).expect("luban root should exist");
         let sqlite =
             SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");

--- a/crates/luban_backend/src/services/test_support.rs
+++ b/crates/luban_backend/src/services/test_support.rs
@@ -10,6 +10,10 @@ pub(super) fn lock_env() -> MutexGuard<'static, ()> {
     crate::env::lock_env_for_tests()
 }
 
+pub(super) fn temp_services_dir(unique: u128) -> PathBuf {
+    std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique))
+}
+
 pub(super) fn run_git(repo_path: &Path, args: &[&str]) -> Output {
     Command::new("git")
         .args(args)


### PR DESCRIPTION
## Summary
- Add a test-only helper for creating the `luban-services-<pid>-<unique>` temp directory path.
- Replace repeated inline formatting in `crates/luban_backend/src/services.rs` tests with the helper.

## Motivation
- Reduce duplication in tests and keep path construction consistent.

## Verification
- `just fmt && just lint && just test`
