### PR TITLE
web: wrap long agent activity output

### DIFF
--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -2670,6 +2670,7 @@ impl Engine {
                         let emit_markdown_reasoning = prompt.contains("e2e-thinking-markdown");
                         let emit_file_change = prompt.contains("e2e-file-change");
                         let emit_streaming_message = prompt.contains("e2e-streaming-message");
+                        let emit_long_output = prompt.contains("e2e-long-output");
 
                         if emit_many_steps || emit_pagination_steps {
                             let count = if emit_pagination_steps {
@@ -2867,6 +2868,16 @@ impl Engine {
                                 }
                                 if !sent_2_done && elapsed >= Duration::from_millis(1750) {
                                     sent_2_done = true;
+                                    let aggregated_output = if emit_long_output {
+                                        [
+                                            "test io::commit::conflict_resolver::tests::test_conflicting_rebase::ours_1__update_full__::other_1__update_full__ ... ok",
+                                            "test io::commit::conflict_resolver::tests::test_conflicting_rebase::ours_1__update_full__::other_2__update_partial__ ... ok",
+                                            "test io::commit::conflict_resolver::tests::test_conflicting_rebase::ours_2__update_partial__::other_4__delete_partial__ ... ok",
+                                        ]
+                                        .join("\n")
+                                    } else {
+                                        "ok".to_owned()
+                                    };
                                     let _ = tx.blocking_send(EngineCommand::DispatchAction {
                                         action: Box::new(Action::AgentEventReceived {
                                             workspace_id,
@@ -2876,7 +2887,7 @@ impl Engine {
                                                 item: luban_domain::CodexThreadItem::CommandExecution {
                                                     id: "e2e_cmd_2".to_owned(),
                                                     command: "echo 2".to_owned(),
-                                                    aggregated_output: "ok".to_owned(),
+                                                    aggregated_output,
                                                     exit_code: Some(0),
                                                     status: luban_domain::CodexCommandExecutionStatus::Completed,
                                                 },

--- a/web/components/activity-stream.tsx
+++ b/web/components/activity-stream.tsx
@@ -94,7 +94,7 @@ function ActivityEventItem({
       </button>
       {isExpanded && hasExpandableDetail && (
         <div className="ml-5 pl-2 border-l border-border text-[11px] text-muted-foreground py-1 mb-1">
-          <pre className="whitespace-pre-wrap font-mono">
+          <pre className="whitespace-pre-wrap break-words font-mono">
             {detail.trim().length > 0 ? detail : "No output."}
           </pre>
         </div>

--- a/web/components/shared/agent-running-card.tsx
+++ b/web/components/shared/agent-running-card.tsx
@@ -296,7 +296,7 @@ export function AgentRunningCard({
 
                 {isEventExpanded && hasExpandableDetail && (
                   <div className="ml-6 mt-1 mb-2 p-2 rounded bg-muted/30 border border-border/50">
-                    <pre className="text-[11px] text-muted-foreground whitespace-pre-wrap font-mono">
+                    <pre className="text-[11px] text-muted-foreground whitespace-pre-wrap break-words font-mono">
                       {detail.trim().length > 0 ? detail : "No output."}
                     </pre>
                   </div>

--- a/web/tests/e2e/activity-detail-wrap.spec.ts
+++ b/web/tests/e2e/activity-detail-wrap.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test"
+
+import { ensureWorkspace } from "./helpers"
+
+test("activity detail wraps long output tokens", async ({ page }) => {
+  await ensureWorkspace(page)
+
+  const runId = Math.random().toString(16).slice(2)
+  const marker = `e2e-running-card-${runId}-e2e-long-output`
+
+  await page.getByTestId("chat-input").fill(marker)
+  await page.getByTestId("chat-send").click()
+
+  const runningHeader = page.getByTestId("agent-running-header")
+  await expect(runningHeader).toBeVisible({ timeout: 20_000 })
+  await expect(runningHeader).toHaveCount(0, { timeout: 30_000 })
+
+  const activityHeader = page.getByRole("button", { name: /Completed|Cancelled/i }).first()
+  await activityHeader.click()
+
+  const echo2 = page.getByRole("button", { name: /echo 2/ }).first()
+  await expect(echo2).toBeVisible({ timeout: 20_000 })
+  await echo2.click()
+
+  const detail = echo2.locator("..").locator("pre").first()
+  await expect(detail).toContainText("io::commit::conflict_resolver")
+
+  const scrollContainer = page.getByTestId("chat-scroll-container")
+  await expect
+    .poll(async () => {
+      const { scrollWidth, clientWidth } = await scrollContainer.evaluate((el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+      }))
+      return scrollWidth <= clientWidth + 1
+    })
+    .toBe(true)
+})


### PR DESCRIPTION
Fix long, space-less tokens in agent activity detail rendering (e.g. test names / paths) by enabling word breaking on the detail <pre> blocks.

Also adds an e2e case that feeds a long output payload via the fake agent and asserts the chat scroll container does not horizontally overflow.

Verification:
- just fmt && just lint && just test
- cd web && pnpm playwright test tests/e2e/activity-detail-wrap.spec.ts
