### PR TITLE
web: show running icon for in-progress events

### DIFF
--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import { useState, useCallback } from "react"
 import Image from "next/image"
 
-import { Brain, Check, Clock, Copy, FileCode, FileText, Wrench } from "lucide-react"
+import { Brain, Check, Clock, Copy, FileCode, FileText, Loader2, Wrench } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import type { Message } from "@/lib/conversation-ui"
@@ -85,6 +85,12 @@ export function ConversationMessage({
         className="text-[11px] text-muted-foreground/80"
         data-testid="conversation-event"
       >
+        {message.status === "running" && (
+          <Loader2
+            data-testid="event-running-icon"
+            className="inline-block w-3 h-3 animate-spin mr-1 align-[-2px]"
+          />
+        )}
         {message.eventSource === "agent" ? "Agent: " : message.eventSource === "system" ? "System: " : ""}
         {message.content}
       </div>

--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -362,19 +362,27 @@ function SystemEventItem({ message, actor }: SystemEventItemProps) {
           backgroundColor: COLORS.background
         }}
       >
-        <div
-          className="flex items-center justify-center text-white"
-          style={{ 
-            width: '14px', 
-            height: '14px', 
-            borderRadius: '50%',
-            backgroundColor: eventActor.color,
-            fontSize: '7px',
-            fontWeight: 500
-          }}
-        >
-          {eventActor.initial}
-        </div>
+        {message.status === "running" ? (
+          <Loader2
+            data-testid="event-running-icon"
+            className="w-3.5 h-3.5 animate-spin flex-shrink-0"
+            style={{ color: eventActor.color }}
+          />
+        ) : (
+          <div
+            className="flex items-center justify-center text-white"
+            style={{ 
+              width: '14px', 
+              height: '14px', 
+              borderRadius: '50%',
+              backgroundColor: eventActor.color,
+              fontSize: '7px',
+              fontWeight: 500
+            }}
+          >
+            {eventActor.initial}
+          </div>
+        )}
       </div>
       
       {/* Event text - Linear style: 12px, muted colors, inline */}

--- a/web/lib/mock/fixtures.ts
+++ b/web/lib/mock/fixtures.ts
@@ -413,17 +413,32 @@ export function defaultMockFixtures(): MockFixtures {
         {
           type: "agent_event",
           entry_id: newEntryId("ae"),
-          event: { type: "item", id: "tail_progress", kind: "reasoning", payload: { text: "Progress update 1" } },
+          event: {
+            type: "item",
+            id: "tail_progress",
+            kind: "command_execution",
+            payload: { command: "Progress update 1", status: "completed", aggregated_output: "" },
+          },
         },
         {
           type: "agent_event",
           entry_id: newEntryId("ae"),
-          event: { type: "item", id: "tail_progress", kind: "reasoning", payload: { text: "Progress update 2" } },
+          event: {
+            type: "item",
+            id: "tail_progress",
+            kind: "command_execution",
+            payload: { command: "Progress update 2", status: "completed", aggregated_output: "" },
+          },
         },
         {
           type: "agent_event",
           entry_id: newEntryId("ae"),
-          event: { type: "item", id: "tail_progress", kind: "reasoning", payload: { text: "Progress update 3" } },
+          event: {
+            type: "item",
+            id: "tail_progress",
+            kind: "command_execution",
+            payload: { command: "Progress update 3", status: "in_progress", aggregated_output: "" },
+          },
         },
       ],
     }),

--- a/web/tests/ui/scenarios/latest-events-visible.mjs
+++ b/web/tests/ui/scenarios/latest-events-visible.mjs
@@ -23,5 +23,7 @@ export async function runLatestEventsVisible({ page }) {
 
   await eventLocator.filter({ hasText: 'Progress update 1' }).first().waitFor({ state: 'visible' });
   await eventLocator.filter({ hasText: 'Progress update 2' }).first().waitFor({ state: 'visible' });
-  await eventLocator.filter({ hasText: 'Progress update 3' }).first().waitFor({ state: 'visible' });
+  const runningRow = eventLocator.filter({ hasText: 'Progress update 3' }).first();
+  await runningRow.waitFor({ state: 'visible' });
+  await runningRow.getByTestId('event-running-icon').waitFor({ state: 'visible' });
 }


### PR DESCRIPTION
## Summary
- Display a running (spinner) icon for in-progress events.

## Behavior
- When an event is derived from an agent item whose payload has `status: "in_progress"`, the UI renders a spinner.
- Applies to the Linear activity view (`data-testid="activity-event"`) and the fallback conversation view (`data-testid="conversation-event"`).

## Verification
- `just fmt && just lint && just test`
- `just test-ui`

## Contracts
- No changes.

## Risk / Rollback
- Low risk (UI-only). Roll back by reverting this PR.
