### PR TITLE
tauri: avoid alloc in build channel parsing

### DIFF
--- a/crates/luban_tauri/src/main.rs
+++ b/crates/luban_tauri/src/main.rs
@@ -20,9 +20,10 @@ enum BuildChannel {
 }
 
 fn parse_build_channel(raw: &str) -> BuildChannel {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "release" => BuildChannel::Release,
-        _ => BuildChannel::Dev,
+    if raw.trim().eq_ignore_ascii_case("release") {
+        BuildChannel::Release
+    } else {
+        BuildChannel::Dev
     }
 }
 
@@ -521,8 +522,15 @@ mod tests {
 
     #[test]
     fn auto_update_is_enabled_on_release_channel() {
-        with_env_var("LUBAN_BUILD_CHANNEL", "release", || {
+        with_env_var("LUBAN_BUILD_CHANNEL", " RELEASE ", || {
             assert!(auto_update_enabled());
+        });
+    }
+
+    #[test]
+    fn auto_update_is_disabled_on_unknown_channel() {
+        with_env_var("LUBAN_BUILD_CHANNEL", "nightly", || {
+            assert!(!auto_update_enabled());
         });
     }
 }


### PR DESCRIPTION
Summary
- Avoids an allocation in `parse_build_channel` by using ASCII case-insensitive comparison.

Changes
- Replace `to_ascii_lowercase()` + match with `eq_ignore_ascii_case()`.
- Extend unit coverage for release/unknown build channel behavior.

Verification
- `just fmt && just lint && just test`

Manual verification
1. Run the desktop app with `LUBAN_BUILD_CHANNEL=RELEASE` and confirm update check is enabled.
2. Run the desktop app with `LUBAN_BUILD_CHANNEL=dev` and confirm update check is disabled.

Risk
- Low: behavior preserved (ASCII-only case-insensitive parse), plus tests.

Rollback
- Revert this PR.
