### PR TITLE
Fix sidebar icon alignment

### DIFF
--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -494,19 +494,22 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
                       : "cursor-default",
                   )}
                 >
-                  {canExpand ? (
-                    isExpanded ? (
-                      <ChevronDown className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-                    ) : (
-                      <ChevronRight className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-                    )
-                  ) : standaloneStatus ? (
-                    <span data-testid="project-agent-status-icon">
-                      <AgentStatusIcon status={standaloneStatus} size="sm" />
-                    </span>
-                  ) : (
-                    <span className="w-3.5 h-3.5 flex-shrink-0" />
-                  )}
+                  <span
+                    data-testid="sidebar-project-leading-icon"
+                    className="w-4 h-4 flex items-center justify-center flex-shrink-0"
+                  >
+                    {canExpand ? (
+                      isExpanded ? (
+                        <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />
+                      )
+                    ) : standaloneStatus ? (
+                      <span data-testid="project-agent-status-icon" className="flex-shrink-0">
+                        <AgentStatusIcon status={standaloneStatus} size="sm" />
+                      </span>
+                    ) : null}
+                  </span>
                   <span
                     className={cn(
                       "text-sm font-semibold truncate flex-1 min-w-0 transition-colors",
@@ -594,7 +597,7 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
                     <div
                       data-testid="worktree-row"
                       className={cn(
-                        "group/worktree relative flex items-center gap-2 px-2.5 py-2 mx-2 rounded-xl cursor-pointer outline-none transition-all duration-200",
+                        "group/worktree relative flex items-center gap-2 px-2 py-2 mx-2 rounded-xl cursor-pointer outline-none transition-all duration-200",
                         worktree.workspaceId === activeWorkspaceId
                           ? "bg-glass-surface shadow-lg"
                           : "hover:bg-glass-surface-muted/50",
@@ -610,16 +613,19 @@ export function Sidebar({ viewMode, onViewModeChange, widthPx }: SidebarProps) {
                         void openWorkspace(worktree.workspaceId)
                       }}
                     >
-                      {worktree.isArchiving ? (
-                        <Loader2
-                          data-testid="worktree-archiving-spinner"
-                          className="w-3.5 h-3.5 animate-spin text-muted-foreground flex-shrink-0"
-                        />
-                      ) : (
-                        <span className="flex-shrink-0">
+                      <span
+                        data-testid="sidebar-worktree-leading-icon"
+                        className="w-4 h-4 flex items-center justify-center flex-shrink-0"
+                      >
+                        {worktree.isArchiving ? (
+                          <Loader2
+                            data-testid="worktree-archiving-spinner"
+                            className="w-3.5 h-3.5 animate-spin text-muted-foreground"
+                          />
+                        ) : (
                           <AgentStatusIcon status={worktree.agentStatus} size="sm" />
-                        </span>
-                      )}
+                        )}
+                      </span>
 
                       <div className="flex flex-col flex-1 min-w-0">
                         <div className="flex items-center gap-1">

--- a/web/tests/e2e/worktree-ui.spec.ts
+++ b/web/tests/e2e/worktree-ui.spec.ts
@@ -44,6 +44,24 @@ test("worktree item shows branch name above worktree name", async ({ page }) => 
   expect((branchBox?.y ?? 0) < (nameBox?.y ?? 0)).toBeTruthy()
 })
 
+test("sidebar leading icons are aligned", async ({ page }) => {
+  await ensureWorkspace(page)
+
+  const projectPath = fs.realpathSync(requireEnv("LUBAN_E2E_PROJECT_DIR"))
+  const projectToggle = projectToggleByPath(page, projectPath)
+  await projectToggle.waitFor({ state: "visible", timeout: 15_000 })
+  const projectContainer = projectToggle.locator("..").locator("..")
+
+  const worktreeRows = projectContainer.getByTestId("worktree-row")
+  await worktreeRows.first().waitFor({ timeout: 15_000 })
+
+  const projectIconBox = await projectToggle.getByTestId("sidebar-project-leading-icon").boundingBox()
+  const worktreeIconBox = await worktreeRows.first().getByTestId("sidebar-worktree-leading-icon").boundingBox()
+  expect(projectIconBox, "project icon box should be visible").not.toBeNull()
+  expect(worktreeIconBox, "worktree icon box should be visible").not.toBeNull()
+  expect(Math.abs((projectIconBox?.x ?? 0) - (worktreeIconBox?.x ?? 0))).toBeLessThanOrEqual(1)
+})
+
 test("switching between worktrees keeps chat content stable (no flash)", async ({ page }) => {
   await ensureWorkspace(page)
 


### PR DESCRIPTION
Summary:
- Align left sidebar leading icons by using a fixed-width icon column.
- Reduce perceived drift across different icon glyphs.
- Add an E2E regression test for icon alignment.

Verification:
- just fmt && just lint && just test
- cd web && pnpm exec playwright test tests/e2e/worktree-ui.spec.ts -g "sidebar leading icons are aligned"

Notes:
- This change is UI-only and does not affect web/server contracts.
