### PR TITLE
domain: avoid alloc when parsing context token kind

### DIFF
--- a/crates/luban_domain/src/context_tokens.rs
+++ b/crates/luban_domain/src/context_tokens.rs
@@ -9,12 +9,17 @@ pub enum ContextTokenKind {
 
 impl ContextTokenKind {
     fn parse(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "image" => Some(Self::Image),
-            "text" => Some(Self::Text),
-            "file" => Some(Self::File),
-            _ => None,
+        let raw = raw.trim();
+        if raw.eq_ignore_ascii_case("image") {
+            return Some(Self::Image);
         }
+        if raw.eq_ignore_ascii_case("text") {
+            return Some(Self::Text);
+        }
+        if raw.eq_ignore_ascii_case("file") {
+            return Some(Self::File);
+        }
+        None
     }
 
     pub fn as_str(self) -> &'static str {


### PR DESCRIPTION
Summary:
- Avoids an allocation in `ContextTokenKind::parse` by using `eq_ignore_ascii_case` instead of `to_ascii_lowercase`.

Verification:
- `just fmt`
- `just lint`
- `just test`
