### PR TITLE
Unify user message font size with agent

### DIFF
--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -513,9 +513,12 @@ function UserActivityEvent({ message }: UserActivityEventProps) {
       </div>
       
       {/* Message content */}
-      <div style={{ fontSize: '15px', fontWeight: 400, lineHeight: '24px', color: COLORS.textPrimary }}>
+      <div
+        data-testid="activity-user-message-content"
+        style={{ fontSize: '13px', fontWeight: 400, lineHeight: '1.625', color: COLORS.textPrimary }}
+      >
         {message.content.split("\n").map((line, idx) => (
-          <p key={idx} className="min-h-[24px]">
+          <p key={idx} className="min-h-[1.625em]">
             {line || "\u00A0"}
           </p>
         ))}
@@ -594,6 +597,7 @@ function AgentActivityEvent({ message }: AgentActivityEventProps) {
 
           {/* Agent message content */}
           <div 
+            data-testid="activity-agent-message-content"
             className="luban-font-chat"
             style={{ fontSize: '15px', fontWeight: 400, lineHeight: '24px', color: COLORS.textPrimary }}
           >


### PR DESCRIPTION

## What
- Make the User Message card content font size match the Agent Message card.
- Add a UI smoke assertion to prevent regressions.

## Why
In the activity view, user message content rendered larger than agent message content.

## How
- Update `UserActivityEvent` content typography to match the agent markdown baseline.
- Add stable `data-testid` hooks and compare computed `font-size` in UI smoke.

## Verification
- `just fmt && just lint && just test && just test-ui`

