### PR TITLE
web: show spinner instead of timestamp for running events

### DIFF
--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -386,14 +386,15 @@ function SystemEventItem({ message, actor }: SystemEventItemProps) {
         <span style={{ marginLeft: '4px' }}>{message.content}</span>
         <span style={{ margin: '0 4px' }}>·</span>
         <span className="inline-flex items-center gap-1">
-          {message.status === "running" && (
+          {message.status === "running" ? (
             <Loader2
               data-testid="event-running-icon"
               className="w-3 h-3 animate-spin flex-shrink-0"
               style={{ color: COLORS.textMuted }}
             />
+          ) : (
+            <span data-testid="event-timestamp">{formatRelativeTime(message.timestamp)}</span>
           )}
-          <span>{formatRelativeTime(message.timestamp)}</span>
         </span>
       </span>
     </div>

--- a/web/tests/ui/scenarios/latest-events-visible.mjs
+++ b/web/tests/ui/scenarios/latest-events-visible.mjs
@@ -26,4 +26,5 @@ export async function runLatestEventsVisible({ page }) {
   const runningRow = eventLocator.filter({ hasText: 'Progress update 3' }).first();
   await runningRow.waitFor({ state: 'visible' });
   await runningRow.getByTestId('event-running-icon').waitFor({ state: 'visible' });
+  await waitForLocatorCount(runningRow.getByTestId('event-timestamp'), 0, 5_000);
 }


### PR DESCRIPTION
## Summary
- For running events, replace the timestamp text with a spinner (since completion time is unknown).

## Behavior
- Avatar stays stable.
- When `message.status === "running"`, the timestamp slot renders only the spinner.

## Verification
- `just fmt && just lint && just test && just test-ui`

## Contracts
- No changes.
