### PR TITLE
refactor: add env var guard for services tests

### DIFF
--- a/crates/luban_backend/src/services/test_support.rs
+++ b/crates/luban_backend/src/services/test_support.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::{OsStr, OsString},
     path::{Path, PathBuf},
     process::{Command, Output},
     sync::MutexGuard,
@@ -12,6 +13,43 @@ pub(super) fn lock_env() -> MutexGuard<'static, ()> {
 
 pub(super) fn temp_services_dir(unique: u128) -> PathBuf {
     std::env::temp_dir().join(format!("luban-services-{}-{}", std::process::id(), unique))
+}
+
+pub(super) struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub(super) fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+
+    pub(super) fn remove(key: &'static str) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = self.prev.take() {
+            unsafe {
+                std::env::set_var(self.key, prev);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 }
 
 pub(super) fn run_git(repo_path: &Path, args: &[&str]) -> Output {


### PR DESCRIPTION
## Summary
- Introduce `EnvVarGuard` for test-only env var overrides.
- Refactor `crates/luban_backend/src/services.rs` tests to use RAII instead of manual `set_var`/`remove_var` restore blocks.

## Verification
- `just fmt`
- `just lint`
- `just test`
