### PR TITLE
persist: per-thread run config overrides

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -3401,6 +3401,7 @@ mod tests {
             workspace_chat_scroll_y10: std::collections::HashMap::new(),
             workspace_chat_scroll_anchor: std::collections::HashMap::new(),
             workspace_unread_completions: std::collections::HashMap::new(),
+            workspace_thread_run_config_overrides: std::collections::HashMap::new(),
             task_prompt_templates: std::collections::HashMap::new(),
         };
 

--- a/crates/luban_domain/src/persistence/save.rs
+++ b/crates/luban_domain/src/persistence/save.rs
@@ -1,5 +1,8 @@
 use crate::time::unix_seconds;
-use crate::{AppState, PersistedAppState, PersistedProject, PersistedWorkspace};
+use crate::{
+    AppState, PersistedAppState, PersistedProject, PersistedWorkspace,
+    PersistedWorkspaceThreadRunConfigOverride,
+};
 use std::collections::HashMap;
 
 pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
@@ -106,6 +109,19 @@ pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
             .iter()
             .map(|workspace_id| (workspace_id.0, true))
             .collect::<HashMap<_, _>>(),
+        workspace_thread_run_config_overrides: state
+            .workspace_thread_run_config_overrides
+            .iter()
+            .map(|((workspace_id, thread_id), run_config)| {
+                (
+                    (workspace_id.0, thread_id.0),
+                    PersistedWorkspaceThreadRunConfigOverride {
+                        model_id: run_config.model_id.clone(),
+                        thinking_effort: run_config.thinking_effort.clone(),
+                    },
+                )
+            })
+            .collect(),
         task_prompt_templates: HashMap::new(),
     }
 }

--- a/crates/luban_domain/src/state/conversation.rs
+++ b/crates/luban_domain/src/state/conversation.rs
@@ -154,6 +154,7 @@ pub struct WorkspaceConversation {
     pub thread_id: Option<String>,
     pub draft: String,
     pub draft_attachments: Vec<DraftAttachment>,
+    pub run_config_overridden_by_user: bool,
     pub agent_model_id: String,
     pub thinking_effort: ThinkingEffort,
     pub entries: Vec<ConversationEntry>,

--- a/crates/luban_domain/src/state/mod.rs
+++ b/crates/luban_domain/src/state/mod.rs
@@ -17,7 +17,10 @@ pub use conversation::{
 };
 pub use ids::{ProjectId, WorkspaceId, WorkspaceThreadId};
 pub use layout::{MainPane, OperationStatus, RightPane, WorkspaceStatus};
-pub use persisted::{PersistedAppState, PersistedProject, PersistedWorkspace};
+pub use persisted::{
+    PersistedAppState, PersistedProject, PersistedWorkspace,
+    PersistedWorkspaceThreadRunConfigOverride,
+};
 pub use tabs::WorkspaceTabs;
 pub use workspace::{AppState, Project, Workspace};
 

--- a/crates/luban_domain/src/state/persisted.rs
+++ b/crates/luban_domain/src/state/persisted.rs
@@ -1,6 +1,12 @@
 use super::{ChatScrollAnchor, WorkspaceStatus};
 use std::{collections::HashMap, path::PathBuf};
 
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PersistedWorkspaceThreadRunConfigOverride {
+    pub model_id: String,
+    pub thinking_effort: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersistedAppState {
     pub projects: Vec<PersistedProject>,
@@ -29,6 +35,8 @@ pub struct PersistedAppState {
     pub workspace_chat_scroll_y10: HashMap<(u64, u64), i32>,
     pub workspace_chat_scroll_anchor: HashMap<(u64, u64), ChatScrollAnchor>,
     pub workspace_unread_completions: HashMap<u64, bool>,
+    pub workspace_thread_run_config_overrides:
+        HashMap<(u64, u64), PersistedWorkspaceThreadRunConfigOverride>,
     pub task_prompt_templates: HashMap<String, String>,
 }
 

--- a/crates/luban_domain/src/state/workspace.rs
+++ b/crates/luban_domain/src/state/workspace.rs
@@ -1,7 +1,7 @@
 use super::{
-    AppearanceFonts, AppearanceTheme, ChatScrollAnchor, MainPane, OperationStatus, ProjectId,
-    RightPane, WorkspaceConversation, WorkspaceId, WorkspaceStatus, WorkspaceTabs,
-    WorkspaceThreadId,
+    AppearanceFonts, AppearanceTheme, ChatScrollAnchor, MainPane, OperationStatus,
+    PersistedWorkspaceThreadRunConfigOverride, ProjectId, RightPane, WorkspaceConversation,
+    WorkspaceId, WorkspaceStatus, WorkspaceTabs, WorkspaceThreadId,
 };
 use crate::{SystemTaskKind, TaskIntentKind};
 use std::{
@@ -63,6 +63,8 @@ pub struct AppState {
     pub workspace_chat_scroll_y10: HashMap<(WorkspaceId, WorkspaceThreadId), i32>,
     pub workspace_chat_scroll_anchor: HashMap<(WorkspaceId, WorkspaceThreadId), ChatScrollAnchor>,
     pub workspace_unread_completions: HashSet<WorkspaceId>,
+    pub workspace_thread_run_config_overrides:
+        HashMap<(WorkspaceId, WorkspaceThreadId), PersistedWorkspaceThreadRunConfigOverride>,
     pub task_prompt_templates: HashMap<TaskIntentKind, String>,
     pub system_prompt_templates: HashMap<SystemTaskKind, String>,
 }

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -4804,6 +4804,7 @@ mod tests {
                 workspace_chat_scroll_y10: HashMap::new(),
                 workspace_chat_scroll_anchor: HashMap::new(),
                 workspace_unread_completions: HashMap::new(),
+                workspace_thread_run_config_overrides: HashMap::new(),
                 task_prompt_templates: HashMap::new(),
             })
         }
@@ -5341,6 +5342,7 @@ mod tests {
             workspace_chat_scroll_y10: HashMap::new(),
             workspace_chat_scroll_anchor: HashMap::new(),
             workspace_unread_completions: HashMap::new(),
+            workspace_thread_run_config_overrides: HashMap::new(),
             task_prompt_templates: HashMap::new(),
         };
 
@@ -5510,6 +5512,7 @@ mod tests {
                 workspace_chat_scroll_y10: HashMap::new(),
                 workspace_chat_scroll_anchor: HashMap::new(),
                 workspace_unread_completions: HashMap::new(),
+                workspace_thread_run_config_overrides: HashMap::new(),
                 task_prompt_templates: HashMap::new(),
             })
         }
