### PR TITLE
server: avoid allocation in auth mode env parsing

### DIFF
--- a/crates/luban_server/src/lib.rs
+++ b/crates/luban_server/src/lib.rs
@@ -42,9 +42,14 @@ impl ServerConfig {
         let mut out = Self::default();
 
         let mode = std::env::var("LUBAN_AUTH_MODE").unwrap_or_default();
-        out.auth.mode = match mode.trim().to_ascii_lowercase().as_str() {
-            "single_user" | "single-user" | "singleuser" => AuthMode::SingleUser,
-            _ => AuthMode::Disabled,
+        let mode = mode.trim();
+        out.auth.mode = if mode.eq_ignore_ascii_case("single_user")
+            || mode.eq_ignore_ascii_case("single-user")
+            || mode.eq_ignore_ascii_case("singleuser")
+        {
+            AuthMode::SingleUser
+        } else {
+            AuthMode::Disabled
         };
 
         out.auth.bootstrap_token = std::env::var("LUBAN_AUTH_BOOTSTRAP_TOKEN")
@@ -107,4 +112,98 @@ pub async fn start_server_with_config(
         addr: actual,
         handle: Some(handle),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prev: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn lock(keys: Vec<&'static str>) -> Self {
+            let lock = ENV_LOCK.lock().expect("env lock poisoned");
+
+            let mut prev = Vec::with_capacity(keys.len());
+            for key in keys {
+                prev.push((key, std::env::var(key).ok()));
+            }
+
+            Self { _lock: lock, prev }
+        }
+
+        fn set(&self, key: &'static str, value: &str) {
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+
+        fn remove(&self, key: &'static str) {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.prev.drain(..) {
+                match value {
+                    Some(value) => unsafe {
+                        std::env::set_var(key, value);
+                    },
+                    None => unsafe {
+                        std::env::remove_var(key);
+                    },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn server_config_from_env_defaults_to_disabled() {
+        let env = EnvGuard::lock(vec!["LUBAN_AUTH_MODE", "LUBAN_AUTH_BOOTSTRAP_TOKEN"]);
+        env.remove("LUBAN_AUTH_MODE");
+        env.remove("LUBAN_AUTH_BOOTSTRAP_TOKEN");
+
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.auth.mode, AuthMode::Disabled);
+        assert_eq!(cfg.auth.bootstrap_token, None);
+    }
+
+    #[test]
+    fn server_config_from_env_parses_auth_mode_single_user() {
+        let env = EnvGuard::lock(vec!["LUBAN_AUTH_MODE"]);
+
+        for value in [
+            "single_user",
+            "SINGLE_USER",
+            " Single-User ",
+            "singleuser",
+            "SINGLEUSER",
+        ] {
+            env.set("LUBAN_AUTH_MODE", value);
+            let cfg = ServerConfig::from_env();
+            assert_eq!(cfg.auth.mode, AuthMode::SingleUser, "value={value:?}");
+        }
+    }
+
+    #[test]
+    fn server_config_from_env_trims_bootstrap_token() {
+        let env = EnvGuard::lock(vec!["LUBAN_AUTH_BOOTSTRAP_TOKEN"]);
+
+        env.set("LUBAN_AUTH_BOOTSTRAP_TOKEN", "  abc  ");
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.auth.bootstrap_token.as_deref(), Some("abc"));
+
+        env.set("LUBAN_AUTH_BOOTSTRAP_TOKEN", "   ");
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.auth.bootstrap_token, None);
+    }
 }


### PR DESCRIPTION
Summary:
- Avoids an allocation in `ServerConfig::from_env()` by using `eq_ignore_ascii_case` instead of `to_ascii_lowercase`.
- Adds unit tests covering `LUBAN_AUTH_MODE` parsing and `LUBAN_AUTH_BOOTSTRAP_TOKEN` trimming.

Verification:
- `just fmt`
- `just lint`
- `just test`
