### PR TITLE
refactor: simplify PR CI state mapping

### DIFF
--- a/crates/luban_backend/src/services/pull_request.rs
+++ b/crates/luban_backend/src/services/pull_request.rs
@@ -4,13 +4,12 @@ pub(super) fn pull_request_ci_state_from_check_buckets<'a>(
     buckets: impl IntoIterator<Item = &'a str>,
 ) -> Option<PullRequestCiState> {
     let mut any_pending = false;
-    let mut any_fail = false;
     let mut any_pass = false;
     let mut any_skip = false;
 
     for bucket in buckets {
         match bucket {
-            "fail" | "cancel" => any_fail = true,
+            "fail" | "cancel" => return Some(PullRequestCiState::Failure),
             "pending" => any_pending = true,
             "pass" => any_pass = true,
             "skipping" => any_skip = true,
@@ -18,9 +17,6 @@ pub(super) fn pull_request_ci_state_from_check_buckets<'a>(
         }
     }
 
-    if any_fail {
-        return Some(PullRequestCiState::Failure);
-    }
     if any_pending {
         return Some(PullRequestCiState::Pending);
     }

--- a/crates/luban_backend/src/services/workspace_name.rs
+++ b/crates/luban_backend/src/services/workspace_name.rs
@@ -1,10 +1,11 @@
 use bip39::Language;
 use rand::{Rng as _, rngs::OsRng};
 
-pub fn generate_workspace_name() -> anyhow::Result<String> {
+pub(super) fn generate_workspace_name() -> anyhow::Result<String> {
     let words = Language::English.word_list();
     let mut rng = OsRng;
-    let w1 = words[rng.gen_range(0..words.len())];
-    let w2 = words[rng.gen_range(0..words.len())];
+    let len = words.len();
+    let w1 = words[rng.gen_range(0..len)];
+    let w2 = words[rng.gen_range(0..len)];
     Ok(format!("{w1}-{w2}"))
 }


### PR DESCRIPTION
Summary:
- Make `pull_request_ci_state_from_check_buckets` return early on failure buckets.
- Reduce `workspace_name::generate_workspace_name` visibility to `pub(super)`.

Why:
- Keep the PR CI mapping logic smaller and make the precedence (fail > pending > pass/skip) explicit.
- Avoid exposing unnecessary APIs within the `services` module.

Testing:
- `just fmt`
- `just lint`
- `just test`