@@ -5877,6 +5880,7 @@ mod tests {
                 workspace_chat_scroll_y10: HashMap::new(),
                 workspace_chat_scroll_anchor: HashMap::new(),
                 workspace_unread_completions: HashMap::new(),
+                workspace_thread_run_config_overrides: HashMap::new(),
                 task_prompt_templates: HashMap::new(),
             })
         }
@@ -6203,6 +6207,7 @@ mod tests {
                 workspace_chat_scroll_y10: HashMap::new(),
                 workspace_chat_scroll_anchor: HashMap::new(),
                 workspace_unread_completions: HashMap::new(),
+                workspace_thread_run_config_overrides: HashMap::new(),
                 task_prompt_templates: HashMap::new(),
             })
         }
@@ -6416,6 +6421,7 @@ mod tests {
                 workspace_chat_scroll_y10: HashMap::new(),
                 workspace_chat_scroll_anchor: HashMap::new(),
                 workspace_unread_completions: HashMap::new(),
+                workspace_thread_run_config_overrides: HashMap::new(),
                 task_prompt_templates: HashMap::new(),
             })
         }


### PR DESCRIPTION
## Behavior changes
- Per-thread model/reasoning overrides persist across workspace switches and across restarts.
- A thread's selected `model_id`/`thinking_effort` stays stable until the user changes it again.

## Scope
- Domain: add a persisted `(workspace_id, thread_id) -> {model_id, thinking_effort}` override map, apply it when (re)creating conversations, and update it on user changes.
- Backend: store/load the override map via `app_settings_text`.

## Verification
- `just fmt && just lint && just test`

## Manual test
1. Open a workspace and a thread.
2. Pick a non-default model/reasoning in the agent selector.
3. Switch to another workspace, then switch back.
4. Restart the app/server.
5. Confirm the same thread still shows the selected model/reasoning.

## Risk / rollback
- Risk: user model/effort changes now also trigger `SaveAppState`.
- Rollback: revert this PR; it removes the persisted override map and returns to conversation-store-only behavior.
