### PR TITLE
feat(tasks): implement scheme A task status

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -313,6 +313,8 @@ pub struct ConversationSnapshot {
     pub workspace_id: WorkspaceId,
     #[serde(rename = "task_id", alias = "thread_id")]
     pub thread_id: WorkspaceThreadId,
+    #[serde(default)]
+    pub task_status: TaskStatus,
     pub agent_runner: AgentRunnerKind,
     pub agent_model_id: String,
     pub thinking_effort: ThinkingEffort,
@@ -362,6 +364,35 @@ pub struct AgentRunConfigSnapshot {
 pub enum OperationStatus {
     Idle,
     Running,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Backlog,
+    #[default]
+    Todo,
+    InProgress,
+    InReview,
+    Done,
+    Canceled,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    #[default]
+    Idle,
+    Running,
+    Awaiting,
+    Paused,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnResult {
+    Completed,
+    Failed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -468,6 +499,12 @@ pub struct TaskSummarySnapshot {
     pub workspace_name: String,
     pub agent_run_status: OperationStatus,
     pub has_unread_completion: bool,
+    #[serde(default)]
+    pub task_status: TaskStatus,
+    #[serde(default)]
+    pub turn_status: TurnStatus,
+    #[serde(default)]
+    pub last_turn_result: Option<TurnResult>,
     #[serde(default)]
     pub is_starred: bool,
 }
@@ -652,6 +689,13 @@ pub enum ClientAction {
         #[serde(rename = "task_id", alias = "thread_id")]
         thread_id: WorkspaceThreadId,
         starred: bool,
+    },
+    TaskStatusSet {
+        #[serde(rename = "workdir_id", alias = "workspace_id")]
+        workspace_id: WorkspaceId,
+        #[serde(rename = "task_id", alias = "thread_id")]
+        thread_id: WorkspaceThreadId,
+        task_status: TaskStatus,
     },
     FeedbackSubmit {
         title: String,
@@ -1053,4 +1097,10 @@ pub struct ThreadMeta {
     pub remote_thread_id: Option<String>,
     pub title: String,
     pub updated_at_unix_seconds: u64,
+    #[serde(default)]
+    pub task_status: TaskStatus,
+    #[serde(default)]
+    pub turn_status: TurnStatus,
+    #[serde(default)]
+    pub last_turn_result: Option<TurnResult>,
 }

--- a/crates/luban_backend/migrations/0016_conversation_task_status.sql
+++ b/crates/luban_backend/migrations/0016_conversation_task_status.sql
@@ -1,0 +1,14 @@
+ALTER TABLE conversations
+    ADD COLUMN task_status TEXT NOT NULL DEFAULT 'todo';
+
+UPDATE conversations
+SET task_status = 'backlog'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM conversation_entries
+    WHERE conversation_entries.project_slug = conversations.project_slug
+      AND conversation_entries.workspace_name = conversations.workspace_name
+      AND conversation_entries.thread_local_id = conversations.thread_local_id
+      AND conversation_entries.kind = 'user_message'
+);
+

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -792,6 +792,18 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(anyhow_error_to_string)
     }
 
+    fn save_conversation_task_status(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+        thread_id: u64,
+        task_status: luban_domain::TaskStatus,
+    ) -> Result<(), String> {
+        self.sqlite
+            .save_conversation_task_status(project_slug, workspace_name, thread_id, task_status)
+            .map_err(anyhow_error_to_string)
+    }
+
     fn store_context_image(
         &self,
         project_slug: String,

--- a/crates/luban_backend/src/services/conversations.rs
+++ b/crates/luban_backend/src/services/conversations.rs
@@ -117,6 +117,7 @@ impl GitWorkspaceService {
         if !events_path.exists() {
             return Ok(Some(ConversationSnapshot {
                 thread_id: meta.thread_id,
+                task_status: luban_domain::TaskStatus::Todo,
                 runner: None,
                 agent_model_id: None,
                 thinking_effort: None,
@@ -162,6 +163,7 @@ impl GitWorkspaceService {
         let entries_total = entries.len() as u64;
         Ok(Some(ConversationSnapshot {
             thread_id: meta.thread_id,
+            task_status: luban_domain::TaskStatus::Todo,
             runner: None,
             agent_model_id: None,
             thinking_effort: None,

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -1,7 +1,8 @@
 use crate::{
     AgentRunnerKind, AgentThreadEvent, AppearanceTheme, AttachmentRef, ChatScrollAnchor,
     ContextTokenKind, ConversationSnapshot, ConversationThreadMeta, OpenTarget, PersistedAppState,
-    ProjectId, SystemTaskKind, TaskIntentKind, ThinkingEffort, WorkspaceId, WorkspaceThreadId,
+    ProjectId, SystemTaskKind, TaskIntentKind, TaskStatus, ThinkingEffort, WorkspaceId,
+    WorkspaceThreadId,
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -335,6 +336,11 @@ pub enum Action {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
         starred: bool,
+    },
+    TaskStatusSet {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        task_status: TaskStatus,
     },
 
     SidebarProjectOrderChanged {

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -1,6 +1,7 @@
 use crate::{
     AgentRunnerKind, AgentThreadEvent, AttachmentRef, ContextItem, ConversationSnapshot,
-    ConversationThreadMeta, PersistedAppState, QueuedPrompt, SystemTaskKind, ThinkingEffort,
+    ConversationThreadMeta, PersistedAppState, QueuedPrompt, SystemTaskKind, TaskStatus,
+    ThinkingEffort,
 };
 use std::collections::HashMap;
 use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool};
@@ -308,6 +309,16 @@ pub trait ProjectWorkspaceService: Send + Sync {
         _model_id: String,
         _thinking_effort: ThinkingEffort,
         _amp_mode: Option<String>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn save_conversation_task_status(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+        _thread_id: u64,
+        _task_status: TaskStatus,
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/luban_domain/src/effects.rs
+++ b/crates/luban_domain/src/effects.rs
@@ -63,6 +63,11 @@ pub enum Effect {
         thinking_effort: crate::ThinkingEffort,
         amp_mode: Option<String>,
     },
+    StoreConversationTaskStatus {
+        workspace_id: WorkspaceId,
+        thread_id: WorkspaceThreadId,
+        task_status: crate::TaskStatus,
+    },
     LoadConversation {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,

--- a/crates/luban_domain/src/state/mod.rs
+++ b/crates/luban_domain/src/state/mod.rs
@@ -6,6 +6,7 @@ mod ids;
 mod layout;
 mod persisted;
 mod tabs;
+mod task;
 mod workspace;
 
 pub use agent::{AgentRunConfig, QueuedPrompt};
@@ -22,6 +23,7 @@ pub use persisted::{
     PersistedWorkspaceThreadRunConfigOverride,
 };
 pub use tabs::WorkspaceTabs;
+pub use task::{TaskStatus, TurnResult, TurnStatus, parse_task_status};
 pub use workspace::{AppState, Project, Workspace};
 
 pub(crate) const MAX_CONVERSATION_ENTRIES_IN_MEMORY: usize = 5000;

--- a/crates/luban_domain/src/state/task.rs
+++ b/crates/luban_domain/src/state/task.rs
@@ -1,0 +1,71 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Backlog,
+    Todo,
+    InProgress,
+    InReview,
+    Done,
+    Canceled,
+}
+
+impl TaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskStatus::Backlog => "backlog",
+            TaskStatus::Todo => "todo",
+            TaskStatus::InProgress => "in_progress",
+            TaskStatus::InReview => "in_review",
+            TaskStatus::Done => "done",
+            TaskStatus::Canceled => "canceled",
+        }
+    }
+}
+
+pub fn parse_task_status(value: &str) -> Option<TaskStatus> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "backlog" => Some(TaskStatus::Backlog),
+        "todo" => Some(TaskStatus::Todo),
+        "in_progress" => Some(TaskStatus::InProgress),
+        "in_review" => Some(TaskStatus::InReview),
+        "done" => Some(TaskStatus::Done),
+        "canceled" => Some(TaskStatus::Canceled),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    Idle,
+    Running,
+    Awaiting,
+    Paused,
+}
+
+impl TurnStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnStatus::Idle => "idle",
+            TurnStatus::Running => "running",
+            TurnStatus::Awaiting => "awaiting",
+            TurnStatus::Paused => "paused",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnResult {
+    Completed,
+    Failed,
+}
+
+impl TurnResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnResult::Completed => "completed",
+            TurnResult::Failed => "failed",
+        }
+    }
+}

--- a/crates/luban_server/src/server.rs
+++ b/crates/luban_server/src/server.rs
@@ -311,6 +311,9 @@ async fn get_tasks(
                     workspace_name: w.workspace_name.clone(),
                     agent_run_status,
                     has_unread_completion,
+                    task_status: t.task_status,
+                    turn_status: t.turn_status,
+                    last_turn_result: t.last_turn_result,
                     is_starred: starred.contains(&(w.id.0, t.thread_id.0)),
                 });
             }

--- a/docs/contracts/features/c-http-conversation.md
+++ b/docs/contracts/features/c-http-conversation.md
@@ -27,6 +27,10 @@ Paginated read for a single conversation thread.
 - `200 OK`
 - JSON body: `ConversationSnapshot`
 
+### Task status
+
+- `snapshot.task_status`: explicit lifecycle stage (`TaskStatus`, see `docs/task-and-turn-status.md`)
+
 ### Run config fields
 
 The response includes the effective per-thread run configuration used by the next agent turn:

--- a/docs/contracts/features/c-http-tasks.md
+++ b/docs/contracts/features/c-http-tasks.md
@@ -28,6 +28,8 @@ client to iterate all workdirs and fan out requests.
 
 - `TasksSnapshot.tasks[]` items are `TaskSummarySnapshot`.
 - `TaskSummarySnapshot.is_starred` indicates whether the user has starred the task.
+- `TaskSummarySnapshot.task_status` is an explicit lifecycle stage (`TaskStatus`).
+- `TaskSummarySnapshot.turn_status` and `TaskSummarySnapshot.last_turn_result` provide derived turn-level status (see `docs/task-and-turn-status.md`).
 
 ## Invariants
 

--- a/docs/contracts/features/c-http-workdir-tasks.md
+++ b/docs/contracts/features/c-http-workdir-tasks.md
@@ -33,6 +33,9 @@ Task titles are user-facing and should be short:
 
 - The response must be deserializable into `ThreadsSnapshot`.
 - Task ordering must match the UI expectations documented in `docs/workspace-thread-tabs.md`.
+- `ThreadsSnapshot.tasks[]` items are `ThreadMeta`.
+- `ThreadMeta.task_status` is the explicit lifecycle stage (`TaskStatus`).
+- `ThreadMeta.turn_status` and `ThreadMeta.last_turn_result` are derived turn-level status (see `docs/task-and-turn-status.md`).
 
 ## Web usage
 

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -91,6 +91,7 @@ update this section.
 - `AddProjectAndOpen`
 - `TaskExecute`
 - `TaskStarSet`
+- `TaskStatusSet`
 - `FeedbackSubmit`
 - `DeleteProject`
 - `ToggleProjectExpanded`

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -54,8 +54,11 @@ Legend:
 - `C-WS-EVENTS`: `ClientAction::SidebarWorktreeOrderChanged` was removed (task-first UI no longer persists worktree ordering).
 - `C-WS-EVENTS`: `ClientAction::TaskPreview` and `ServerEvent::TaskPreviewReady` were removed; task execution is prompt-based.
 - `C-WS-EVENTS`: `ClientAction::TaskStarSet` is implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_http.rs` (roundtrip: WS toggle then `GET /api/tasks`).
+- `C-WS-EVENTS`: `ClientAction::TaskStatusSet` updates per-task `TaskStatus` and is implemented in mock + provider.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
+- `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
 - `C-HTTP-TASKS`: `TaskSummarySnapshot` includes `is_starred` for rendering Favorites and in-view star toggles.
+- `C-HTTP-TASKS` / `C-HTTP-WORKDIR-TASKS`: thread metadata includes `task_status`, `turn_status`, and `last_turn_result` (see `docs/task-and-turn-status.md`).
 
 ## Feature contracts
 

--- a/docs/task-and-turn-status.md
+++ b/docs/task-and-turn-status.md
@@ -1,0 +1,67 @@
+# Task and Turn Status
+
+This document defines how Luban models task lifecycle state (`TaskStatus`) and agent execution state (`TurnStatus`).
+
+## Core model
+
+- A **Task** is a conversation thread (`workdir_id` + `task_id`).
+- A **Turn** is a single agent execution triggered by a user message within a task.
+- A task can have many turns.
+- A turn always belongs to exactly one task.
+
+## Task status
+
+`TaskStatus` is an explicit, user-facing lifecycle stage. It must not encode runtime execution details.
+
+Enum values:
+
+- `backlog`: captured but not ready to start
+- `todo`: ready to start
+- `in_progress`: actively being worked on
+- `in_review`: awaiting verification/acceptance
+- `done`: accepted and closed
+- `canceled`: stopped and closed
+
+Notes:
+
+- Archive is intentionally not modeled as a task status.
+- Task status changes are triggered by explicit user actions (including sending a message, which is treated as an explicit start-work action).
+
+## Turn status and last turn result
+
+`TurnStatus` is an execution-time state derived from the conversation runtime/queue state.
+
+Enum values:
+
+- `idle`: no active turn and no queued work
+- `running`: an active turn is executing
+- `awaiting`: queued prompts exist and the queue is not paused
+- `paused`: queued prompts exist and the queue is paused
+
+`TurnResult` is the terminal outcome of the most recent finished turn:
+
+- `completed`
+- `failed`
+
+### Derivation (scheme A)
+
+We do not persist a separate "turn table". Instead, we derive:
+
+- `turn_status` from conversation run timing and queue state (`run_started_at_unix_ms`, `run_finished_at_unix_ms`, `queue_paused`, queued prompt count).
+- `last_turn_result` from the most recent terminal turn marker in `conversation_entries`:
+  - `turn_duration` => `completed`
+  - `turn_error` or `turn_canceled` => `failed`
+
+## Storage
+
+- `TaskStatus` is persisted in the `conversations.task_status` column.
+- `TurnStatus` and `TurnResult` are derived for thread list responses.
+
+## API surface
+
+The following snapshots expose task/turn state:
+
+- `ConversationSnapshot.task_status`
+- `ThreadMeta.task_status`, `ThreadMeta.turn_status`, `ThreadMeta.last_turn_result`
+- `TaskSummarySnapshot.task_status`, `TaskSummarySnapshot.turn_status`, `TaskSummarySnapshot.last_turn_result`
+

--- a/web/components/luban-ide.tsx
+++ b/web/components/luban-ide.tsx
@@ -47,22 +47,22 @@ export function LubanIDE() {
   const handleOpenFullViewFromInbox = (notification: InboxNotification) => {
     void (async () => {
       await openWorkspace(notification.workdirId)
-            await activateTask(notification.taskId)
-        setSelectedTask({
-          id: notification.id,
-          workspaceId: notification.workdirId,
-          title: notification.taskTitle,
-          status:
-            notification.type === "completed"
-              ? "done"
-              : notification.type === "failed"
-                ? "cancelled"
-                : "in-progress",
-          workdir: notification.workdir,
-          projectName: notification.projectName,
-          projectColor: notification.projectColor,
-          createdAt: notification.timestamp,
-        })
+      await activateTask(notification.taskId)
+      setSelectedTask({
+        id: notification.id,
+        workspaceId: notification.workdirId,
+        title: notification.taskTitle,
+        status:
+          notification.type === "completed"
+            ? "done"
+            : notification.type === "failed"
+              ? "canceled"
+              : "in_progress",
+        workdir: notification.workdir,
+        projectName: notification.projectName,
+        projectColor: notification.projectColor,
+        createdAt: notification.timestamp,
+      })
       setActiveView("tasks")
       setShowDetail(true)
     })()
@@ -81,12 +81,6 @@ export function LubanIDE() {
     return out
   }, [app])
 
-  const taskStatusFromSummary = (args: { agentRunStatus: string; hasUnreadCompletion: boolean }): Task["status"] => {
-    if (args.agentRunStatus === "running") return "in-progress"
-    if (args.hasUnreadCompletion) return "done"
-    return "todo"
-  }
-
   const taskFromSummary = (summary: TaskSummarySnapshot): Task => {
     const project = projectInfoById.get(summary.project_id) ?? { name: summary.project_id, color: "bg-violet-500" }
     return {
@@ -94,10 +88,7 @@ export function LubanIDE() {
       workspaceId: summary.workdir_id,
       taskId: summary.task_id,
       title: summary.title,
-      status: taskStatusFromSummary({
-        agentRunStatus: summary.agent_run_status,
-        hasUnreadCompletion: summary.has_unread_completion,
-      }),
+      status: summary.task_status,
       workdir: summary.workdir_name || summary.branch_name,
       projectName: project.name,
       projectColor: project.color,

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -156,6 +156,9 @@ export type TaskSummarySnapshot = {
   workdir_name: string
   agent_run_status: OperationStatus
   has_unread_completion: boolean
+  task_status: TaskStatus
+  turn_status: TurnStatus
+  last_turn_result: TurnResult | null
   is_starred: boolean
 }
 
@@ -175,6 +178,9 @@ export type ThreadMeta = {
   remote_thread_id: string | null
   title: string
   updated_at_unix_seconds: number
+  task_status: TaskStatus
+  turn_status: TurnStatus
+  last_turn_result: TurnResult | null
 }
 
 export type AttachmentKind = "image" | "text" | "file"
@@ -203,6 +209,7 @@ export type ConversationSnapshot = {
   rev: number
   workdir_id: WorkspaceId
   task_id: WorkspaceThreadId
+  task_status: TaskStatus
   agent_runner: AgentRunnerKind
   agent_model_id: string
   thinking_effort: ThinkingEffort
@@ -236,6 +243,18 @@ export type QueuedPromptSnapshot = {
 }
 
 export type OperationStatus = "idle" | "running"
+
+export type TaskStatus =
+  | "backlog"
+  | "todo"
+  | "in_progress"
+  | "in_review"
+  | "done"
+  | "canceled"
+
+export type TurnStatus = "idle" | "running" | "awaiting" | "paused"
+
+export type TurnResult = "completed" | "failed"
 
 export type ThinkingEffort = "minimal" | "low" | "medium" | "high" | "xhigh"
 
@@ -331,6 +350,7 @@ export type ClientAction =
   | { type: "add_project_and_open"; path: string }
   | { type: "task_execute"; prompt: string; mode: TaskExecuteMode; workdir_id: WorkspaceId }
   | { type: "task_star_set"; workdir_id: WorkspaceId; task_id: WorkspaceThreadId; starred: boolean }
+  | { type: "task_status_set"; workdir_id: WorkspaceId; task_id: WorkspaceThreadId; task_status: TaskStatus }
   | {
       type: "feedback_submit"
       title: string

--- a/web/lib/mock/mock-runtime.ts
+++ b/web/lib/mock/mock-runtime.ts
@@ -204,6 +204,9 @@ export async function mockFetchTasks(args: { projectId?: string } = {}): Promise
           workdir_name: workdir.workdir_name,
           agent_run_status: workdir.agent_run_status,
           has_unread_completion: workdir.has_unread_completion,
+          task_status: t.task_status,
+          turn_status: t.turn_status,
+          last_turn_result: t.last_turn_result,
           is_starred: state.starredTasks.has(workdirTaskKey(workdir.id, t.task_id)),
         })
       }
@@ -300,7 +303,15 @@ function createTaskInWorkdir(state: RuntimeState, workdirId: WorkspaceId, title:
   const taskId: WorkspaceThreadId = state.nextTaskId
   state.nextTaskId += 1
   const now = Math.floor(Date.now() / 1000)
-  snap.tasks = [{ task_id: taskId, remote_thread_id: null, title, updated_at_unix_seconds: now }, ...snap.tasks]
+  snap.tasks = [{
+    task_id: taskId,
+    remote_thread_id: null,
+    title,
+    updated_at_unix_seconds: now,
+    task_status: "backlog",
+    turn_status: "idle",
+    last_turn_result: null,
+  }, ...snap.tasks]
   snap.tabs.open_tabs = [taskId, ...snap.tabs.open_tabs.filter((id) => id !== taskId)]
   snap.tabs.active_tab = taskId
   snap.rev = state.rev
@@ -309,6 +320,7 @@ function createTaskInWorkdir(state: RuntimeState, workdirId: WorkspaceId, title:
     rev: state.rev,
     workdir_id: workdirId,
     task_id: taskId,
+    task_status: "backlog",
     agent_runner: "codex",
     agent_model_id: state.app.agent.default_model_id ?? "gpt-5",
     thinking_effort: state.app.agent.default_thinking_effort ?? "medium",


### PR DESCRIPTION
Summary
- Introduce persisted TaskStatus for conversations: backlog/todo/in_progress/in_review/done/canceled.
- Model "Turn" as a per-task agent interaction and derive TurnStatus + last TurnResult from stored conversation entries (no separate turn table).
- Wire through domain/backend/server, web types/UI, and contracts.

Behavior changes
- Task list is grouped by task_status.
- Sending an agent message upgrades task_status from backlog/todo to in_progress.
- /api/tasks and /api/workdir/*/tasks include task_status, turn_status, last_turn_result.
- WebSocket supports ClientAction.TaskStatusSet.

Docs
- docs/task-and-turn-status.md

Verification
- just fmt
- just lint
- just test
- just test-ui

Risk / Rollback
- Risk: DB migration adds conversations.task_status; existing conversations default to todo.
- Rollback: revert this PR; optionally restore the DB from backup.

Contracts
- Updated: docs/contracts/features/c-http-tasks.md
- Updated: docs/contracts/features/c-http-workdir-tasks.md
- Updated: docs/contracts/features/c-http-conversation.md
- Updated: docs/contracts/features/c-ws-events.md
- Updated: docs/contracts/progress.md
