### PR TITLE
Fix terminal theme to match sidebar

### DIFF
--- a/web/components/pty-terminal.tsx
+++ b/web/components/pty-terminal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, type CSSProperties } from "react"
 import { Terminal, type ITheme } from "@xterm/xterm"
 import { FitAddon } from "@xterm/addon-fit"
 import { WebLinksAddon } from "@xterm/addon-web-links"
@@ -887,7 +887,13 @@ export function PtyTerminal() {
       data-testid="pty-terminal"
       ref={outerRef}
       tabIndex={0}
-      className="luban-terminal h-full w-full p-0 font-mono text-xs overflow-hidden bg-card text-card-foreground focus:outline-none flex"
+      style={
+        {
+          "--terminal-background": "var(--secondary)",
+          "--terminal-foreground": "var(--foreground)",
+        } as unknown as CSSProperties
+      }
+      className="luban-terminal h-full w-full p-0 font-mono text-xs overflow-hidden bg-secondary text-foreground focus:outline-none flex"
     >
       <div className="flex-1 min-h-0 min-w-0 overflow-hidden px-3">
         <div ref={containerRef} className="h-full w-full overflow-hidden" />

--- a/web/tests/e2e/terminal-ui.spec.ts
+++ b/web/tests/e2e/terminal-ui.spec.ts
@@ -92,15 +92,16 @@ function samplePixel(png: PNG, x: number, y: number): { r: number; g: number; b:
   }
 }
 
-test("terminal background matches card background and survives reload", async ({ page }) => {
+test("terminal background matches sidebar background and survives reload", async ({ page }) => {
   await ensureWorkspace(page)
 
   const terminal = page.getByTestId("pty-terminal")
   await waitForTerminalReady(terminal)
 
-  const expected = await terminal.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
+  const sidebar = page.getByTestId("left-sidebar")
+  const expected = await sidebar.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
   const rgb = parseRgb(expected)
-  expect(rgb, `unexpected terminal background: ${expected}`).not.toBeNull()
+  expect(rgb, `unexpected sidebar background: ${expected}`).not.toBeNull()
 
   const shot = await terminal.screenshot()
   const png = PNG.sync.read(shot)
@@ -115,9 +116,9 @@ test("terminal background matches card background and survives reload", async ({
   await ensureWorkspace(page)
   await waitForTerminalReady(terminal)
 
-  const expectedAfter = await terminal.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
+  const expectedAfter = await sidebar.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
   const rgbAfter = parseRgb(expectedAfter)
-  expect(rgbAfter, `unexpected terminal background after reload: ${expectedAfter}`).not.toBeNull()
+  expect(rgbAfter, `unexpected sidebar background after reload: ${expectedAfter}`).not.toBeNull()
 
   const shotAfter = await terminal.screenshot()
   const pngAfter = PNG.sync.read(shotAfter)
@@ -128,7 +129,7 @@ test("terminal background matches card background and survives reload", async ({
   expect(Math.abs(pixelAfter.b - (rgbAfter?.b ?? 0))).toBeLessThanOrEqual(tol)
 })
 
-test("terminal ANSI black background is distinct from card background", async ({ page }) => {
+test("terminal ANSI black background is distinct from sidebar background", async ({ page }) => {
   const token = `ANSI_BG_DONE_${Math.random().toString(16).slice(2)}`
   const reversed = token.split("").reverse().join("")
   const output = waitForPtyOutput(page, new RegExp(escapeRegExp(reversed)), 20_000)
@@ -145,9 +146,10 @@ test("terminal ANSI black background is distinct from card background", async ({
   await page.keyboard.press("Enter")
   await output
 
-  const expected = await terminal.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
+  const sidebar = page.getByTestId("left-sidebar")
+  const expected = await sidebar.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
   const background = parseRgb(expected)
-  expect(background, `unexpected terminal background: ${expected}`).not.toBeNull()
+  expect(background, `unexpected sidebar background: ${expected}`).not.toBeNull()
 
   const samplePoint = await terminal.evaluate((outer) => {
     const target = (outer.querySelector("canvas") ?? outer.querySelector(".xterm")) as HTMLElement | null


### PR DESCRIPTION
## Summary
- Make the right-sidebar terminal background match the left sidebar theme (no separate card-like surface).

## Changes
- web/components/pty-terminal.tsx: render terminal container with `bg-secondary` and override `--terminal-background`/`--terminal-foreground` so xterm draws the same surface.
- web/tests/e2e/terminal-ui.spec.ts: assert terminal background matches `left-sidebar` background (including reload).

## Verification
- Ran `just fmt`, `just lint`, `just test`.
- Ran `just test-ui` locally; terminal tests passed, but the full suite had unrelated flaky failures (chat/worktree timeouts).

## Manual Checks
1. Open the right sidebar terminal tab.
2. Confirm the terminal surface visually matches the left sidebar background.
3. Toggle light/dark themes and re-check.
4. Reload the page and re-check.

## Risk / Rollback
- Low risk (styling + test expectation).
- Rollback by reverting the two files above.

## Contracts
- No web/server contract changes.
