### PR TITLE
Fix activity event avatar/text alignment

### DIFF
--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -355,14 +355,14 @@ function SystemEventItem({ message, actor }: SystemEventItemProps) {
         className="flex items-center justify-center flex-shrink-0 relative z-10"
         style={{ 
           width: '14px', 
-          height: '18px',
+          height: '16.8px',
           marginLeft: '13px',  /* Align icon center (13+7=20px) with card avatar center */
           marginRight: '4px',
-          paddingTop: '2px',
           backgroundColor: COLORS.background
         }}
       >
         <div
+          data-testid="event-avatar"
           className="flex items-center justify-center text-white"
           style={{ 
             width: '14px', 
@@ -379,6 +379,7 @@ function SystemEventItem({ message, actor }: SystemEventItemProps) {
       
       {/* Event text - Linear style: 12px, muted colors, inline */}
       <span 
+        data-testid="event-text"
         className="flex items-center flex-wrap"
         style={{ fontSize: '12px', lineHeight: '16.8px', color: COLORS.textMuted }}
       >

--- a/web/tests/ui/scenarios/latest-events-visible.mjs
+++ b/web/tests/ui/scenarios/latest-events-visible.mjs
@@ -21,7 +21,28 @@ export async function runLatestEventsVisible({ page }) {
   const progressEvents = eventLocator.filter({ hasText: 'Progress update' });
   await waitForLocatorCount(progressEvents, 3, 20_000);
 
-  await eventLocator.filter({ hasText: 'Progress update 1' }).first().waitFor({ state: 'visible' });
+  const progressUpdate1 = eventLocator.filter({ hasText: 'Progress update 1' }).first();
+  await progressUpdate1.waitFor({ state: 'visible' });
+  await progressUpdate1.scrollIntoViewIfNeeded();
+
+  const avatar = progressUpdate1.getByTestId('event-avatar');
+  const text = progressUpdate1.getByTestId('event-text');
+  await avatar.waitFor({ state: 'visible' });
+  await text.waitFor({ state: 'visible' });
+
+  const avatarBox = await avatar.boundingBox();
+  const textBox = await text.boundingBox();
+  if (!avatarBox) throw new Error('missing avatar bounding box');
+  if (!textBox) throw new Error('missing text bounding box');
+
+  const avatarCenterY = avatarBox.y + avatarBox.height / 2;
+  const textCenterY = textBox.y + textBox.height / 2;
+  const delta = Math.abs(avatarCenterY - textCenterY);
+  const tolerance = 1.5;
+  if (delta > tolerance) {
+    throw new Error(`expected avatar/text vertical alignment within ${tolerance}px, got delta=${delta}px`);
+  }
+
   await eventLocator.filter({ hasText: 'Progress update 2' }).first().waitFor({ state: 'visible' });
   const runningRow = eventLocator.filter({ hasText: 'Progress update 3' }).first();
   await runningRow.waitFor({ state: 'visible' });


### PR DESCRIPTION

## What
- Align the activity event avatar circle with the first text line.
- Add a UI smoke assertion to prevent regression.

## Why
The avatar circle and the event text were visually misaligned (vertical center mismatch).

## How
- Match the icon column height to the event line-height (`16.8px`) and remove the extra top offset.
- Add `data-testid` hooks for stable UI test selectors.

## Verification
- `just fmt && just lint && just test && just test-ui`

