### PR TITLE
Push task summary updates via WS events

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -1062,6 +1062,12 @@ pub enum ServerEvent {
         rev: u64,
         snapshot: Box<AppSnapshot>,
     },
+    TaskSummariesChanged {
+        project_id: ProjectId,
+        #[serde(rename = "workdir_id", alias = "workspace_id")]
+        workspace_id: WorkspaceId,
+        tasks: Vec<TaskSummarySnapshot>,
+    },
     #[serde(rename = "workdir_tasks_changed", alias = "workspace_threads_changed")]
     WorkspaceThreadsChanged {
         #[serde(rename = "workdir_id", alias = "workspace_id")]

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -178,6 +178,7 @@ update this section.
 All `ServerEvent` variants are part of this contract surface:
 
 - `AppChanged`
+- `TaskSummariesChanged`
 - `WorkdirTasksChanged`
 - `ConversationChanged`
 - `Toast`
@@ -198,6 +199,17 @@ All `ServerEvent` variants are part of this contract surface:
 - `ClaudeCheckReady`
 - `ClaudeConfigTreeReady`
 - `ClaudeConfigListDirReady`
+
+## `ServerEvent::TaskSummariesChanged`
+
+Purpose: push incremental updates for task-first UI surfaces (inbox, global task lists) without
+requiring polling `GET /api/tasks`.
+
+Payload:
+
+- `project_id`: owning project id
+- `workdir_id`: owning workdir id
+- `tasks`: current `TaskSummarySnapshot[]` for that workdir
 - `ClaudeConfigFileReady`
 - `ClaudeConfigFileSaved`
 

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -57,6 +57,7 @@ Legend:
 - `C-WS-EVENTS`: `ClientAction::TaskPreview` and `ServerEvent::TaskPreviewReady` were removed; task execution is prompt-based.
 - `C-WS-EVENTS`: `ClientAction::TaskStarSet` is implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_http.rs` (roundtrip: WS toggle then `GET /api/tasks`).
 - `C-WS-EVENTS`: `ClientAction::TaskStatusSet` updates per-task `TaskStatus` and is implemented in mock + provider.
+- `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -487,6 +487,7 @@ export type ClientAction =
 
 export type ServerEvent =
   | { type: "app_changed"; rev: number; snapshot: AppSnapshot }
+  | { type: "task_summaries_changed"; project_id: ProjectId; workdir_id: WorkspaceId; tasks: TaskSummarySnapshot[] }
   | { type: "workdir_tasks_changed"; workdir_id: WorkspaceId; tabs: WorkspaceTabsSnapshot; tasks: ThreadMeta[] }
   | { type: "conversation_changed"; snapshot: ConversationSnapshot }
   | { type: "toast"; message: string }

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -25,6 +25,7 @@ import { runSidebarProjectAvatars } from './scenarios/sidebar-project-avatars.mj
 import { runStarFavorites } from './scenarios/star-favorites.mjs';
 import { runTaskStatusChange } from './scenarios/task-status-change.mjs';
 import { runTaskListNavigation } from './scenarios/task-list-navigation.mjs';
+import { runTaskSummariesEventsRefresh } from './scenarios/task-summaries-events-refresh.mjs';
 import { runQueuedPrompts } from './scenarios/queued-prompts.mjs';
 
 async function canRun(command, args) {
@@ -170,6 +171,7 @@ async function main() {
     await runLatestEventsVisible({ page, baseUrl });
     await runAgentRunnerIcons({ page, baseUrl });
     await runNewTaskDoubleSubmitNoDuplicate({ page, baseUrl });
+    await runTaskSummariesEventsRefresh({ page, baseUrl });
   } catch (err) {
     if (logFile) {
       process.stderr.write(`ui smoke failed; log: ${logFile}\n`);

--- a/web/tests/ui/scenarios/task-summaries-events-refresh.mjs
+++ b/web/tests/ui/scenarios/task-summaries-events-refresh.mjs
@@ -1,0 +1,25 @@
+import { waitForLocatorCount } from '../lib/utils.mjs';
+
+export async function runTaskSummariesEventsRefresh({ page, baseUrl }) {
+  if (baseUrl) {
+    await page.goto(baseUrl, { waitUntil: 'networkidle' });
+    await page.getByTestId('nav-sidebar').waitFor({ state: 'visible' });
+  }
+
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const pill = page.getByTestId('task-agent-pill-2-10');
+  await pill.waitFor({ state: 'attached' });
+  await pill.scrollIntoViewIfNeeded();
+  await pill.waitFor({ state: 'visible' });
+
+  const title = await pill.getAttribute('title');
+  if (title !== 'Codex: awaiting_ack') {
+    throw new Error(`expected awaiting ack pill title to be Codex: awaiting_ack, got: ${title}`);
+  }
+
+  await page.getByText('Todo: awaiting ack').first().click();
+
+  await waitForLocatorCount(pill, 0, 20_000);
+}


### PR DESCRIPTION
## What
- Add `ServerEvent::TaskSummariesChanged` so the server can push per-workdir task summary snapshots.
- Make Inbox and Task List refresh from WS events (reduce polling).

## Contracts
- Updated `docs/contracts/features/c-ws-events.md` and `docs/contracts/progress.md`.

## Tests
- `just fmt && just lint && just test`
- `just test-ui`
