### PR TITLE
task-status-auto: extract validation PR and auto-done on merge

### DIFF
--- a/crates/luban_backend/migrations/0020_conversation_task_validation_pr.sql
+++ b/crates/luban_backend/migrations/0020_conversation_task_validation_pr.sql
@@ -1,0 +1,5 @@
+ALTER TABLE conversations
+  ADD COLUMN task_validation_pr_number INTEGER;
+
+ALTER TABLE conversations
+  ADD COLUMN task_validation_pr_url TEXT;

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -815,6 +815,36 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(anyhow_error_to_string)
     }
 
+    fn save_conversation_task_validation_pr(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+        thread_id: u64,
+        pr_number: u64,
+        pr_url: Option<String>,
+    ) -> Result<(), String> {
+        self.sqlite
+            .save_conversation_task_validation_pr(
+                project_slug,
+                workspace_name,
+                thread_id,
+                pr_number,
+                pr_url,
+            )
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn mark_conversation_tasks_done_for_merged_pr(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+        pr_number: u64,
+    ) -> Result<Vec<u64>, String> {
+        self.sqlite
+            .mark_conversation_tasks_done_for_merged_pr(project_slug, workspace_name, pr_number)
+            .map_err(anyhow_error_to_string)
+    }
+
     fn store_context_image(
         &self,
         project_slug: String,
@@ -2150,6 +2180,25 @@ impl ProjectWorkspaceService for GitWorkspaceService {
     ) -> Result<luban_domain::TaskStatus, String> {
         task::task_suggest_task_status(self, input, runner, model_id, thinking_effort, amp_mode)
             .map_err(anyhow_error_to_string)
+    }
+
+    fn task_suggest_task_status_auto_update(
+        &self,
+        input: String,
+        runner: luban_domain::AgentRunnerKind,
+        model_id: String,
+        thinking_effort: luban_domain::ThinkingEffort,
+        amp_mode: Option<String>,
+    ) -> Result<luban_domain::TaskStatusAutoUpdateSuggestion, String> {
+        task::task_suggest_task_status_auto_update(
+            self,
+            input,
+            runner,
+            model_id,
+            thinking_effort,
+            amp_mode,
+        )
+        .map_err(anyhow_error_to_string)
     }
 
     fn conversation_update_title_if_matches(

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -165,6 +165,13 @@ pub struct TaskIssueInfo {
 }
 
 #[derive(Clone, Debug)]
+pub struct TaskStatusAutoUpdateSuggestion {
+    pub task_status: TaskStatus,
+    pub validation_pr_number: Option<u64>,
+    pub validation_pr_url: Option<String>,
+}
+
+#[derive(Clone, Debug)]
 pub struct ProjectIdentity {
     pub root_path: PathBuf,
     pub github_repo: Option<String>,
@@ -332,6 +339,26 @@ pub trait ProjectWorkspaceService: Send + Sync {
         Ok(())
     }
 
+    fn save_conversation_task_validation_pr(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+        _thread_id: u64,
+        _pr_number: u64,
+        _pr_url: Option<String>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn mark_conversation_tasks_done_for_merged_pr(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+        _pr_number: u64,
+    ) -> Result<Vec<u64>, String> {
+        Ok(Vec::new())
+    }
+
     fn store_context_image(
         &self,
         project_slug: String,
@@ -487,6 +514,23 @@ pub trait ProjectWorkspaceService: Send + Sync {
         _amp_mode: Option<String>,
     ) -> Result<TaskStatus, String> {
         Err("unimplemented".to_owned())
+    }
+
+    fn task_suggest_task_status_auto_update(
+        &self,
+        input: String,
+        runner: AgentRunnerKind,
+        model_id: String,
+        thinking_effort: ThinkingEffort,
+        amp_mode: Option<String>,
+    ) -> Result<TaskStatusAutoUpdateSuggestion, String> {
+        let task_status =
+            self.task_suggest_task_status(input, runner, model_id, thinking_effort, amp_mode)?;
+        Ok(TaskStatusAutoUpdateSuggestion {
+            task_status,
+            validation_pr_number: None,
+            validation_pr_url: None,
+        })
     }
 
     fn conversation_update_title_if_matches(

--- a/crates/luban_domain/src/lib.rs
+++ b/crates/luban_domain/src/lib.rs
@@ -17,7 +17,7 @@ pub use adapters::{
     AmpConfigEntry, AmpConfigEntryKind, ClaudeConfigEntry, ClaudeConfigEntryKind, CodexConfigEntry,
     CodexConfigEntryKind, ContextImage, CreatedWorkspace, OpenTarget, ProjectIdentity,
     ProjectWorkspaceService, PullRequestCiState, PullRequestInfo, PullRequestState,
-    RunAgentTurnRequest, TaskIntentKind, TaskIssueInfo,
+    RunAgentTurnRequest, TaskIntentKind, TaskIssueInfo, TaskStatusAutoUpdateSuggestion,
 };
 mod context_tokens;
 pub use context_tokens::{

--- a/crates/luban_domain/src/system_prompts.rs
+++ b/crates/luban_domain/src/system_prompts.rs
@@ -130,7 +130,8 @@ Rules:
 - Do NOT include rationale, notes, or any extra fields in the output.
 - Always output a result, even if the input is vague: keep the current status.
 - Prefer conservative updates: do not mark as "done" unless the task is clearly finished.
-- If the current task_status is "validating" and the input indicates a related pull request is already merged, you may mark the task as "done" (only when the conversation context suggests the PR is the validation target).
+- If the conversation indicates the work has been submitted as a pull request, you should generally use task_status="validating".
+- When you output task_status="validating", you must try to extract the pull request number (and URL if present) from the conversation context, so the system can auto-complete the task when that PR is merged later.
 
 Allowed task_status values:
 - backlog
@@ -149,20 +150,15 @@ Context (JSON):
 Output JSON schema:
 {
   "task_status": "<one of the allowed values>",
-  "evidence": {
-    "kind": "<one of: none, pr_reference>",
-    "pr_number": "<integer or null>",
-    "text": "<string; empty if kind=none>"
-  }
+  "validation_pr_number": "<integer or null>",
+  "validation_pr_url": "<string; empty if validation_pr_number is null>"
 }
 
-Evidence rules:
-- Always include the evidence object.
-- If you set task_status to "done" because a pull request is already merged, you MUST set:
-  - evidence.kind = "pr_reference"
-  - evidence.pr_number = the referenced PR number
-  - evidence.text = a short excerpt from the conversation that references that PR
-- Otherwise set evidence.kind = "none" and keep pr_number as null and text as an empty string.
+Validation PR rules:
+- Always include validation_pr_number and validation_pr_url.
+- Only set validation_pr_number if task_status="validating" and the conversation clearly references the PR number.
+- If you cannot identify a PR number, set validation_pr_number to null and validation_pr_url to an empty string.
+- If you set validation_pr_number, set validation_pr_url if and only if a URL is present in the conversation.
 "#
             .to_owned()
         }


### PR DESCRIPTION
Behavior changes:
- When auto status updates a task to "validating", the system prompt requires the agent to extract the validation pull request number (and URL if present).
- The extracted PR number is persisted on the conversation.
- When that workspace PR transitions to merged, matching "validating" tasks are automatically marked as "done" (no text parsing in code).

Notes:
- This corrects the earlier approach of enforcing "done" evidence at merge time. PR mention recognition stays in the AutoUpdateTaskStatus prompt output.

Verification:
- just fmt && just lint && just test
