### PR TITLE
refactor: derive Clone for SqliteStore

### DIFF
--- a/crates/luban_backend/src/sqlite_store.rs
+++ b/crates/luban_backend/src/sqlite_store.rs
@@ -136,6 +136,7 @@ const MIGRATIONS: &[(u32, &str)] = &[
     ),
 ];
 
+#[derive(Clone)]
 pub struct SqliteStore {
     tx: mpsc::Sender<DbCommand>,
 }
@@ -149,14 +150,6 @@ impl Default for SqliteStoreOptions {
     fn default() -> Self {
         Self {
             persist_ui_state: true,
-        }
-    }
-}
-
-impl Clone for SqliteStore {
-    fn clone(&self) -> Self {
-        Self {
-            tx: self.tx.clone(),
         }
     }
 }


### PR DESCRIPTION
Summary:
- Replace a manual Clone impl with #[derive(Clone)] for SqliteStore.

Why:
- SqliteStore only wraps an mpsc::Sender, which already implements Clone.
- Deriving removes boilerplate and keeps the type definition self-contained.

Testing:
- just fmt && just lint && just test
