### PR TITLE
fix(chat): pin runner and amp mode per thread

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -305,8 +305,11 @@ pub struct ConversationSnapshot {
     pub rev: u64,
     pub workspace_id: WorkspaceId,
     pub thread_id: WorkspaceThreadId,
+    pub agent_runner: AgentRunnerKind,
     pub agent_model_id: String,
     pub thinking_effort: ThinkingEffort,
+    #[serde(default)]
+    pub amp_mode: Option<String>,
     pub run_status: OperationStatus,
     #[serde(default)]
     pub run_started_at_unix_ms: Option<u64>,
@@ -339,8 +342,11 @@ pub struct QueuedPromptSnapshot {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgentRunConfigSnapshot {
+    pub runner: AgentRunnerKind,
     pub model_id: String,
     pub thinking_effort: ThinkingEffort,
+    #[serde(default)]
+    pub amp_mode: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -682,6 +688,16 @@ pub enum ClientAction {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
         model_id: String,
+    },
+    ChatRunnerChanged {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        runner: AgentRunnerKind,
+    },
+    ChatAmpModeChanged {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        amp_mode: String,
     },
     ThinkingEffortChanged {
         workspace_id: WorkspaceId,

--- a/crates/luban_backend/migrations/0015_conversation_agent_runner.sql
+++ b/crates/luban_backend/migrations/0015_conversation_agent_runner.sql
@@ -1,0 +1,6 @@
+ALTER TABLE conversations
+    ADD COLUMN agent_runner TEXT;
+
+ALTER TABLE conversations
+    ADD COLUMN amp_mode TEXT;
+

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -774,16 +774,20 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         project_slug: String,
         workspace_name: String,
         thread_id: u64,
+        runner: luban_domain::AgentRunnerKind,
         model_id: String,
         thinking_effort: luban_domain::ThinkingEffort,
+        amp_mode: Option<String>,
     ) -> Result<(), String> {
         self.sqlite
             .save_conversation_run_config(
                 project_slug,
                 workspace_name,
                 thread_id,
+                runner,
                 model_id,
                 thinking_effort,
+                amp_mode,
             )
             .map_err(anyhow_error_to_string)
     }

--- a/crates/luban_backend/src/services/conversations.rs
+++ b/crates/luban_backend/src/services/conversations.rs
@@ -117,8 +117,10 @@ impl GitWorkspaceService {
         if !events_path.exists() {
             return Ok(Some(ConversationSnapshot {
                 thread_id: meta.thread_id,
+                runner: None,
                 agent_model_id: None,
                 thinking_effort: None,
+                amp_mode: None,
                 entries: Vec::new(),
                 entries_total: 0,
                 entries_start: 0,
@@ -160,8 +162,10 @@ impl GitWorkspaceService {
         let entries_total = entries.len() as u64;
         Ok(Some(ConversationSnapshot {
             thread_id: meta.thread_id,
+            runner: None,
             agent_model_id: None,
             thinking_effort: None,
+            amp_mode: None,
             entries,
             entries_total,
             entries_start: 0,

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -139,6 +139,16 @@ pub enum Action {
         thread_id: WorkspaceThreadId,
         model_id: String,
     },
+    ChatRunnerChanged {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        runner: AgentRunnerKind,
+    },
+    ChatAmpModeChanged {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        amp_mode: String,
+    },
     ThinkingEffortChanged {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -334,13 +334,16 @@ pub trait ProjectWorkspaceService: Send + Sync {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn save_conversation_run_config(
         &self,
         _project_slug: String,
         _workspace_name: String,
         _thread_id: u64,
+        _runner: AgentRunnerKind,
         _model_id: String,
         _thinking_effort: ThinkingEffort,
+        _amp_mode: Option<String>,
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/luban_domain/src/effects.rs
+++ b/crates/luban_domain/src/effects.rs
@@ -58,8 +58,10 @@ pub enum Effect {
     StoreConversationRunConfig {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
+        runner: crate::AgentRunnerKind,
         model_id: String,
         thinking_effort: crate::ThinkingEffort,
+        amp_mode: Option<String>,
     },
     LoadConversation {
         workspace_id: WorkspaceId,

--- a/crates/luban_domain/src/persistence/save.rs
+++ b/crates/luban_domain/src/persistence/save.rs
@@ -117,6 +117,8 @@ pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
                 (
                     (workspace_id.0, thread_id.0),
                     PersistedWorkspaceThreadRunConfigOverride {
+                        runner: run_config.runner.clone(),
+                        amp_mode: run_config.amp_mode.clone(),
                         model_id: run_config.model_id.clone(),
                         thinking_effort: run_config.thinking_effort.clone(),
                     },

--- a/crates/luban_domain/src/state/conversation.rs
+++ b/crates/luban_domain/src/state/conversation.rs
@@ -121,9 +121,13 @@ pub(crate) fn entries_is_suffix(suffix: &[ConversationEntry], full: &[Conversati
 pub struct ConversationSnapshot {
     pub thread_id: Option<String>,
     #[serde(default)]
+    pub runner: Option<crate::AgentRunnerKind>,
+    #[serde(default)]
     pub agent_model_id: Option<String>,
     #[serde(default)]
     pub thinking_effort: Option<crate::ThinkingEffort>,
+    #[serde(default)]
+    pub amp_mode: Option<String>,
     pub entries: Vec<ConversationEntry>,
     #[serde(default)]
     pub entries_total: u64,
@@ -155,8 +159,10 @@ pub struct WorkspaceConversation {
     pub draft: String,
     pub draft_attachments: Vec<DraftAttachment>,
     pub run_config_overridden_by_user: bool,
+    pub agent_runner: crate::AgentRunnerKind,
     pub agent_model_id: String,
     pub thinking_effort: ThinkingEffort,
+    pub amp_mode: Option<String>,
     pub entries: Vec<ConversationEntry>,
     pub entries_total: u64,
     pub entries_start: u64,

--- a/crates/luban_domain/src/state/persisted.rs
+++ b/crates/luban_domain/src/state/persisted.rs
@@ -3,6 +3,10 @@ use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PersistedWorkspaceThreadRunConfigOverride {
+    #[serde(default)]
+    pub runner: Option<String>,
+    #[serde(default)]
+    pub amp_mode: Option<String>,
     pub model_id: String,
     pub thinking_effort: String,
 }

--- a/docs/contracts/features/c-http-conversation.md
+++ b/docs/contracts/features/c-http-conversation.md
@@ -27,6 +27,15 @@ Paginated read for a single conversation thread.
 - `200 OK`
 - JSON body: `ConversationSnapshot`
 
+### Run config fields
+
+The response includes the effective per-thread run configuration used by the next agent turn:
+
+- `snapshot.agent_runner`: `AgentRunnerKind` (`codex` / `amp` / `claude`)
+- `snapshot.agent_model_id`: codex model id string (kept per-thread)
+- `snapshot.thinking_effort`: codex thinking effort (kept per-thread)
+- `snapshot.amp_mode`: optional string (only meaningful when `agent_runner` is `amp`)
+
 ## Invariants
 
 - Pagination must be stable (no duplicates across pages for the same cursor).

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -103,6 +103,8 @@ update this section.
 - `ArchiveWorkspace`
 - `EnsureMainWorkspace`
 - `ChatModelChanged`
+- `ChatRunnerChanged`
+- `ChatAmpModeChanged`
 - `ThinkingEffortChanged`
 - `SendAgentMessage`
 - `CancelAndSendAgentMessage`

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -47,6 +47,11 @@ Legend:
 | C-WS-EVENTS | `WS /api/events` | `crates/luban_server/src/server.rs:ws_events` | `web/lib/luban-transport.ts:useLubanTransport` | Draft | ✅ | ✅ | ✅ |
 | C-WS-PTY | `WS /api/pty/{workspace_id}/{thread_id}` | `crates/luban_server/src/server.rs:ws_pty` | `web/components/pty-terminal.tsx` | Draft | ✅ | ✅ | ✅ |
 
+## Notes
+
+- `C-WS-EVENTS`: `ClientAction::ChatRunnerChanged` and `ClientAction::ChatAmpModeChanged` are implemented in mock + provider and enforced in CI via `crates/luban_server/src/engine.rs` unit tests (see `agent_turn_uses_pinned_chat_runner_and_amp_mode`).
+- `C-HTTP-CONVERSATION`: `ConversationSnapshot` now includes `agent_runner` and `amp_mode` (mock + provider implemented; CI not yet enforced).
+
 ## Feature contracts
 
 - `docs/contracts/features/c-auth-single-user.md`

--- a/web/components/chat-composer.tsx
+++ b/web/components/chat-composer.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { Send } from "lucide-react"
 
-import { AgentSelector, type AgentRunnerOverride, type AmpModeOverride } from "@/components/shared/agent-selector"
+import { AgentSelector, type AmpMode } from "@/components/shared/agent-selector"
 import { MessageEditor, type ComposerAttachment } from "@/components/shared/message-editor"
 import type { AgentRunnerKind, AttachmentRef, CodexCustomPromptSnapshot, ThinkingEffort } from "@/lib/luban-api"
 
@@ -30,10 +30,10 @@ export function ChatComposer({
   onChangeModelId,
   onChangeThinkingEffort,
   defaultRunner,
-  runnerOverride,
-  ampModeOverride,
-  onChangeRunnerOverride,
-  onChangeAmpModeOverride,
+  runner,
+  ampMode,
+  onChangeRunner,
+  onChangeAmpMode,
   onSend,
   canSend,
   codexEnabled = true,
@@ -60,10 +60,10 @@ export function ChatComposer({
   onChangeModelId: (modelId: string) => void
   onChangeThinkingEffort: (effort: ThinkingEffort) => void
   defaultRunner: AgentRunnerKind | null
-  runnerOverride: AgentRunnerOverride
-  ampModeOverride: AmpModeOverride
-  onChangeRunnerOverride: (runner: AgentRunnerOverride) => void
-  onChangeAmpModeOverride: (mode: AmpModeOverride) => void
+  runner: AgentRunnerKind | null | undefined
+  ampMode: string | null | undefined
+  onChangeRunner: (runner: AgentRunnerKind) => void
+  onChangeAmpMode: (mode: AmpMode) => void
   onSend: () => void
   canSend: boolean
   codexEnabled?: boolean
@@ -100,10 +100,10 @@ export function ChatComposer({
               onChangeModelId={onChangeModelId}
               onChangeThinkingEffort={onChangeThinkingEffort}
               defaultRunner={defaultRunner}
-              runnerOverride={runnerOverride}
-              ampModeOverride={ampModeOverride}
-              onChangeRunnerOverride={onChangeRunnerOverride}
-              onChangeAmpModeOverride={onChangeAmpModeOverride}
+              runner={runner}
+              ampMode={ampMode}
+              onChangeRunner={onChangeRunner}
+              onChangeAmpMode={onChangeAmpMode}
               codexEnabled={codexEnabled}
               ampEnabled={ampEnabled}
             />

--- a/web/components/shared/agent-selector.tsx
+++ b/web/components/shared/agent-selector.tsx
@@ -212,9 +212,7 @@ export function CodexAgentSelector({
   )
 }
 
-export type AgentRunnerOverride = AgentRunnerKind | null
-
-export type AmpModeOverride = "smart" | "rush" | null
+export type AmpMode = "smart" | "rush" | null
 
 export function AgentSelector({
   testId = "agent-selector",
@@ -230,10 +228,10 @@ export function AgentSelector({
   className,
   defaultRunner,
   defaultAmpMode,
-  runnerOverride,
-  onChangeRunnerOverride,
-  ampModeOverride,
-  onChangeAmpModeOverride,
+  runner,
+  onChangeRunner,
+  ampMode,
+  onChangeAmpMode,
   codexEnabled = true,
   ampEnabled = true,
 }: {
@@ -250,23 +248,25 @@ export function AgentSelector({
   className?: string
   defaultRunner: AgentRunnerKind | null | undefined
   defaultAmpMode: string | null | undefined
-  runnerOverride: AgentRunnerOverride
-  onChangeRunnerOverride: (runner: AgentRunnerOverride) => void
-  ampModeOverride: AmpModeOverride
-  onChangeAmpModeOverride: (mode: AmpModeOverride) => void
+  runner: AgentRunnerKind | null | undefined
+  onChangeRunner: (runner: AgentRunnerKind) => void
+  ampMode: string | null | undefined
+  onChangeAmpMode: (mode: AmpMode) => void
   codexEnabled?: boolean
   ampEnabled?: boolean
 }) {
   const resolvedDefaultRunner: AgentRunnerKind = defaultRunner ?? "codex"
-  const resolvedRunner: AgentRunnerKind = runnerOverride ?? resolvedDefaultRunner
+  const resolvedRunner: AgentRunnerKind = runner ?? resolvedDefaultRunner
   const isAmp = resolvedRunner === "amp"
   const isClaude = resolvedRunner === "claude"
-  const resolvedDefaultAmpMode: AmpModeOverride = defaultAmpMode === "rush" ? "rush" : defaultAmpMode === "smart" ? "smart" : null
+  const resolvedDefaultAmpMode: AmpMode =
+    defaultAmpMode === "rush" ? "rush" : defaultAmpMode === "smart" ? "smart" : null
+  const resolvedAmpMode: AmpMode = ampMode === "rush" ? "rush" : ampMode === "smart" ? "smart" : null
 
   const displayName = useMemo(() => {
     if (isAmp) {
-      if (ampModeOverride === "rush") return "Amp · Rush"
-      if (ampModeOverride === "smart") return "Amp · Smart"
+      if (resolvedAmpMode === "rush") return "Amp · Rush"
+      if (resolvedAmpMode === "smart") return "Amp · Smart"
       return "Amp"
     }
     if (isClaude) return "Claude"
@@ -274,7 +274,7 @@ export function AgentSelector({
     const effort = thinkingEffortLabel(thinkingEffort)
     if (model === "Model" || effort === "Effort") return "Codex"
     return `${model} · ${effort}`
-  }, [ampModeOverride, isAmp, isClaude, modelId, thinkingEffort])
+  }, [isAmp, isClaude, modelId, resolvedAmpMode, thinkingEffort])
 
   const icon = isAmp ? (
     <Zap className="w-3.5 h-3.5" />
@@ -309,16 +309,7 @@ export function AgentSelector({
   const selectRunner = (next: AgentRunnerKind) => {
     setTempRunner(next)
     setTempModelId(null)
-
-    if (next === resolvedDefaultRunner) {
-      onChangeRunnerOverride(null)
-    } else {
-      onChangeRunnerOverride(next)
-    }
-
-    if (next !== "amp") {
-      onChangeAmpModeOverride(null)
-    }
+    onChangeRunner(next)
   }
 
   const claudeEnabled = true
@@ -538,18 +529,14 @@ export function AgentSelector({
                     { id: "smart" as const, label: "Smart" },
                     { id: "rush" as const, label: "Rush" },
                   ] as const).map((opt) => {
-                    const selected = opt.id === (ampModeOverride ?? resolvedDefaultAmpMode)
+                    const selected = opt.id === (resolvedAmpMode ?? resolvedDefaultAmpMode)
                     const isDefault = resolvedDefaultAmpMode != null && opt.id === resolvedDefaultAmpMode
                     return (
                       <div key={opt.id} className="relative group">
                         <button
                           onMouseDown={(e) => e.preventDefault()}
                           onClick={() => {
-                            if (resolvedDefaultAmpMode != null && opt.id === resolvedDefaultAmpMode) {
-                              onChangeAmpModeOverride(null)
-                            } else {
-                              onChangeAmpModeOverride(opt.id)
-                            }
+                            onChangeAmpMode(opt.id)
                             close()
                           }}
                           className={cn(

--- a/web/lib/luban-actions.ts
+++ b/web/lib/luban-actions.ts
@@ -746,6 +746,33 @@ export function createLubanActions(args: {
     })
   }
 
+  function setChatRunner(workspaceId: WorkspaceId, threadId: WorkspaceThreadId, runner: AgentRunnerKind) {
+    store.setConversation((prev) => {
+      if (!prev) return prev
+      if (prev.workspace_id !== workspaceId || prev.thread_id !== threadId) return prev
+      const nextAmpMode =
+        runner === "amp" ? (prev.amp_mode ?? store.state.app?.agent.amp_mode ?? null) : null
+      return {
+        ...prev,
+        agent_runner: runner,
+        amp_mode: nextAmpMode,
+      }
+    })
+    args.sendAction({ type: "chat_runner_changed", workspace_id: workspaceId, thread_id: threadId, runner })
+  }
+
+  function setChatAmpMode(workspaceId: WorkspaceId, threadId: WorkspaceThreadId, ampMode: string) {
+    const trimmed = ampMode.trim()
+    if (!trimmed) return
+    store.setConversation((prev) => {
+      if (!prev) return prev
+      if (prev.workspace_id !== workspaceId || prev.thread_id !== threadId) return prev
+      if (prev.agent_runner !== "amp") return prev
+      return { ...prev, amp_mode: trimmed }
+    })
+    args.sendAction({ type: "chat_amp_mode_changed", workspace_id: workspaceId, thread_id: threadId, amp_mode: trimmed })
+  }
+
   function setAppearanceTheme(theme: AppearanceTheme) {
     args.sendAction({ type: "appearance_theme_changed", theme })
   }
@@ -850,6 +877,8 @@ export function createLubanActions(args: {
     aiRenameWorkspaceBranch,
     setChatModel,
     setThinkingEffort,
+    setChatRunner,
+    setChatAmpMode,
     setAppearanceTheme,
     setAppearanceFonts,
     setGlobalZoom,

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -186,8 +186,10 @@ export type ConversationSnapshot = {
   rev: number
   workspace_id: WorkspaceId
   thread_id: WorkspaceThreadId
+  agent_runner: AgentRunnerKind
   agent_model_id: string
   thinking_effort: ThinkingEffort
+  amp_mode?: string | null
   run_status: OperationStatus
   run_started_at_unix_ms?: number | null
   run_finished_at_unix_ms?: number | null
@@ -203,8 +205,10 @@ export type ConversationSnapshot = {
 }
 
 export type AgentRunConfigSnapshot = {
+  runner: AgentRunnerKind
   model_id: string
   thinking_effort: ThinkingEffort
+  amp_mode?: string | null
 }
 
 export type QueuedPromptSnapshot = {
@@ -360,6 +364,8 @@ export type ClientAction =
   | { type: "open_workspace_pull_request_failed_action"; workspace_id: WorkspaceId }
   | { type: "archive_workspace"; workspace_id: WorkspaceId }
   | { type: "chat_model_changed"; workspace_id: WorkspaceId; thread_id: WorkspaceThreadId; model_id: string }
+  | { type: "chat_runner_changed"; workspace_id: WorkspaceId; thread_id: WorkspaceThreadId; runner: AgentRunnerKind }
+  | { type: "chat_amp_mode_changed"; workspace_id: WorkspaceId; thread_id: WorkspaceThreadId; amp_mode: string }
   | {
       type: "thinking_effort_changed"
       workspace_id: WorkspaceId

--- a/web/lib/luban-context.tsx
+++ b/web/lib/luban-context.tsx
@@ -129,6 +129,8 @@ type LubanContextValue = {
 
   setChatModel: (workspaceId: WorkspaceId, threadId: WorkspaceThreadId, modelId: string) => void
   setThinkingEffort: (workspaceId: WorkspaceId, threadId: WorkspaceThreadId, effort: ThinkingEffort) => void
+  setChatRunner: (workspaceId: WorkspaceId, threadId: WorkspaceThreadId, runner: AgentRunnerKind) => void
+  setChatAmpMode: (workspaceId: WorkspaceId, threadId: WorkspaceThreadId, ampMode: string) => void
   setAppearanceTheme: (theme: AppearanceTheme) => void
   setAppearanceFonts: (fonts: AppearanceFontsSnapshot) => void
   setGlobalZoom: (zoom: number) => void
@@ -372,6 +374,8 @@ export function LubanProvider({ children }: { children: React.ReactNode }) {
     aiRenameWorkspaceBranch: actions.aiRenameWorkspaceBranch,
     setChatModel: actions.setChatModel,
     setThinkingEffort: actions.setThinkingEffort,
+    setChatRunner: actions.setChatRunner,
+    setChatAmpMode: actions.setChatAmpMode,
     setAppearanceTheme: actions.setAppearanceTheme,
     setAppearanceFonts: actions.setAppearanceFonts,
     setGlobalZoom: actions.setGlobalZoom,

--- a/web/lib/mock/fixtures.ts
+++ b/web/lib/mock/fixtures.ts
@@ -1,5 +1,6 @@
 import type {
   AgentItem,
+  AgentRunnerKind,
   AmpConfigEntrySnapshot,
   AppSnapshot,
   AttachmentKind,
@@ -548,23 +549,27 @@ export function defaultMockFixtures(): MockFixtures {
     },
   }
 
-  const conversationBase = (args: {
-    workspaceId: WorkspaceId
-    threadId: WorkspaceThreadId
-    title: string
-    entries: ConversationEntry[]
-    agentModelId?: string
-    thinkingEffort?: "minimal" | "low" | "medium" | "high" | "xhigh"
-  }): ConversationSnapshot => ({
-    rev: 1,
-    workspace_id: args.workspaceId,
-    thread_id: args.threadId,
-    agent_model_id: args.agentModelId ?? "gpt-5",
-    thinking_effort: args.thinkingEffort ?? "medium",
-    run_status: op("idle"),
-    run_started_at_unix_ms: null,
-    run_finished_at_unix_ms: null,
-    entries: args.entries,
+	  const conversationBase = (args: {
+	    workspaceId: WorkspaceId
+	    threadId: WorkspaceThreadId
+	    title: string
+	    entries: ConversationEntry[]
+	    agentRunner?: AgentRunnerKind
+	    agentModelId?: string
+	    thinkingEffort?: "minimal" | "low" | "medium" | "high" | "xhigh"
+	    ampMode?: string | null
+	  }): ConversationSnapshot => ({
+	    rev: 1,
+	    workspace_id: args.workspaceId,
+	    thread_id: args.threadId,
+	    agent_runner: args.agentRunner ?? "codex",
+	    agent_model_id: args.agentModelId ?? "gpt-5",
+	    thinking_effort: args.thinkingEffort ?? "medium",
+	    amp_mode: args.ampMode ?? null,
+	    run_status: op("idle"),
+	    run_started_at_unix_ms: null,
+	    run_finished_at_unix_ms: null,
+	    entries: args.entries,
     entries_total: args.entries.length,
     entries_start: 0,
     entries_truncated: false,
@@ -653,24 +658,34 @@ export function defaultMockFixtures(): MockFixtures {
         { id: "loop_error_1", kind: "error", payload: { message: "Retrying after a temporary failure." } },
       ],
     },
-    [key(workspace1, thread2)]: {
-      ...conversationBase({
-        workspaceId: workspace1,
-        threadId: thread2,
-        title: "Running: with queue",
-        entries: [
-          { type: "user_message", text: "Queue a few prompts while running.", attachments: [] },
-          { type: "agent_item", id: "queue_running_msg_1", kind: "agent_message", payload: { text: "Processing current prompt; others are queued." } },
-        ],
-      }),
-      run_status: op("running"),
-      run_started_at_unix_ms: unixMs(-12_000),
-      run_finished_at_unix_ms: null,
-      pending_prompts: [
-        { id: 1, text: "First queued prompt.", attachments: [], run_config: { model_id: "gpt-5", thinking_effort: "medium" } },
-        { id: 2, text: "Second queued prompt.", attachments: [fileA], run_config: { model_id: "gpt-5", thinking_effort: "medium" } },
-      ],
-    },
+	    [key(workspace1, thread2)]: {
+	      ...conversationBase({
+	        workspaceId: workspace1,
+	        threadId: thread2,
+	        title: "Running: with queue",
+	        entries: [
+	          { type: "user_message", text: "Queue a few prompts while running.", attachments: [] },
+	          { type: "agent_item", id: "queue_running_msg_1", kind: "agent_message", payload: { text: "Processing current prompt; others are queued." } },
+	        ],
+	      }),
+	      run_status: op("running"),
+	      run_started_at_unix_ms: unixMs(-12_000),
+	      run_finished_at_unix_ms: null,
+	      pending_prompts: [
+	        {
+	          id: 1,
+	          text: "First queued prompt.",
+	          attachments: [],
+	          run_config: { runner: "codex", model_id: "gpt-5", thinking_effort: "medium" },
+	        },
+	        {
+	          id: 2,
+	          text: "Second queued prompt.",
+	          attachments: [fileA],
+	          run_config: { runner: "codex", model_id: "gpt-5", thinking_effort: "medium" },
+	        },
+	      ],
+	    },
     [key(workspace1, thread3)]: {
       ...conversationBase({
         workspaceId: workspace1,


### PR DESCRIPTION
## Problem
When a user manually selects an agent runner (e.g. codex vs amp) and amp mode for a conversation thread, the selection can be unexpectedly reset when switching workspaces/threads.

## Fix
- Treat runner + amp mode as thread-pinned run config.
- Persist the pinned selection:
  - In domain persisted app state (per-thread overrides), so reload restores immediately.
  - In the backend conversation store (SQLite), so server snapshots are consistent.
- Add explicit WS client actions to change the pinned runner / amp mode.
- Make agent turns default to the pinned runner / amp mode when no per-message override is provided.

## Contracts
- Updated `docs/contracts/features/c-ws-events.md` (new client actions)
- Updated `docs/contracts/features/c-http-conversation.md` (snapshot fields)
- Updated `docs/contracts/progress.md` (verification note)

## Storage
- Added migration: `crates/luban_backend/migrations/0015_conversation_agent_runner.sql`

## Verification
- `just fmt && just lint && just test`

## Manual test
1. Open a conversation thread.
2. Select runner `amp` and set an amp mode.
3. Switch to another workspace/thread and back.
4. Confirm the selection is unchanged.
