### PR TITLE
telegram: add bot integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "luban_domain",
  "notify",
  "portable-pty",
+ "rand 0.8.5",
  "reqwest 0.13.1",
  "rfd",
  "serde",

--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -25,6 +25,30 @@ pub struct AppSnapshot {
     pub task: TaskSettingsSnapshot,
     #[serde(default)]
     pub ui: UiSnapshot,
+    #[serde(default)]
+    pub integrations: IntegrationsSnapshot,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct IntegrationsSnapshot {
+    #[serde(default)]
+    pub telegram: TelegramIntegrationSnapshot,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TelegramIntegrationSnapshot {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub has_token: bool,
+    #[serde(default)]
+    pub bot_username: Option<String>,
+    #[serde(default)]
+    pub paired_chat_id: Option<i64>,
+    #[serde(default)]
+    pub config_rev: u64,
+    #[serde(default)]
+    pub last_error: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -759,6 +783,12 @@ pub enum ClientAction {
         #[serde(default)]
         attachments: Vec<AttachmentRef>,
     },
+    TelegramBotTokenSet {
+        token: String,
+    },
+    TelegramBotTokenClear,
+    TelegramPairStart,
+    TelegramUnpair,
     TaskStarSet {
         #[serde(rename = "workdir_id", alias = "workspace_id")]
         workspace_id: WorkspaceId,
@@ -1061,6 +1091,10 @@ pub enum ServerEvent {
     AppChanged {
         rev: u64,
         snapshot: Box<AppSnapshot>,
+    },
+    TelegramPairReady {
+        request_id: String,
+        url: String,
     },
     TaskSummariesChanged {
         project_id: ProjectId,

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -3706,6 +3706,11 @@ mod tests {
             workspace_thread_run_config_overrides: std::collections::HashMap::new(),
             starred_tasks: std::collections::HashMap::new(),
             task_prompt_templates: std::collections::HashMap::new(),
+            telegram_enabled: None,
+            telegram_bot_token: None,
+            telegram_bot_username: None,
+            telegram_paired_chat_id: None,
+            telegram_topic_bindings: None,
         };
 
         service

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -303,6 +303,30 @@ pub enum Action {
     AgentAmpModeChanged {
         mode: String,
     },
+    TelegramBotTokenSet {
+        token: String,
+    },
+    TelegramBotTokenCleared,
+    TelegramBotUsernameSet {
+        username: Option<String>,
+    },
+    TelegramChatPaired {
+        chat_id: i64,
+    },
+    TelegramUnpaired,
+    TelegramLastErrorSet {
+        message: Option<String>,
+    },
+    TelegramTopicBound {
+        message_thread_id: i64,
+        workspace_id: u64,
+        thread_id: u64,
+        replayed_up_to: Option<u64>,
+    },
+    TelegramTopicUnbound {
+        message_thread_id: i64,
+    },
+    TelegramTopicBindingsCleared,
     CodexDefaultsLoaded {
         model_id: Option<String>,
         thinking_effort: Option<ThinkingEffort>,

--- a/crates/luban_domain/src/persistence/save.rs
+++ b/crates/luban_domain/src/persistence/save.rs
@@ -116,5 +116,22 @@ pub(crate) fn to_persisted_app_state(state: &AppState) -> PersistedAppState {
             .map(|(workspace_id, thread_id)| ((workspace_id.0, thread_id.0), true))
             .collect(),
         task_prompt_templates: HashMap::new(),
+        telegram_enabled: Some(state.telegram_enabled),
+        telegram_bot_token: state.telegram_bot_token.clone(),
+        telegram_bot_username: state.telegram_bot_username.clone(),
+        telegram_paired_chat_id: state.telegram_paired_chat_id,
+        telegram_topic_bindings: serialize_telegram_topic_bindings(&state.telegram_topic_bindings),
     }
+}
+
+fn serialize_telegram_topic_bindings(
+    bindings: &HashMap<i64, crate::TelegramTopicBinding>,
+) -> Option<String> {
+    if bindings.is_empty() {
+        return None;
+    }
+
+    let mut list = bindings.values().cloned().collect::<Vec<_>>();
+    list.sort_by_key(|b| b.message_thread_id);
+    serde_json::to_string(&list).ok()
 }

--- a/crates/luban_domain/src/state/mod.rs
+++ b/crates/luban_domain/src/state/mod.rs
@@ -24,7 +24,7 @@ pub use persisted::{
 };
 pub use tabs::WorkspaceTabs;
 pub use task::{TaskStatus, TurnResult, TurnStatus, parse_task_status};
-pub use workspace::{AppState, Project, Workspace};
+pub use workspace::{AppState, Project, TelegramTopicBinding, Workspace};
 
 pub(crate) const MAX_CONVERSATION_ENTRIES_IN_MEMORY: usize = 5000;
 

--- a/crates/luban_domain/src/state/persisted.rs
+++ b/crates/luban_domain/src/state/persisted.rs
@@ -43,6 +43,11 @@ pub struct PersistedAppState {
         HashMap<(u64, u64), PersistedWorkspaceThreadRunConfigOverride>,
     pub starred_tasks: HashMap<(u64, u64), bool>,
     pub task_prompt_templates: HashMap<String, String>,
+    pub telegram_enabled: Option<bool>,
+    pub telegram_bot_token: Option<String>,
+    pub telegram_bot_username: Option<String>,
+    pub telegram_paired_chat_id: Option<i64>,
+    pub telegram_topic_bindings: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/luban_domain/src/state/workspace.rs
+++ b/crates/luban_domain/src/state/workspace.rs
@@ -9,6 +9,15 @@ use std::{
     path::PathBuf,
 };
 
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TelegramTopicBinding {
+    pub message_thread_id: i64,
+    pub workspace_id: u64,
+    pub thread_id: u64,
+    #[serde(default)]
+    pub replayed_up_to: Option<u64>,
+}
+
 #[derive(Clone, Debug)]
 pub struct Workspace {
     pub id: WorkspaceId,
@@ -68,6 +77,13 @@ pub struct AppState {
         HashMap<(WorkspaceId, WorkspaceThreadId), PersistedWorkspaceThreadRunConfigOverride>,
     pub task_prompt_templates: HashMap<TaskIntentKind, String>,
     pub system_prompt_templates: HashMap<SystemTaskKind, String>,
+    pub(crate) telegram_enabled: bool,
+    pub(crate) telegram_bot_token: Option<String>,
+    pub(crate) telegram_bot_username: Option<String>,
+    pub(crate) telegram_paired_chat_id: Option<i64>,
+    pub(crate) telegram_config_rev: u64,
+    pub(crate) telegram_last_error: Option<String>,
+    pub(crate) telegram_topic_bindings: HashMap<i64, TelegramTopicBinding>,
 }
 
 impl AppState {
@@ -97,5 +113,33 @@ impl AppState {
 
     pub fn agent_amp_mode(&self) -> &str {
         &self.agent_amp_mode
+    }
+
+    pub fn telegram_enabled(&self) -> bool {
+        self.telegram_enabled
+    }
+
+    pub fn telegram_bot_token(&self) -> Option<&str> {
+        self.telegram_bot_token.as_deref()
+    }
+
+    pub fn telegram_bot_username(&self) -> Option<&str> {
+        self.telegram_bot_username.as_deref()
+    }
+
+    pub fn telegram_paired_chat_id(&self) -> Option<i64> {
+        self.telegram_paired_chat_id
+    }
+
+    pub fn telegram_config_rev(&self) -> u64 {
+        self.telegram_config_rev
+    }
+
+    pub fn telegram_last_error(&self) -> Option<&str> {
+        self.telegram_last_error.as_deref()
+    }
+
+    pub fn telegram_topic_bindings(&self) -> &HashMap<i64, TelegramTopicBinding> {
+        &self.telegram_topic_bindings
     }
 }

--- a/crates/luban_server/Cargo.toml
+++ b/crates/luban_server/Cargo.toml
@@ -14,6 +14,7 @@ luban_domain = { path = "../luban_domain" }
 notify = "6"
 portable-pty.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "multipart", "rustls"] }
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/luban_server/src/lib.rs
+++ b/crates/luban_server/src/lib.rs
@@ -11,6 +11,7 @@ mod mentions;
 mod project_avatars;
 pub mod pty;
 pub mod server;
+mod telegram;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AuthMode {

--- a/crates/luban_server/src/server.rs
+++ b/crates/luban_server/src/server.rs
@@ -27,6 +27,7 @@ use tower_http::services::{ServeDir, ServeFile};
 pub async fn router(config: crate::ServerConfig) -> anyhow::Result<Router> {
     let services = new_default_services()?;
     let (engine, events) = Engine::start(services.clone());
+    crate::telegram::start_gateway(engine.clone(), events.clone());
 
     let avatar_http = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))

--- a/crates/luban_server/src/telegram.rs
+++ b/crates/luban_server/src/telegram.rs
@@ -1,0 +1,2234 @@
+use crate::engine::EngineHandle;
+use crate::engine::TelegramRuntimeConfig;
+use anyhow::Context as _;
+use luban_api::{ConversationEntry, ServerEvent, TaskStatus, WsServerMessage};
+use luban_domain::Action;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+use tokio::sync::broadcast;
+
+const TELEGRAM_DISABLED_ENV: &str = "LUBAN_TELEGRAM_DISABLED";
+const TELEGRAM_API_BASE_URL_ENV: &str = "LUBAN_TELEGRAM_API_BASE_URL";
+const TELEGRAM_API_BASE_URL_DEFAULT: &str = "https://api.telegram.org";
+
+const TELEGRAM_LONG_POLL_TIMEOUT_SECS: u64 = 20;
+const TELEGRAM_REQUEST_TIMEOUT_SECS: u64 = 30;
+const TELEGRAM_MAX_MESSAGE_CHARS: usize = 3800;
+const TELEGRAM_REPLY_ROUTE_TTL_SECS: u64 = 6 * 60 * 60;
+const TELEGRAM_REPLY_ROUTE_MAX_ROUTES: usize = 256;
+const TELEGRAM_PARSE_MODE_MARKDOWN_V2: &str = "MarkdownV2";
+
+const KB_HOME: &str = "Home";
+const KB_PROJECTS: &str = "Projects";
+const KB_RECENT_TASKS: &str = "Recent tasks";
+const KB_ACTIVE_TASK: &str = "Active task";
+const KB_NEW_TASK: &str = "New task";
+const KB_BACK: &str = "Back";
+const KB_CANCEL: &str = "Cancel";
+
+pub(crate) fn telegram_disabled() -> bool {
+    std::env::var(TELEGRAM_DISABLED_ENV)
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty())
+        .is_some_and(|v| v == "1" || v == "true" || v == "yes")
+}
+
+fn telegram_api_base_url() -> String {
+    std::env::var(TELEGRAM_API_BASE_URL_ENV)
+        .ok()
+        .map(|v| v.trim().to_owned())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| TELEGRAM_API_BASE_URL_DEFAULT.to_owned())
+}
+
+pub(crate) fn start_gateway(engine: EngineHandle, events: broadcast::Sender<WsServerMessage>) {
+    if telegram_disabled() {
+        tracing::info!("telegram gateway disabled by env");
+        return;
+    }
+
+    tokio::spawn(async move {
+        let mut gateway = TelegramGateway::new(engine, events.subscribe());
+        if let Err(err) = gateway.run().await {
+            tracing::warn!(error = %err, "telegram gateway stopped");
+        }
+    });
+}
+
+pub(crate) async fn telegram_get_me_username(token: &str) -> Result<String, String> {
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(TELEGRAM_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|err| format!("failed to build http client: {err}"))?;
+
+    let base = telegram_api_base_url();
+    let url = format!("{base}/bot{token}/getMe");
+    let res = http
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| format!("telegram getMe request failed: {err}"))?;
+
+    let parsed = res
+        .json::<TelegramApiResponse<TelegramGetMeResult>>()
+        .await
+        .map_err(|err| format!("telegram getMe response parse failed: {err}"))?;
+
+    if !parsed.ok {
+        return Err(parsed
+            .description
+            .unwrap_or_else(|| "telegram getMe failed".to_owned()));
+    }
+
+    let username = parsed
+        .result
+        .username
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "telegram bot username is missing".to_owned())?;
+
+    Ok(username.to_owned())
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TelegramApiResponse<T> {
+    ok: bool,
+    #[serde(default)]
+    result: T,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramGetMeResult {
+    #[serde(default)]
+    username: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramSendMessageResult {
+    #[serde(default)]
+    message_id: i64,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramUpdate {
+    update_id: i64,
+    #[serde(default)]
+    message: Option<TelegramMessage>,
+    #[serde(default)]
+    callback_query: Option<TelegramCallbackQuery>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramCallbackQuery {
+    id: String,
+    #[serde(default)]
+    data: Option<String>,
+    #[serde(default)]
+    message: Option<TelegramMessage>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramMessage {
+    #[serde(default)]
+    message_id: i64,
+    chat: TelegramChat,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    message_thread_id: Option<i64>,
+    #[serde(default)]
+    is_topic_message: Option<bool>,
+    #[serde(default)]
+    reply_to_message: Option<Box<TelegramMessage>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TelegramChat {
+    id: i64,
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+}
+
+struct TelegramGateway {
+    engine: EngineHandle,
+    events: broadcast::Receiver<WsServerMessage>,
+    http: reqwest::Client,
+    api_base: String,
+    last_config_rev: u64,
+    runtime: TelegramRuntimeConfig,
+    session: TelegramSession,
+    last_seen_entry_index: HashMap<(i64, Option<i64>, u64, u64), u64>,
+    reply_routes: HashMap<i64, ReplyRoute>,
+    topic_bindings: HashMap<i64, TopicBinding>,
+    inbox_initialized_workspaces: HashSet<u64>,
+    inbox_task_status: HashMap<(u64, u64), TaskStatus>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TelegramSession {
+    active_workspace_id: Option<u64>,
+    active_thread_id: Option<u64>,
+    ui_state: TelegramUiState,
+    keyboard_routes: HashMap<String, KeyboardRoute>,
+    pending_comment_target: Option<(u64, u64)>,
+}
+
+#[derive(Clone, Debug, Default)]
+enum TelegramUiState {
+    #[default]
+    Home,
+    SelectingProject,
+    SelectingTask,
+    SelectingWorktree {
+        project_slug: String,
+    },
+}
+
+#[derive(Clone, Debug)]
+enum KeyboardRoute {
+    SelectProject { project_slug: String },
+    SelectTask { workspace_id: u64, thread_id: u64 },
+    NewTask { project_slug: String },
+    SelectWorktree { workspace_id: u64 },
+}
+
+#[derive(Clone, Debug)]
+struct ReplyRoute {
+    workspace_id: u64,
+    thread_id: u64,
+    created_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct TopicBinding {
+    workspace_id: u64,
+    thread_id: u64,
+    replayed_up_to: Option<u64>,
+}
+
+impl TelegramGateway {
+    fn new(engine: EngineHandle, events: broadcast::Receiver<WsServerMessage>) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(TELEGRAM_REQUEST_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            engine,
+            events,
+            http,
+            api_base: telegram_api_base_url(),
+            last_config_rev: 0,
+            runtime: TelegramRuntimeConfig {
+                enabled: false,
+                bot_token: None,
+                paired_chat_id: None,
+                topic_bindings: Vec::new(),
+            },
+            session: TelegramSession::default(),
+            last_seen_entry_index: HashMap::new(),
+            reply_routes: HashMap::new(),
+            topic_bindings: HashMap::new(),
+            inbox_initialized_workspaces: HashSet::new(),
+            inbox_task_status: HashMap::new(),
+        }
+    }
+
+    async fn run(&mut self) -> anyhow::Result<()> {
+        self.refresh_runtime_config().await;
+
+        let mut update_offset = 0i64;
+
+        loop {
+            let token = self.runtime.bot_token.clone();
+            let enabled = self.runtime.enabled;
+            let api_base = self.api_base.clone();
+            let http = self.http.clone();
+            let offset = update_offset;
+
+            let poll_fut = async move {
+                if !enabled {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    return Ok(None);
+                }
+                let Some(token) = token else {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    return Ok(None);
+                };
+                poll_updates(http, api_base, token, offset).await.map(Some)
+            };
+
+            tokio::select! {
+                msg = self.events.recv() => {
+                    match msg {
+                        Ok(msg) => self.handle_server_message(msg).await,
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                polled = poll_fut => {
+                    match polled {
+                        Ok(Some((updates, next_offset))) => {
+                            update_offset = next_offset;
+                            self.handle_updates(updates).await;
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            self.set_last_error(err).await;
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_server_message(&mut self, msg: WsServerMessage) {
+        let WsServerMessage::Event { event, .. } = msg else {
+            return;
+        };
+
+        match *event {
+            ServerEvent::AppChanged { snapshot, .. } => {
+                let next_rev = snapshot.integrations.telegram.config_rev;
+                if next_rev != self.last_config_rev {
+                    self.last_config_rev = next_rev;
+                    self.refresh_runtime_config().await;
+                }
+            }
+            ServerEvent::TaskSummariesChanged { tasks, .. } => {
+                self.handle_task_summaries_changed(tasks).await;
+            }
+            ServerEvent::ConversationChanged { snapshot } => {
+                let Some(chat_id) = self.runtime.paired_chat_id else {
+                    return;
+                };
+                self.forward_conversation_updates(chat_id, None, &snapshot)
+                    .await;
+            }
+            _ => {}
+        }
+    }
+
+    async fn handle_task_summaries_changed(&mut self, tasks: Vec<luban_api::TaskSummarySnapshot>) {
+        let Some(chat_id) = self.runtime.paired_chat_id else {
+            return;
+        };
+
+        if tasks.is_empty() {
+            return;
+        }
+
+        let workspace_id = tasks[0].workspace_id.0;
+        let initialized = self.inbox_initialized_workspaces.contains(&workspace_id);
+        if !initialized {
+            for t in tasks {
+                self.inbox_task_status
+                    .insert((t.workspace_id.0, t.thread_id.0), t.task_status);
+            }
+            self.inbox_initialized_workspaces.insert(workspace_id);
+            return;
+        }
+
+        for t in tasks {
+            let key = (t.workspace_id.0, t.thread_id.0);
+            match self.inbox_task_status.get(&key).copied() {
+                None => {
+                    self.inbox_task_status.insert(key, t.task_status);
+                    let text = format!("Task created: {}", t.title.trim());
+                    let kb = inline_keyboard(vec![vec![InlineButton::new(
+                        "Comment",
+                        &format!("comment:{}:{}", t.workspace_id.0, t.thread_id.0),
+                    )]]);
+                    let _ = self.send_message(chat_id, None, &text, Some(kb)).await;
+                }
+                Some(prev) => {
+                    self.inbox_task_status.insert(key, t.task_status);
+                    if prev != TaskStatus::Done && t.task_status == TaskStatus::Done {
+                        let text = format!("Task completed: {}", t.title.trim());
+                        let kb = inline_keyboard(vec![vec![InlineButton::new(
+                            "Comment",
+                            &format!("comment:{}:{}", t.workspace_id.0, t.thread_id.0),
+                        )]]);
+                        let _ = self.send_message(chat_id, None, &text, Some(kb)).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn refresh_runtime_config(&mut self) {
+        match self.engine.telegram_runtime_config().await {
+            Ok(cfg) => {
+                let token_changed = cfg.bot_token != self.runtime.bot_token;
+                let paired_chat_changed = cfg.paired_chat_id != self.runtime.paired_chat_id;
+                self.runtime = cfg;
+                if token_changed {
+                    self.session = TelegramSession::default();
+                    self.last_seen_entry_index.clear();
+                    self.reply_routes.clear();
+                }
+                if paired_chat_changed {
+                    self.session = TelegramSession::default();
+                    self.last_seen_entry_index.clear();
+                    self.reply_routes.clear();
+                }
+
+                self.topic_bindings = self
+                    .runtime
+                    .topic_bindings
+                    .iter()
+                    .map(|b| {
+                        (
+                            b.message_thread_id,
+                            TopicBinding {
+                                workspace_id: b.workspace_id,
+                                thread_id: b.thread_id,
+                                replayed_up_to: b.replayed_up_to,
+                            },
+                        )
+                    })
+                    .collect();
+
+                if let Some(chat_id) = self.runtime.paired_chat_id {
+                    for (topic_id, binding) in &self.topic_bindings {
+                        let Some(replayed_up_to) = binding.replayed_up_to else {
+                            continue;
+                        };
+                        let key = (
+                            chat_id,
+                            Some(*topic_id),
+                            binding.workspace_id,
+                            binding.thread_id,
+                        );
+                        self.last_seen_entry_index
+                            .entry(key)
+                            .or_insert(replayed_up_to);
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "failed to refresh telegram runtime config");
+            }
+        }
+    }
+
+    fn prune_reply_routes(&mut self) {
+        let now = Instant::now();
+        let ttl = Duration::from_secs(TELEGRAM_REPLY_ROUTE_TTL_SECS);
+        self.reply_routes
+            .retain(|_, route| now.duration_since(route.created_at) <= ttl);
+    }
+
+    fn insert_reply_route(&mut self, message_id: i64, workspace_id: u64, thread_id: u64) {
+        self.prune_reply_routes();
+
+        if self.reply_routes.len() >= TELEGRAM_REPLY_ROUTE_MAX_ROUTES {
+            if let Some(oldest) = self
+                .reply_routes
+                .iter()
+                .min_by_key(|(_, route)| route.created_at)
+                .map(|(k, _)| *k)
+            {
+                self.reply_routes.remove(&oldest);
+            } else {
+                self.reply_routes.clear();
+            }
+        }
+
+        self.reply_routes.insert(
+            message_id,
+            ReplyRoute {
+                workspace_id,
+                thread_id,
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    async fn handle_updates(&mut self, updates: Vec<TelegramUpdate>) {
+        for update in updates {
+            if let Some(cb) = update.callback_query {
+                if let Err(err) = self.handle_callback_query(cb).await {
+                    tracing::debug!(error = %err, "telegram callback query failed");
+                }
+                continue;
+            }
+
+            if let Some(msg) = update.message {
+                if let Err(err) = self.handle_message(msg).await {
+                    tracing::debug!(error = %err, "telegram message failed");
+                }
+                continue;
+            }
+        }
+    }
+
+    async fn handle_message(&mut self, msg: TelegramMessage) -> anyhow::Result<()> {
+        let chat_id = msg.chat.id;
+        if msg.chat.kind.as_deref() != Some("private") {
+            return Ok(());
+        }
+
+        let text = msg.text.as_deref().unwrap_or_default().trim();
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        if text.starts_with("/start") {
+            let code = text
+                .split_whitespace()
+                .nth(1)
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .unwrap_or_default()
+                .to_owned();
+            if code.is_empty() {
+                self.send_message(chat_id, None, "Missing pairing code.", None)
+                    .await?;
+                return Ok(());
+            }
+
+            match self
+                .engine
+                .consume_telegram_pairing_code(code, chat_id)
+                .await
+            {
+                Ok(()) => {
+                    self.set_last_error("".to_owned()).await;
+                    self.send_home(chat_id).await?;
+                }
+                Err(message) => {
+                    self.send_message(chat_id, None, &message, None).await?;
+                }
+            }
+            return Ok(());
+        }
+
+        let Some(paired_chat_id) = self.runtime.paired_chat_id else {
+            self.send_message(
+                chat_id,
+                None,
+                "Telegram is not paired. Open Settings -> Integrations -> Telegram.",
+                None,
+            )
+            .await?;
+            return Ok(());
+        };
+        if paired_chat_id != chat_id {
+            return Ok(());
+        }
+
+        if msg.is_topic_message.unwrap_or(false) || msg.message_thread_id.is_some() {
+            self.send_message(
+                chat_id,
+                None,
+                "Topics are not supported. Please use the main chat.",
+                None,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        if self.handle_keyboard_input(chat_id, text).await? {
+            return Ok(());
+        }
+
+        if let Some((wid, tid)) = self.session.pending_comment_target.take() {
+            self.session.active_workspace_id = Some(wid);
+            self.session.active_thread_id = Some(tid);
+            self.send_agent_message(wid, tid, text).await;
+            self.send_home(chat_id).await?;
+            return Ok(());
+        }
+
+        self.prune_reply_routes();
+        let now = Instant::now();
+        let Some((wid, tid)) = resolve_message_target(
+            &msg,
+            &self.session,
+            &self.reply_routes,
+            &self.topic_bindings,
+            now,
+        ) else {
+            self.send_home(chat_id).await?;
+            return Ok(());
+        };
+        self.session.active_workspace_id = Some(wid);
+        self.session.active_thread_id = Some(tid);
+
+        self.send_agent_message(wid, tid, text).await;
+        Ok(())
+    }
+
+    async fn send_agent_message(&self, wid: u64, tid: u64, text: &str) {
+        let action = luban_api::ClientAction::SendAgentMessage {
+            workspace_id: luban_api::WorkspaceId(wid),
+            thread_id: luban_api::WorkspaceThreadId(tid),
+            text: text.to_owned(),
+            attachments: Vec::new(),
+            runner: None,
+            amp_mode: None,
+        };
+        let _ = self
+            .engine
+            .apply_client_action("telegram_send".to_owned(), action)
+            .await;
+    }
+
+    async fn handle_callback_query(&mut self, cb: TelegramCallbackQuery) -> anyhow::Result<()> {
+        let Some(chat_id) = cb.message.as_ref().map(|m| m.chat.id) else {
+            return Ok(());
+        };
+        if cb.message.as_ref().and_then(|m| m.chat.kind.as_deref()) != Some("private") {
+            return Ok(());
+        }
+
+        let data = cb.data.as_deref().unwrap_or_default().trim();
+        let topic_action = parse_topic_callback_action(data);
+        let action = parse_callback_action(data);
+        self.answer_callback_query(&cb.id).await?;
+
+        let Some(paired_chat_id) = self.runtime.paired_chat_id else {
+            self.send_message(
+                chat_id,
+                None,
+                "Telegram is not paired. Open Settings -> Integrations -> Telegram.",
+                None,
+            )
+            .await?;
+            return Ok(());
+        };
+        if paired_chat_id != chat_id {
+            return Ok(());
+        }
+
+        if let Some(topic_action) = topic_action {
+            self.handle_topic_callback_action(chat_id, topic_action)
+                .await?;
+            return Ok(());
+        }
+
+        match action {
+            CallbackAction::Home => self.send_home(chat_id).await?,
+            CallbackAction::Workspaces => self.send_workspaces(chat_id).await?,
+            CallbackAction::SelectWorkspace { workspace_id } => {
+                self.session.active_workspace_id = Some(workspace_id);
+                self.session.active_thread_id = None;
+                self.send_tasks(chat_id, workspace_id).await?;
+            }
+            CallbackAction::SelectTask {
+                workspace_id,
+                thread_id,
+            } => {
+                self.session.active_workspace_id = Some(workspace_id);
+                self.session.active_thread_id = Some(thread_id);
+                self.send_task_selected(chat_id, workspace_id, thread_id)
+                    .await?;
+            }
+            CallbackAction::NewTask { workspace_id } => {
+                self.create_task_and_select(chat_id, workspace_id).await?;
+            }
+            CallbackAction::Comment {
+                workspace_id,
+                thread_id,
+            } => {
+                self.session.pending_comment_target = Some((workspace_id, thread_id));
+                let title = self.task_title_or_default(workspace_id, thread_id).await;
+                let text = format!("Comment on: {title}\n\nSend your message now.");
+                self.send_message(chat_id, None, &text, Some(home_reply_keyboard()))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn create_task_and_select(
+        &mut self,
+        chat_id: i64,
+        workspace_id: u64,
+    ) -> anyhow::Result<()> {
+        let action = luban_api::ClientAction::CreateWorkspaceThread {
+            workspace_id: luban_api::WorkspaceId(workspace_id),
+        };
+        let _ = self
+            .engine
+            .apply_client_action("telegram_new_task".to_owned(), action)
+            .await;
+
+        let snapshot = self
+            .engine
+            .threads_snapshot(luban_api::WorkspaceId(workspace_id))
+            .await
+            .context("threads snapshot")?;
+
+        let new_tid = snapshot
+            .threads
+            .iter()
+            .map(|t| t.thread_id.0)
+            .max()
+            .unwrap_or(1);
+        self.session.active_workspace_id = Some(workspace_id);
+        self.session.active_thread_id = Some(new_tid);
+        self.send_task_selected(chat_id, workspace_id, new_tid)
+            .await?;
+        Ok(())
+    }
+
+    async fn handle_topic_callback_action(
+        &mut self,
+        chat_id: i64,
+        action: TopicCallbackAction,
+    ) -> anyhow::Result<()> {
+        match action {
+            TopicCallbackAction::ShowProjectMenu { topic_id } => {
+                self.send_topic_project_menu(chat_id, topic_id).await?;
+            }
+            TopicCallbackAction::SelectProject {
+                topic_id,
+                project_slug,
+            } => {
+                self.send_topic_task_menu(chat_id, topic_id, &project_slug)
+                    .await?;
+            }
+            TopicCallbackAction::BindTask {
+                topic_id,
+                workspace_id,
+                thread_id,
+            } => {
+                self.bind_topic_to_task(chat_id, topic_id, workspace_id, thread_id, true)
+                    .await?;
+            }
+            TopicCallbackAction::NewTask {
+                topic_id,
+                project_slug,
+            } => {
+                self.send_topic_worktree_menu(chat_id, topic_id, &project_slug)
+                    .await?;
+            }
+            TopicCallbackAction::CreateTask {
+                topic_id,
+                workspace_id,
+            } => {
+                let thread_id = self.create_task(workspace_id).await?;
+                self.bind_topic_to_task(chat_id, topic_id, workspace_id, thread_id, false)
+                    .await?;
+            }
+            TopicCallbackAction::Unbind { topic_id } => {
+                self.unbind_topic(chat_id, topic_id).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_topic_project_menu(&mut self, chat_id: i64, topic_id: i64) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+        let mut rows = Vec::new();
+        for project in &app.projects {
+            rows.push(vec![InlineButton::new(
+                &project.name,
+                &format!("tproj:{topic_id}:{}", project.slug),
+            )]);
+        }
+
+        let text = "Select a project for this topic.";
+        let kb = inline_keyboard(rows);
+        self.send_message(chat_id, Some(topic_id), text, Some(kb))
+            .await?;
+        Ok(())
+    }
+
+    async fn send_topic_task_menu(
+        &mut self,
+        chat_id: i64,
+        topic_id: i64,
+        project_slug: &str,
+    ) -> anyhow::Result<()> {
+        let tasks = self.project_recent_tasks(project_slug).await?;
+
+        let mut rows = Vec::new();
+        for t in tasks.into_iter().take(8) {
+            let label = format!("{} · {}", truncate_label(&t.title, 32), t.workspace_name);
+            let data = format!("tbind:{topic_id}:{}:{}", t.workspace_id, t.thread_id);
+            rows.push(vec![InlineButton::new(&label, &data)]);
+        }
+
+        rows.push(vec![InlineButton::new(
+            "New Task",
+            &format!("tnew:{topic_id}:{project_slug}"),
+        )]);
+        rows.push(vec![InlineButton::new(
+            "Change Project",
+            &format!("tproj:{topic_id}"),
+        )]);
+
+        let text = format!("Project: {project_slug}\n\nSelect a task for this topic.");
+        let kb = inline_keyboard(rows);
+        self.send_message(chat_id, Some(topic_id), &text, Some(kb))
+            .await?;
+        Ok(())
+    }
+
+    async fn send_topic_worktree_menu(
+        &mut self,
+        chat_id: i64,
+        topic_id: i64,
+        project_slug: &str,
+    ) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+        let Some(project) = app.projects.iter().find(|p| p.slug == project_slug) else {
+            self.send_topic_project_menu(chat_id, topic_id).await?;
+            return Ok(());
+        };
+
+        let mut rows = Vec::new();
+        for ws in &project.workspaces {
+            let label = format!("{} ({})", ws.workspace_name, ws.branch_name);
+            let data = format!("tcreate:{topic_id}:{}", ws.id.0);
+            rows.push(vec![InlineButton::new(&label, &data)]);
+        }
+        rows.push(vec![InlineButton::new(
+            "Back",
+            &format!("tproj:{topic_id}:{project_slug}"),
+        )]);
+
+        let text = "Select a worktree for the new task.";
+        let kb = inline_keyboard(rows);
+        self.send_message(chat_id, Some(topic_id), text, Some(kb))
+            .await?;
+        Ok(())
+    }
+
+    async fn create_task(&mut self, workspace_id: u64) -> anyhow::Result<u64> {
+        let action = luban_api::ClientAction::CreateWorkspaceThread {
+            workspace_id: luban_api::WorkspaceId(workspace_id),
+        };
+        let _ = self
+            .engine
+            .apply_client_action("telegram_topic_new_task".to_owned(), action)
+            .await;
+
+        let snapshot = self
+            .engine
+            .threads_snapshot(luban_api::WorkspaceId(workspace_id))
+            .await
+            .context("threads snapshot")?;
+
+        Ok(snapshot
+            .threads
+            .iter()
+            .map(|t| t.thread_id.0)
+            .max()
+            .unwrap_or(1))
+    }
+
+    async fn bind_topic_to_task(
+        &mut self,
+        chat_id: i64,
+        topic_id: i64,
+        workspace_id: u64,
+        thread_id: u64,
+        replay_history: bool,
+    ) -> anyhow::Result<()> {
+        self.last_seen_entry_index
+            .retain(|(cid, tid, _, _), _| *cid != chat_id || *tid != Some(topic_id));
+
+        let snapshot = self
+            .engine
+            .conversation_snapshot(
+                luban_api::WorkspaceId(workspace_id),
+                luban_api::WorkspaceThreadId(thread_id),
+                None,
+                Some(1),
+            )
+            .await
+            .context("conversation snapshot")?;
+
+        let title = snapshot.title.trim();
+        let title = if title.is_empty() { "Task" } else { title };
+        let topic_name = sanitize_telegram_topic_name(title);
+        let _ = self.edit_forum_topic(chat_id, topic_id, &topic_name).await;
+
+        let mut replayed_up_to = None;
+        if replay_history {
+            replayed_up_to = self
+                .latest_global_entry_index(workspace_id, thread_id)
+                .await?;
+            if let Some(replayed_up_to) = replayed_up_to {
+                self.last_seen_entry_index.insert(
+                    (chat_id, Some(topic_id), workspace_id, thread_id),
+                    replayed_up_to,
+                );
+            }
+        }
+
+        self.topic_bindings.insert(
+            topic_id,
+            TopicBinding {
+                workspace_id,
+                thread_id,
+                replayed_up_to,
+            },
+        );
+
+        let kb = inline_keyboard(vec![vec![InlineButton::new(
+            "Unlink",
+            &format!("tunbind:{topic_id}"),
+        )]]);
+        let text = format!("Linked to: {title}\n\nSend a message in this topic to continue.");
+        self.send_message(chat_id, Some(topic_id), &text, Some(kb))
+            .await?;
+
+        if replay_history && replayed_up_to.is_some() {
+            self.replay_task_dynamics(chat_id, topic_id, workspace_id, thread_id)
+                .await?;
+        }
+
+        let _ = self
+            .engine
+            .dispatch_domain_action(Action::TelegramTopicBound {
+                message_thread_id: topic_id,
+                workspace_id,
+                thread_id,
+                replayed_up_to,
+            })
+            .await;
+
+        Ok(())
+    }
+
+    async fn unbind_topic(&mut self, chat_id: i64, topic_id: i64) -> anyhow::Result<()> {
+        self.topic_bindings.remove(&topic_id);
+        self.last_seen_entry_index
+            .retain(|(cid, tid, _, _), _| *cid != chat_id || *tid != Some(topic_id));
+
+        let _ = self
+            .engine
+            .dispatch_domain_action(Action::TelegramTopicUnbound {
+                message_thread_id: topic_id,
+            })
+            .await;
+
+        self.send_topic_project_menu(chat_id, topic_id).await?;
+        Ok(())
+    }
+
+    async fn latest_global_entry_index(
+        &mut self,
+        workspace_id: u64,
+        thread_id: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        let snapshot = self
+            .engine
+            .conversation_snapshot(
+                luban_api::WorkspaceId(workspace_id),
+                luban_api::WorkspaceThreadId(thread_id),
+                None,
+                Some(1),
+            )
+            .await
+            .context("conversation snapshot")?;
+
+        if snapshot.entries_total == 0 || snapshot.entries.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(snapshot.entries_start.saturating_add(
+            snapshot.entries.len().saturating_sub(1) as u64,
+        )))
+    }
+
+    async fn replay_task_dynamics(
+        &mut self,
+        chat_id: i64,
+        topic_id: i64,
+        workspace_id: u64,
+        thread_id: u64,
+    ) -> anyhow::Result<()> {
+        const PAGE_LIMIT: u64 = 5000;
+
+        let mut before = None;
+        let mut pages = Vec::new();
+        loop {
+            let snapshot = self
+                .engine
+                .conversation_snapshot(
+                    luban_api::WorkspaceId(workspace_id),
+                    luban_api::WorkspaceThreadId(thread_id),
+                    before,
+                    Some(PAGE_LIMIT),
+                )
+                .await
+                .context("conversation snapshot")?;
+            before = if snapshot.entries_start == 0 {
+                None
+            } else {
+                Some(snapshot.entries_start)
+            };
+            pages.push(snapshot);
+            if before.is_none() {
+                break;
+            }
+        }
+
+        let mut items = Vec::new();
+        for page in pages.into_iter().rev() {
+            for entry in &page.entries {
+                if let Some(text) = format_conversation_entry_for_telegram(entry) {
+                    items.push(truncate_message(&text));
+                }
+            }
+        }
+
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        self.send_message(chat_id, Some(topic_id), "Previous activity:", None)
+            .await?;
+
+        let mut buf = String::new();
+        for item in items {
+            let candidate = if buf.is_empty() {
+                item.clone()
+            } else {
+                format!("{buf}\n\n{item}")
+            };
+
+            if candidate.chars().count() > TELEGRAM_MAX_MESSAGE_CHARS {
+                self.send_message(chat_id, Some(topic_id), &buf, None)
+                    .await?;
+                buf = item;
+            } else {
+                buf = candidate;
+            }
+        }
+        if !buf.trim().is_empty() {
+            self.send_message(chat_id, Some(topic_id), &buf, None)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn project_recent_tasks(
+        &mut self,
+        project_slug: &str,
+    ) -> anyhow::Result<Vec<ProjectTask>> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+        let Some(project) = app.projects.iter().find(|p| p.slug == project_slug) else {
+            return Ok(Vec::new());
+        };
+
+        let mut out = Vec::new();
+        for ws in &project.workspaces {
+            let snapshot = self
+                .engine
+                .threads_snapshot(luban_api::WorkspaceId(ws.id.0))
+                .await
+                .context("threads snapshot")?;
+            for t in snapshot.threads {
+                out.push(ProjectTask {
+                    workspace_id: ws.id.0,
+                    workspace_name: ws.workspace_name.clone(),
+                    thread_id: t.thread_id.0,
+                    title: t.title,
+                    updated_at_unix_seconds: t.updated_at_unix_seconds,
+                });
+            }
+        }
+
+        out.sort_by_key(|t| std::cmp::Reverse(t.updated_at_unix_seconds));
+        Ok(out)
+    }
+
+    async fn send_home(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        self.session.ui_state = TelegramUiState::Home;
+        self.session.keyboard_routes.clear();
+
+        let mut text = "Luban (Telegram)\n\nUse the keyboard to select a task.\nIf you don't see it, tap the keyboard icon next to the input field.\n\nMessages are sent to the active task.".to_owned();
+        if let (Some(wid), Some(tid)) = (
+            self.session.active_workspace_id,
+            self.session.active_thread_id,
+        ) {
+            let title = self.task_title_or_default(wid, tid).await;
+            text.push_str(&format!("\n\nActive task: {title}"));
+        }
+        if self.session.pending_comment_target.is_some() {
+            text.push_str("\n\nComment mode is active.");
+        }
+
+        self.send_message(chat_id, None, &text, Some(home_reply_keyboard()))
+            .await?;
+        Ok(())
+    }
+
+    async fn task_title_or_default(&mut self, workspace_id: u64, thread_id: u64) -> String {
+        let snapshot = self
+            .engine
+            .conversation_snapshot(
+                luban_api::WorkspaceId(workspace_id),
+                luban_api::WorkspaceThreadId(thread_id),
+                None,
+                Some(1),
+            )
+            .await;
+        match snapshot {
+            Ok(snapshot) => {
+                let title = snapshot.title.trim();
+                if title.is_empty() {
+                    "Task".to_owned()
+                } else {
+                    truncate_label(title, 48)
+                }
+            }
+            Err(_) => "Task".to_owned(),
+        }
+    }
+
+    async fn handle_keyboard_input(&mut self, chat_id: i64, text: &str) -> anyhow::Result<bool> {
+        match text {
+            KB_HOME => {
+                self.session.pending_comment_target = None;
+                self.send_home(chat_id).await?;
+                return Ok(true);
+            }
+            KB_CANCEL => {
+                self.session.pending_comment_target = None;
+                self.send_home(chat_id).await?;
+                return Ok(true);
+            }
+            KB_PROJECTS => {
+                self.send_project_menu(chat_id).await?;
+                return Ok(true);
+            }
+            KB_RECENT_TASKS => {
+                self.send_recent_tasks_menu(chat_id).await?;
+                return Ok(true);
+            }
+            KB_ACTIVE_TASK => {
+                self.send_active_task(chat_id).await?;
+                return Ok(true);
+            }
+            KB_BACK => {
+                self.handle_keyboard_back(chat_id).await?;
+                return Ok(true);
+            }
+            _ => {}
+        }
+
+        if let Some(route) = self.session.keyboard_routes.get(text).cloned() {
+            self.session.pending_comment_target = None;
+            self.handle_keyboard_route(chat_id, route).await?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn handle_keyboard_back(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        match self.session.ui_state.clone() {
+            TelegramUiState::SelectingProject | TelegramUiState::Home => {
+                self.send_home(chat_id).await
+            }
+            TelegramUiState::SelectingTask => self.send_project_menu(chat_id).await,
+            TelegramUiState::SelectingWorktree { project_slug } => {
+                self.send_project_task_menu(chat_id, &project_slug).await
+            }
+        }
+    }
+
+    async fn handle_keyboard_route(
+        &mut self,
+        chat_id: i64,
+        route: KeyboardRoute,
+    ) -> anyhow::Result<()> {
+        match route {
+            KeyboardRoute::SelectProject { project_slug } => {
+                self.send_project_task_menu(chat_id, &project_slug).await?;
+            }
+            KeyboardRoute::SelectTask {
+                workspace_id,
+                thread_id,
+            } => {
+                self.session.active_workspace_id = Some(workspace_id);
+                self.session.active_thread_id = Some(thread_id);
+                self.session.ui_state = TelegramUiState::Home;
+                self.session.keyboard_routes.clear();
+                let title = self.task_title_or_default(workspace_id, thread_id).await;
+                let text = format!("Selected: {title}");
+                self.send_message(chat_id, None, &text, Some(home_reply_keyboard()))
+                    .await?;
+            }
+            KeyboardRoute::NewTask { project_slug } => {
+                self.send_project_worktree_menu(chat_id, &project_slug)
+                    .await?;
+            }
+            KeyboardRoute::SelectWorktree { workspace_id } => {
+                let thread_id = self.create_task(workspace_id).await?;
+                self.session.active_workspace_id = Some(workspace_id);
+                self.session.active_thread_id = Some(thread_id);
+                self.session.ui_state = TelegramUiState::Home;
+                self.session.keyboard_routes.clear();
+                let title = self.task_title_or_default(workspace_id, thread_id).await;
+                let text = format!("Created and selected: {title}");
+                self.send_message(chat_id, None, &text, Some(home_reply_keyboard()))
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_active_task(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        if let (Some(wid), Some(tid)) = (
+            self.session.active_workspace_id,
+            self.session.active_thread_id,
+        ) {
+            let title = self.task_title_or_default(wid, tid).await;
+            let text = format!("Active task: {title}");
+            self.send_message(chat_id, None, &text, Some(home_reply_keyboard()))
+                .await?;
+            return Ok(());
+        }
+
+        self.send_message(
+            chat_id,
+            None,
+            "No active task. Use Projects or Recent tasks to select one.",
+            Some(home_reply_keyboard()),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn send_project_menu(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+
+        self.session.ui_state = TelegramUiState::SelectingProject;
+        self.session.keyboard_routes.clear();
+
+        let mut rows = Vec::new();
+        for project in &app.projects {
+            let label = truncate_label(&project.name, 48);
+            let label = ensure_unique_label(&self.session.keyboard_routes, label);
+            self.session.keyboard_routes.insert(
+                label.clone(),
+                KeyboardRoute::SelectProject {
+                    project_slug: project.slug.clone(),
+                },
+            );
+            rows.push(vec![label]);
+        }
+        rows.push(vec![KB_HOME.to_owned()]);
+
+        let text = "Select a project.";
+        let kb = reply_keyboard(rows);
+        self.send_message(chat_id, None, text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_project_task_menu(
+        &mut self,
+        chat_id: i64,
+        project_slug: &str,
+    ) -> anyhow::Result<()> {
+        let tasks = self.project_recent_tasks(project_slug).await?;
+
+        self.session.ui_state = TelegramUiState::SelectingTask;
+        self.session.keyboard_routes.clear();
+
+        let mut rows = Vec::new();
+        for t in tasks.into_iter().take(12) {
+            let label = format!(
+                "{} · {}",
+                truncate_label(&t.title, 32),
+                truncate_label(&t.workspace_name, 16)
+            );
+            let label = ensure_unique_label(&self.session.keyboard_routes, label);
+            self.session.keyboard_routes.insert(
+                label.clone(),
+                KeyboardRoute::SelectTask {
+                    workspace_id: t.workspace_id,
+                    thread_id: t.thread_id,
+                },
+            );
+            rows.push(vec![label]);
+        }
+
+        let new_task_label =
+            ensure_unique_label(&self.session.keyboard_routes, KB_NEW_TASK.to_owned());
+        self.session.keyboard_routes.insert(
+            new_task_label.clone(),
+            KeyboardRoute::NewTask {
+                project_slug: project_slug.to_owned(),
+            },
+        );
+        rows.push(vec![new_task_label]);
+
+        rows.push(vec![KB_BACK.to_owned(), KB_HOME.to_owned()]);
+
+        let text = format!("Project: {project_slug}\n\nSelect a task.");
+        let kb = reply_keyboard(rows);
+        self.send_message(chat_id, None, &text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_project_worktree_menu(
+        &mut self,
+        chat_id: i64,
+        project_slug: &str,
+    ) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+        let Some(project) = app.projects.iter().find(|p| p.slug == project_slug) else {
+            self.send_project_menu(chat_id).await?;
+            return Ok(());
+        };
+
+        self.session.ui_state = TelegramUiState::SelectingWorktree {
+            project_slug: project_slug.to_owned(),
+        };
+        self.session.keyboard_routes.clear();
+
+        let mut rows = Vec::new();
+        for ws in &project.workspaces {
+            let label = format!("{} ({})", ws.workspace_name, ws.branch_name);
+            let label =
+                ensure_unique_label(&self.session.keyboard_routes, truncate_label(&label, 48));
+            self.session.keyboard_routes.insert(
+                label.clone(),
+                KeyboardRoute::SelectWorktree {
+                    workspace_id: ws.id.0,
+                },
+            );
+            rows.push(vec![label]);
+        }
+        rows.push(vec![KB_BACK.to_owned(), KB_HOME.to_owned()]);
+
+        let text = "Select a worktree for the new task.";
+        let kb = reply_keyboard(rows);
+        self.send_message(chat_id, None, text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_recent_tasks_menu(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+
+        let mut out = Vec::new();
+        for project in &app.projects {
+            for ws in &project.workspaces {
+                let snapshot = self
+                    .engine
+                    .threads_snapshot(luban_api::WorkspaceId(ws.id.0))
+                    .await
+                    .context("threads snapshot")?;
+                for t in snapshot.threads {
+                    out.push(ProjectTask {
+                        workspace_id: ws.id.0,
+                        workspace_name: ws.workspace_name.clone(),
+                        thread_id: t.thread_id.0,
+                        title: t.title,
+                        updated_at_unix_seconds: t.updated_at_unix_seconds,
+                    });
+                }
+            }
+        }
+        out.sort_by_key(|t| std::cmp::Reverse(t.updated_at_unix_seconds));
+
+        self.session.ui_state = TelegramUiState::Home;
+        self.session.keyboard_routes.clear();
+
+        let mut rows = Vec::new();
+        for t in out.into_iter().take(12) {
+            let label = format!(
+                "{} · {}",
+                truncate_label(&t.title, 32),
+                truncate_label(&t.workspace_name, 16)
+            );
+            let label = ensure_unique_label(&self.session.keyboard_routes, label);
+            self.session.keyboard_routes.insert(
+                label.clone(),
+                KeyboardRoute::SelectTask {
+                    workspace_id: t.workspace_id,
+                    thread_id: t.thread_id,
+                },
+            );
+            rows.push(vec![label]);
+        }
+        rows.push(vec![KB_HOME.to_owned()]);
+
+        let text = "Select a recent task.";
+        let kb = reply_keyboard(rows);
+        self.send_message(chat_id, None, text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_workspaces(&mut self, chat_id: i64) -> anyhow::Result<()> {
+        let app = self.engine.app_snapshot().await.context("app snapshot")?;
+        let mut rows = Vec::new();
+        for project in &app.projects {
+            for ws in &project.workspaces {
+                let label = format!("{}/{}", project.slug, ws.workspace_name);
+                let data = format!("ws:{}", ws.id.0);
+                rows.push(vec![InlineButton::new(&label, &data)]);
+            }
+        }
+
+        let text = "Workspaces";
+        let kb = inline_keyboard(rows);
+        self.send_message(chat_id, None, text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_tasks(&mut self, chat_id: i64, workspace_id: u64) -> anyhow::Result<()> {
+        let snapshot = self
+            .engine
+            .threads_snapshot(luban_api::WorkspaceId(workspace_id))
+            .await
+            .context("threads snapshot")?;
+
+        let mut rows = Vec::new();
+        for t in snapshot.threads.iter().take(8) {
+            let label = truncate_label(&t.title, 32);
+            let data = format!("task:{}:{}", workspace_id, t.thread_id.0);
+            rows.push(vec![InlineButton::new(&label, &data)]);
+        }
+        rows.push(vec![InlineButton::new(
+            "New Task",
+            &format!("new:{workspace_id}"),
+        )]);
+        rows.push(vec![InlineButton::new("Workspaces", "workspaces")]);
+
+        let text = "Tasks";
+        let kb = inline_keyboard(rows);
+        self.send_message(chat_id, None, text, Some(kb)).await?;
+        Ok(())
+    }
+
+    async fn send_task_selected(
+        &mut self,
+        chat_id: i64,
+        workspace_id: u64,
+        thread_id: u64,
+    ) -> anyhow::Result<()> {
+        let snapshot = self
+            .engine
+            .conversation_snapshot(
+                luban_api::WorkspaceId(workspace_id),
+                luban_api::WorkspaceThreadId(thread_id),
+                None,
+                Some(25),
+            )
+            .await
+            .context("conversation snapshot")?;
+
+        let title = snapshot.title.trim();
+        let title = if title.is_empty() { "Task" } else { title };
+
+        let text = format!("Selected: {title}\n\nSend a message to continue this task.");
+        let kb = inline_keyboard(vec![vec![
+            InlineButton::new("Tasks", &format!("ws:{workspace_id}")),
+            InlineButton::new("Workspaces", "workspaces"),
+        ]]);
+        if let Some(message_id) = self
+            .send_message_with_id(chat_id, None, &text, Some(kb), None)
+            .await?
+        {
+            self.insert_reply_route(message_id, workspace_id, thread_id);
+        }
+        Ok(())
+    }
+
+    async fn forward_conversation_updates(
+        &mut self,
+        chat_id: i64,
+        message_thread_id: Option<i64>,
+        snapshot: &luban_api::ConversationSnapshot,
+    ) {
+        let key = (
+            chat_id,
+            message_thread_id,
+            snapshot.workspace_id.0,
+            snapshot.thread_id.0,
+        );
+        let start = snapshot.entries_start;
+        let last_seen = self.last_seen_entry_index.get(&key).copied();
+
+        let mut candidate = None::<(u64, String)>;
+        for (idx, entry) in snapshot.entries.iter().enumerate() {
+            let global_idx = start.saturating_add(idx as u64);
+            if let Some(last_seen) = last_seen
+                && global_idx <= last_seen
+            {
+                continue;
+            }
+
+            if let Some(text) = format_conversation_entry_for_telegram(entry) {
+                candidate = Some((global_idx, text));
+            }
+        }
+
+        let Some((global_idx, text)) = candidate else {
+            return;
+        };
+
+        let title = snapshot.title.trim();
+        let title = if title.is_empty() { "Task" } else { title };
+
+        let formatted = format_task_push_markdown(title, &text);
+        let kb = inline_keyboard(vec![vec![InlineButton::new(
+            "Comment",
+            &format!(
+                "comment:{}:{}",
+                snapshot.workspace_id.0, snapshot.thread_id.0
+            ),
+        )]]);
+        let sent = self
+            .send_message_with_id(
+                chat_id,
+                message_thread_id,
+                &formatted,
+                Some(kb),
+                Some(TELEGRAM_PARSE_MODE_MARKDOWN_V2),
+            )
+            .await;
+        let Ok(Some(message_id)) = sent else {
+            return;
+        };
+
+        self.insert_reply_route(message_id, snapshot.workspace_id.0, snapshot.thread_id.0);
+        self.last_seen_entry_index.insert(key, global_idx);
+    }
+
+    async fn send_message(
+        &self,
+        chat_id: i64,
+        message_thread_id: Option<i64>,
+        text: &str,
+        reply_markup: Option<serde_json::Value>,
+    ) -> anyhow::Result<()> {
+        let _ = self
+            .send_message_with_id(chat_id, message_thread_id, text, reply_markup, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn send_message_with_id(
+        &self,
+        chat_id: i64,
+        message_thread_id: Option<i64>,
+        text: &str,
+        reply_markup: Option<serde_json::Value>,
+        parse_mode: Option<&str>,
+    ) -> anyhow::Result<Option<i64>> {
+        let Some(token) = self.runtime.bot_token.as_deref() else {
+            return Ok(None);
+        };
+        let url = format!(
+            "{}/bot{}/sendMessage",
+            self.api_base.trim_end_matches('/'),
+            token
+        );
+
+        let mut body = serde_json::json!({
+            "chat_id": chat_id,
+            "text": text,
+            "disable_web_page_preview": true,
+        });
+        if let Some(topic_id) = message_thread_id {
+            body["message_thread_id"] = serde_json::json!(topic_id);
+        }
+        if let Some(markup) = reply_markup {
+            body["reply_markup"] = markup;
+        }
+        if let Some(parse_mode) = parse_mode {
+            body["parse_mode"] = serde_json::json!(parse_mode);
+        }
+
+        let res = self.http.post(url).json(&body).send().await;
+        let res = match res {
+            Ok(res) => res,
+            Err(err) => {
+                self.set_last_error(format!("telegram sendMessage failed: {err}"))
+                    .await;
+                return Ok(None);
+            }
+        };
+
+        let parsed = res
+            .json::<TelegramApiResponse<TelegramSendMessageResult>>()
+            .await;
+        let parsed = match parsed {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                self.set_last_error(format!("telegram sendMessage response parse failed: {err}"))
+                    .await;
+                return Ok(None);
+            }
+        };
+
+        if !parsed.ok {
+            let message = parsed
+                .description
+                .unwrap_or_else(|| "telegram sendMessage failed".to_owned());
+            self.set_last_error(message).await;
+            return Ok(None);
+        }
+
+        Ok(Some(parsed.result.message_id))
+    }
+
+    async fn edit_forum_topic(
+        &self,
+        chat_id: i64,
+        topic_id: i64,
+        name: &str,
+    ) -> anyhow::Result<()> {
+        let Some(token) = self.runtime.bot_token.as_deref() else {
+            return Ok(());
+        };
+        let url = format!(
+            "{}/bot{}/editForumTopic",
+            self.api_base.trim_end_matches('/'),
+            token
+        );
+
+        let body = serde_json::json!({
+            "chat_id": chat_id,
+            "message_thread_id": topic_id,
+            "name": name,
+        });
+
+        let res = self.http.post(url).json(&body).send().await;
+        let res = match res {
+            Ok(res) => res,
+            Err(err) => {
+                self.set_last_error(format!("telegram editForumTopic failed: {err}"))
+                    .await;
+                return Ok(());
+            }
+        };
+
+        let parsed = res.json::<TelegramApiResponse<bool>>().await;
+        let parsed = match parsed {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                self.set_last_error(format!(
+                    "telegram editForumTopic response parse failed: {err}"
+                ))
+                .await;
+                return Ok(());
+            }
+        };
+
+        if !parsed.ok {
+            let message = parsed
+                .description
+                .unwrap_or_else(|| "telegram editForumTopic failed".to_owned());
+            self.set_last_error(message).await;
+        }
+
+        Ok(())
+    }
+
+    async fn answer_callback_query(&self, id: &str) -> anyhow::Result<()> {
+        let Some(token) = self.runtime.bot_token.as_deref() else {
+            return Ok(());
+        };
+        let url = format!(
+            "{}/bot{}/answerCallbackQuery",
+            self.api_base.trim_end_matches('/'),
+            token
+        );
+        let body = serde_json::json!({ "callback_query_id": id });
+        let _ = self.http.post(url).json(&body).send().await;
+        Ok(())
+    }
+
+    async fn set_last_error(&self, message: String) {
+        let next = message.trim();
+        let message = if next.is_empty() {
+            None
+        } else if next.len() <= 1024 {
+            Some(next.to_owned())
+        } else {
+            Some(next.chars().take(1024).collect::<String>())
+        };
+
+        let _ = self
+            .engine
+            .dispatch_domain_action(Action::TelegramLastErrorSet { message })
+            .await;
+    }
+}
+
+async fn poll_updates(
+    http: reqwest::Client,
+    api_base: String,
+    token: String,
+    offset: i64,
+) -> Result<(Vec<TelegramUpdate>, i64), String> {
+    let url = format!(
+        "{}/bot{}/getUpdates?timeout={}&offset={}",
+        api_base.trim_end_matches('/'),
+        token,
+        TELEGRAM_LONG_POLL_TIMEOUT_SECS,
+        offset
+    );
+    let res = http
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| format!("telegram getUpdates failed: {err}"))?;
+
+    let parsed = res
+        .json::<TelegramApiResponse<Vec<TelegramUpdate>>>()
+        .await
+        .map_err(|err| format!("telegram getUpdates parse failed: {err}"))?;
+
+    if !parsed.ok {
+        return Err(parsed
+            .description
+            .unwrap_or_else(|| "telegram getUpdates failed".to_owned()));
+    }
+
+    let mut next_offset = offset;
+    for update in &parsed.result {
+        next_offset = next_offset.max(update.update_id.saturating_add(1));
+    }
+
+    Ok((parsed.result, next_offset))
+}
+
+#[derive(Clone, Debug)]
+enum CallbackAction {
+    Home,
+    Workspaces,
+    SelectWorkspace { workspace_id: u64 },
+    SelectTask { workspace_id: u64, thread_id: u64 },
+    NewTask { workspace_id: u64 },
+    Comment { workspace_id: u64, thread_id: u64 },
+}
+
+#[derive(Clone, Debug)]
+enum TopicCallbackAction {
+    ShowProjectMenu {
+        topic_id: i64,
+    },
+    SelectProject {
+        topic_id: i64,
+        project_slug: String,
+    },
+    BindTask {
+        topic_id: i64,
+        workspace_id: u64,
+        thread_id: u64,
+    },
+    NewTask {
+        topic_id: i64,
+        project_slug: String,
+    },
+    CreateTask {
+        topic_id: i64,
+        workspace_id: u64,
+    },
+    Unbind {
+        topic_id: i64,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct ProjectTask {
+    workspace_id: u64,
+    workspace_name: String,
+    thread_id: u64,
+    title: String,
+    updated_at_unix_seconds: u64,
+}
+
+fn parse_callback_action(raw: &str) -> CallbackAction {
+    if raw == "home" {
+        return CallbackAction::Home;
+    }
+    if raw == "workspaces" {
+        return CallbackAction::Workspaces;
+    }
+    if let Some(rest) = raw.strip_prefix("ws:")
+        && let Ok(workspace_id) = rest.parse::<u64>()
+    {
+        return CallbackAction::SelectWorkspace { workspace_id };
+    }
+    if let Some(rest) = raw.strip_prefix("task:") {
+        let mut parts = rest.split(':');
+        if let (Some(wid), Some(tid)) = (parts.next(), parts.next())
+            && let (Ok(workspace_id), Ok(thread_id)) = (wid.parse::<u64>(), tid.parse::<u64>())
+        {
+            return CallbackAction::SelectTask {
+                workspace_id,
+                thread_id,
+            };
+        }
+    }
+    if let Some(rest) = raw.strip_prefix("new:")
+        && let Ok(workspace_id) = rest.parse::<u64>()
+    {
+        return CallbackAction::NewTask { workspace_id };
+    }
+    if let Some(rest) = raw.strip_prefix("comment:") {
+        let mut parts = rest.split(':');
+        if let (Some(wid), Some(tid)) = (parts.next(), parts.next())
+            && let (Ok(workspace_id), Ok(thread_id)) = (wid.parse::<u64>(), tid.parse::<u64>())
+        {
+            return CallbackAction::Comment {
+                workspace_id,
+                thread_id,
+            };
+        }
+    }
+    CallbackAction::Home
+}
+
+fn parse_topic_callback_action(raw: &str) -> Option<TopicCallbackAction> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = raw.strip_prefix("tproj:") {
+        let mut parts = rest.split(':');
+        let topic_id = parts.next()?.parse::<i64>().ok()?;
+        let slug = parts.next().map(str::trim).unwrap_or_default();
+        if slug.is_empty() {
+            return Some(TopicCallbackAction::ShowProjectMenu { topic_id });
+        }
+        return Some(TopicCallbackAction::SelectProject {
+            topic_id,
+            project_slug: slug.to_owned(),
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("tbind:") {
+        let mut parts = rest.split(':');
+        let topic_id = parts.next()?.parse::<i64>().ok()?;
+        let workspace_id = parts.next()?.parse::<u64>().ok()?;
+        let thread_id = parts.next()?.parse::<u64>().ok()?;
+        return Some(TopicCallbackAction::BindTask {
+            topic_id,
+            workspace_id,
+            thread_id,
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("tnew:") {
+        let mut parts = rest.split(':');
+        let topic_id = parts.next()?.parse::<i64>().ok()?;
+        let slug = parts.next()?.trim();
+        if slug.is_empty() {
+            return None;
+        }
+        return Some(TopicCallbackAction::NewTask {
+            topic_id,
+            project_slug: slug.to_owned(),
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("tcreate:") {
+        let mut parts = rest.split(':');
+        let topic_id = parts.next()?.parse::<i64>().ok()?;
+        let workspace_id = parts.next()?.parse::<u64>().ok()?;
+        return Some(TopicCallbackAction::CreateTask {
+            topic_id,
+            workspace_id,
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("tunbind:")
+        && let Ok(topic_id) = rest.trim().parse::<i64>()
+    {
+        return Some(TopicCallbackAction::Unbind { topic_id });
+    }
+
+    None
+}
+
+#[derive(Clone, Debug)]
+struct InlineButton {
+    text: String,
+    callback_data: String,
+}
+
+impl InlineButton {
+    fn new(text: &str, callback_data: &str) -> Self {
+        Self {
+            text: truncate_label(text, 64),
+            callback_data: callback_data.to_owned(),
+        }
+    }
+}
+
+fn inline_keyboard(rows: Vec<Vec<InlineButton>>) -> serde_json::Value {
+    let inline_keyboard = rows
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|b| {
+                    serde_json::json!({
+                        "text": b.text,
+                        "callback_data": b.callback_data,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({ "inline_keyboard": inline_keyboard })
+}
+
+fn reply_keyboard(rows: Vec<Vec<String>>) -> serde_json::Value {
+    let keyboard = rows
+        .into_iter()
+        .map(|row| row.into_iter().map(serde_json::Value::String).collect())
+        .collect::<Vec<Vec<_>>>();
+    serde_json::json!({
+        "keyboard": keyboard,
+        "resize_keyboard": true,
+    })
+}
+
+fn home_reply_keyboard() -> serde_json::Value {
+    reply_keyboard(vec![
+        vec![KB_PROJECTS.to_owned(), KB_RECENT_TASKS.to_owned()],
+        vec![KB_ACTIVE_TASK.to_owned(), KB_HOME.to_owned()],
+        vec![KB_CANCEL.to_owned()],
+    ])
+}
+
+fn ensure_unique_label(routes: &HashMap<String, KeyboardRoute>, raw: String) -> String {
+    let trimmed = raw.trim();
+    let trimmed = if trimmed.is_empty() { "Item" } else { trimmed };
+
+    for suffix in 0..32 {
+        let candidate = if suffix == 0 {
+            trimmed.to_owned()
+        } else {
+            format!("{trimmed} ({suffix})")
+        };
+
+        if is_reserved_keyboard_label(&candidate) {
+            continue;
+        }
+        if !routes.contains_key(&candidate) {
+            return candidate;
+        }
+    }
+
+    truncate_label(trimmed, 48)
+}
+
+fn is_reserved_keyboard_label(raw: &str) -> bool {
+    matches!(
+        raw,
+        KB_HOME | KB_PROJECTS | KB_RECENT_TASKS | KB_ACTIVE_TASK | KB_BACK | KB_CANCEL
+    )
+}
+
+fn truncate_label(raw: &str, max_chars: usize) -> String {
+    let trimmed = raw.trim();
+    if trimmed.chars().count() <= max_chars {
+        return trimmed.to_owned();
+    }
+    let mut out = trimmed
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    out.push('…');
+    out
+}
+
+fn truncate_message(raw: &str) -> String {
+    if raw.chars().count() <= TELEGRAM_MAX_MESSAGE_CHARS {
+        return raw.to_owned();
+    }
+    let mut out = raw
+        .chars()
+        .take(TELEGRAM_MAX_MESSAGE_CHARS.saturating_sub(1))
+        .collect::<String>();
+    out.push('…');
+    out
+}
+
+fn format_task_push_markdown(task_title: &str, raw: &str) -> String {
+    let title = truncate_label(task_title, 48);
+    let title = escape_markdown_v2(&title);
+
+    let body_budget = TELEGRAM_MAX_MESSAGE_CHARS
+        .saturating_sub(title.chars().count())
+        .saturating_sub(3);
+    let body = escape_markdown_v2(raw);
+    let body = truncate_markdown_v2_body(&body, body_budget);
+
+    format!("*{title}*\n{body}")
+}
+
+fn truncate_markdown_v2_body(raw: &str, max_chars: usize) -> String {
+    if raw.chars().count() <= max_chars {
+        return raw.to_owned();
+    }
+    let mut out = raw
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    while out.ends_with('\\') {
+        out.pop();
+    }
+    out.push('…');
+    out
+}
+
+fn escape_markdown_v2(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len().saturating_add(8));
+    for ch in raw.chars() {
+        if matches!(
+            ch,
+            '_' | '*'
+                | '['
+                | ']'
+                | '('
+                | ')'
+                | '~'
+                | '`'
+                | '>'
+                | '#'
+                | '+'
+                | '-'
+                | '='
+                | '|'
+                | '{'
+                | '}'
+                | '.'
+                | '!'
+        ) {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn sanitize_telegram_topic_name(raw: &str) -> String {
+    const LIMIT: usize = 128;
+    let collapsed = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let trimmed = collapsed.trim();
+    let trimmed = if trimmed.is_empty() { "Task" } else { trimmed };
+    trimmed.chars().take(LIMIT).collect()
+}
+
+fn format_conversation_entry_for_telegram(entry: &ConversationEntry) -> Option<String> {
+    match entry {
+        ConversationEntry::AgentEvent(v) => match &v.event {
+            luban_api::AgentEvent::Message(msg) => Some(msg.text.clone()),
+            luban_api::AgentEvent::TurnDuration { duration_ms } => {
+                Some(format!("Turn completed ({duration_ms} ms)"))
+            }
+            luban_api::AgentEvent::TurnError { message } => Some(format!("Turn failed: {message}")),
+            luban_api::AgentEvent::TurnCanceled => Some("Turn canceled.".to_owned()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn resolve_message_target(
+    msg: &TelegramMessage,
+    session: &TelegramSession,
+    routes: &HashMap<i64, ReplyRoute>,
+    topic_bindings: &HashMap<i64, TopicBinding>,
+    now: Instant,
+) -> Option<(u64, u64)> {
+    let ttl = Duration::from_secs(TELEGRAM_REPLY_ROUTE_TTL_SECS);
+    if let Some(reply_to) = msg.reply_to_message.as_deref()
+        && let Some(route) = routes.get(&reply_to.message_id)
+        && now.duration_since(route.created_at) <= ttl
+    {
+        return Some((route.workspace_id, route.thread_id));
+    }
+
+    if let Some(topic_id) = msg.message_thread_id
+        && let Some(binding) = topic_bindings.get(&topic_id)
+    {
+        return Some((binding.workspace_id, binding.thread_id));
+    }
+
+    match (session.active_workspace_id, session.active_thread_id) {
+        (Some(wid), Some(tid)) => Some((wid, tid)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg_with_reply(reply_to_message_id: i64) -> TelegramMessage {
+        TelegramMessage {
+            message_id: 100,
+            chat: TelegramChat {
+                id: 1,
+                kind: Some("private".to_owned()),
+            },
+            text: Some("hello".to_owned()),
+            message_thread_id: None,
+            is_topic_message: None,
+            reply_to_message: Some(Box::new(TelegramMessage {
+                message_id: reply_to_message_id,
+                chat: TelegramChat {
+                    id: 1,
+                    kind: Some("private".to_owned()),
+                },
+                text: None,
+                message_thread_id: None,
+                is_topic_message: None,
+                reply_to_message: None,
+            })),
+        }
+    }
+
+    #[test]
+    fn resolve_message_target_prefers_reply_route() {
+        let now = Instant::now();
+        let mut routes = HashMap::new();
+        routes.insert(
+            10,
+            ReplyRoute {
+                workspace_id: 1,
+                thread_id: 2,
+                created_at: now,
+            },
+        );
+        let session = TelegramSession {
+            active_workspace_id: Some(9),
+            active_thread_id: Some(9),
+            ..Default::default()
+        };
+        let topic_bindings = HashMap::new();
+        assert_eq!(
+            resolve_message_target(&msg_with_reply(10), &session, &routes, &topic_bindings, now),
+            Some((1, 2))
+        );
+    }
+
+    #[test]
+    fn resolve_message_target_ignores_expired_reply_route() {
+        let now = Instant::now();
+        let mut routes = HashMap::new();
+        routes.insert(
+            10,
+            ReplyRoute {
+                workspace_id: 1,
+                thread_id: 2,
+                created_at: now - Duration::from_secs(TELEGRAM_REPLY_ROUTE_TTL_SECS + 1),
+            },
+        );
+        let session = TelegramSession {
+            active_workspace_id: Some(3),
+            active_thread_id: Some(4),
+            ..Default::default()
+        };
+        let topic_bindings = HashMap::new();
+        assert_eq!(
+            resolve_message_target(&msg_with_reply(10), &session, &routes, &topic_bindings, now),
+            Some((3, 4))
+        );
+    }
+
+    #[test]
+    fn resolve_message_target_falls_back_to_session() {
+        let now = Instant::now();
+        let routes = HashMap::new();
+        let topic_bindings = HashMap::new();
+        let session = TelegramSession {
+            active_workspace_id: Some(3),
+            active_thread_id: Some(4),
+            ..Default::default()
+        };
+        let msg = TelegramMessage {
+            message_id: 1,
+            chat: TelegramChat {
+                id: 1,
+                kind: Some("private".to_owned()),
+            },
+            text: Some("hello".to_owned()),
+            message_thread_id: None,
+            is_topic_message: None,
+            reply_to_message: None,
+        };
+        assert_eq!(
+            resolve_message_target(&msg, &session, &routes, &topic_bindings, now),
+            Some((3, 4))
+        );
+    }
+
+    #[test]
+    fn resolve_message_target_returns_none_without_route_or_session() {
+        let now = Instant::now();
+        let routes = HashMap::new();
+        let topic_bindings = HashMap::new();
+        let session = TelegramSession::default();
+        let msg = TelegramMessage {
+            message_id: 1,
+            chat: TelegramChat {
+                id: 1,
+                kind: Some("private".to_owned()),
+            },
+            text: Some("hello".to_owned()),
+            message_thread_id: None,
+            is_topic_message: None,
+            reply_to_message: None,
+        };
+        assert_eq!(
+            resolve_message_target(&msg, &session, &routes, &topic_bindings, now),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_message_target_uses_topic_binding() {
+        let now = Instant::now();
+        let routes = HashMap::new();
+        let session = TelegramSession::default();
+        let mut topic_bindings = HashMap::new();
+        topic_bindings.insert(
+            55,
+            TopicBinding {
+                workspace_id: 7,
+                thread_id: 8,
+                replayed_up_to: None,
+            },
+        );
+        let msg = TelegramMessage {
+            message_id: 1,
+            chat: TelegramChat {
+                id: 1,
+                kind: Some("private".to_owned()),
+            },
+            text: Some("hello".to_owned()),
+            message_thread_id: Some(55),
+            is_topic_message: Some(true),
+            reply_to_message: None,
+        };
+        assert_eq!(
+            resolve_message_target(&msg, &session, &routes, &topic_bindings, now),
+            Some((7, 8))
+        );
+    }
+}

--- a/crates/luban_server/tests/contracts_ws_events_telegram.rs
+++ b/crates/luban_server/tests/contracts_ws_events_telegram.rs
@@ -1,0 +1,222 @@
+use axum::Json;
+use futures::{SinkExt as _, StreamExt as _};
+use serde_json::json;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tokio_tungstenite::tungstenite::Message;
+
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn lock(keys: Vec<&'static str>) -> Self {
+        let lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let mut prev = Vec::with_capacity(keys.len());
+        for key in keys {
+            prev.push((key, std::env::var_os(key)));
+        }
+        Self { _lock: lock, prev }
+    }
+
+    fn set_str(&self, key: &'static str, value: &str) {
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prev) in self.prev.drain(..) {
+            if let Some(prev) = prev {
+                unsafe {
+                    std::env::set_var(key, prev);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+        }
+    }
+}
+
+async fn recv_ws_msg(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    timeout: Duration,
+) -> luban_api::WsServerMessage {
+    let next = tokio::time::timeout(timeout, socket.next())
+        .await
+        .expect("timed out waiting for ws message")
+        .expect("websocket stream ended")
+        .expect("websocket recv failed");
+    let Message::Text(text) = next else {
+        panic!("expected text ws message");
+    };
+    serde_json::from_str(&text).expect("failed to parse ws server message")
+}
+
+async fn start_fake_telegram_api(username: &'static str) -> (String, oneshot::Sender<()>) {
+    let app = axum::Router::new()
+        .route(
+            "/{bot}/getMe",
+            axum::routing::get(move || async move {
+                Json(json!({
+                    "ok": true,
+                    "result": { "username": username },
+                }))
+            }),
+        )
+        .route(
+            "/{bot}/getUpdates",
+            axum::routing::get(|| async move {
+                Json(json!({
+                    "ok": true,
+                    "result": [],
+                }))
+            }),
+        )
+        .route(
+            "/{bot}/sendMessage",
+            axum::routing::post(|| async move {
+                Json(json!({
+                    "ok": true,
+                    "result": { "message_id": 1 },
+                }))
+            }),
+        )
+        .route(
+            "/{bot}/answerCallbackQuery",
+            axum::routing::post(|| async move { Json(json!({ "ok": true, "result": true })) }),
+        );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake telegram api");
+    let addr = listener.local_addr().expect("get addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        });
+        let _ = server.await;
+    });
+
+    (format!("http://{addr}"), shutdown_tx)
+}
+
+#[tokio::test]
+async fn ws_events_telegram_pair_start_emits_pair_ready() {
+    let (api_base, shutdown) = start_fake_telegram_api("TestBot").await;
+    let env = EnvGuard::lock(vec!["LUBAN_TELEGRAM_API_BASE_URL"]);
+    env.set_str("LUBAN_TELEGRAM_API_BASE_URL", &api_base);
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let server =
+        luban_server::start_server_with_config(addr, luban_server::ServerConfig::default())
+            .await
+            .unwrap();
+
+    let url = format!("ws://{}/api/events", server.addr);
+    let (mut socket, _) = tokio_tungstenite::connect_async(url)
+        .await
+        .expect("connect websocket");
+
+    let first = recv_ws_msg(&mut socket, Duration::from_secs(2)).await;
+    assert!(matches!(first, luban_api::WsServerMessage::Hello { .. }));
+
+    let hello = luban_api::WsClientMessage::Hello {
+        protocol_version: luban_api::PROTOCOL_VERSION,
+        last_seen_rev: None,
+    };
+    socket
+        .send(Message::Text(
+            serde_json::to_string(&hello)
+                .expect("serialize hello")
+                .into(),
+        ))
+        .await
+        .expect("send hello");
+
+    let action = luban_api::WsClientMessage::Action {
+        request_id: "req-telegram-token".to_owned(),
+        action: Box::new(luban_api::ClientAction::TelegramBotTokenSet {
+            token: "test-token".to_owned(),
+        }),
+    };
+    socket
+        .send(Message::Text(
+            serde_json::to_string(&action)
+                .expect("serialize telegram token set")
+                .into(),
+        ))
+        .await
+        .expect("send telegram token set");
+
+    let mut saw_token_ack = false;
+    for _ in 0..50 {
+        let msg = recv_ws_msg(&mut socket, Duration::from_secs(2)).await;
+        if let luban_api::WsServerMessage::Ack { request_id, .. } = msg
+            && request_id == "req-telegram-token"
+        {
+            saw_token_ack = true;
+            break;
+        }
+    }
+    assert!(saw_token_ack, "expected ack for TelegramBotTokenSet");
+
+    let action = luban_api::WsClientMessage::Action {
+        request_id: "req-telegram-pair".to_owned(),
+        action: Box::new(luban_api::ClientAction::TelegramPairStart),
+    };
+    socket
+        .send(Message::Text(
+            serde_json::to_string(&action)
+                .expect("serialize telegram pair start")
+                .into(),
+        ))
+        .await
+        .expect("send telegram pair start");
+
+    let mut saw_ack = false;
+    let mut saw_ready = false;
+    for _ in 0..80 {
+        let msg = recv_ws_msg(&mut socket, Duration::from_secs(2)).await;
+        match msg {
+            luban_api::WsServerMessage::Ack { request_id, .. } => {
+                if request_id == "req-telegram-pair" {
+                    saw_ack = true;
+                }
+            }
+            luban_api::WsServerMessage::Event { event, .. } => {
+                if let luban_api::ServerEvent::TelegramPairReady { request_id, url } = *event
+                    && request_id == "req-telegram-pair"
+                {
+                    let prefix = "https://t.me/TestBot?start=";
+                    assert!(url.starts_with(prefix));
+                    let code = &url[prefix.len()..];
+                    assert_eq!(code.len(), 32);
+                    assert!(code.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')));
+                    saw_ready = true;
+                }
+            }
+            _ => {}
+        }
+        if saw_ack && saw_ready {
+            break;
+        }
+    }
+
+    assert!(saw_ack, "expected ack for TelegramPairStart");
+    assert!(saw_ready, "expected TelegramPairReady event");
+
+    let _ = shutdown.send(());
+    drop(env);
+}

--- a/docs/contracts/features/c-http-app.md
+++ b/docs/contracts/features/c-http-app.md
@@ -35,6 +35,12 @@ This includes Agent settings:
 - `agent.default_runner` / `agent.amp_mode`
 - `agent.default_model_id` / `agent.default_thinking_effort`
 
+This includes integration status:
+
+- `integrations.telegram.enabled` / `integrations.telegram.has_token`
+- `integrations.telegram.bot_username` / `integrations.telegram.paired_chat_id`
+- `integrations.telegram.config_rev` / `integrations.telegram.last_error`
+
 ## Response
 
 - `200 OK`
@@ -44,6 +50,7 @@ This includes Agent settings:
 
 - The response must be valid JSON and deserializable into `AppSnapshot`.
 - `rev` must be monotonically increasing over time (within a single server instance).
+- The provider must not include Telegram bot tokens in `AppSnapshot`.
 
 ## Web usage
 

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -97,6 +97,10 @@ update this section.
 - `AddProject`
 - `AddProjectAndOpen`
 - `TaskExecute`
+- `TelegramBotTokenSet`
+- `TelegramBotTokenClear`
+- `TelegramPairStart`
+- `TelegramUnpair`
 - `TaskStarSet`
 - `TaskStatusSet`
 - `FeedbackSubmit`
@@ -178,6 +182,7 @@ update this section.
 All `ServerEvent` variants are part of this contract surface:
 
 - `AppChanged`
+- `TelegramPairReady`
 - `TaskSummariesChanged`
 - `WorkdirTasksChanged`
 - `ConversationChanged`

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -57,6 +57,7 @@ Legend:
 - `C-WS-EVENTS`: `ClientAction::TaskPreview` and `ServerEvent::TaskPreviewReady` were removed; task execution is prompt-based.
 - `C-WS-EVENTS`: `ClientAction::TaskStarSet` is implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_http.rs` (roundtrip: WS toggle then `GET /api/tasks`).
 - `C-WS-EVENTS`: `ClientAction::TaskStatusSet` updates per-task `TaskStatus` and is implemented in mock + provider.
+- `C-WS-EVENTS`: Telegram integration actions (`TelegramBotTokenSet` / `TelegramBotTokenClear` / `TelegramPairStart` / `TelegramUnpair`) are implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_ws_events_telegram.rs`.
 - `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.

--- a/web/lib/luban-actions.ts
+++ b/web/lib/luban-actions.ts
@@ -49,6 +49,10 @@ export type LubanActions = {
   setClaudeEnabled: (enabled: boolean) => void
   setAgentRunner: (runner: AgentRunnerKind) => void
   setAgentAmpMode: (mode: string) => void
+  setTelegramBotToken: (token: string) => void
+  clearTelegramBotToken: () => void
+  startTelegramPairing: () => Promise<string>
+  unpairTelegram: () => void
   setTaskPromptTemplate: (intentKind: TaskIntentKind, template: string) => void
   setSystemPromptTemplate: (kind: SystemTaskKind, template: string) => void
   checkCodex: () => Promise<{ ok: boolean; message: string | null }>
@@ -225,6 +229,24 @@ export function createLubanActions(args: {
 
   function setAgentAmpMode(mode: string) {
     args.sendAction({ type: "agent_amp_mode_changed", mode })
+  }
+
+  function setTelegramBotToken(token: string) {
+    const trimmed = token.trim()
+    if (!trimmed) return
+    args.sendAction({ type: "telegram_bot_token_set", token: trimmed })
+  }
+
+  function clearTelegramBotToken() {
+    args.sendAction({ type: "telegram_bot_token_clear" })
+  }
+
+  function startTelegramPairing(): Promise<string> {
+    return args.request<string>({ type: "telegram_pair_start" })
+  }
+
+  function unpairTelegram() {
+    args.sendAction({ type: "telegram_unpair" })
   }
 
   function setTaskPromptTemplate(intentKind: TaskIntentKind, template: string) {
@@ -849,6 +871,10 @@ export function createLubanActions(args: {
     setClaudeEnabled,
     setAgentRunner,
     setAgentAmpMode,
+    setTelegramBotToken,
+    clearTelegramBotToken,
+    startTelegramPairing,
+    unpairTelegram,
     setTaskPromptTemplate,
     setSystemPromptTemplate,
     checkCodex,

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -54,6 +54,19 @@ export type TaskSettingsSnapshot = {
   default_system_prompt_templates: SystemPromptTemplateSnapshot[]
 }
 
+export type TelegramIntegrationSnapshot = {
+  enabled: boolean
+  has_token: boolean
+  bot_username?: string
+  paired_chat_id?: number
+  config_rev: number
+  last_error?: string
+}
+
+export type IntegrationsSnapshot = {
+  telegram: TelegramIntegrationSnapshot
+}
+
 export type AppSnapshot = {
   rev: number
   projects: ProjectSnapshot[]
@@ -61,6 +74,7 @@ export type AppSnapshot = {
   agent: AgentSettingsSnapshot
   task: TaskSettingsSnapshot
   ui: UiSnapshot
+  integrations: IntegrationsSnapshot
 }
 
 export type UiSnapshot = {
@@ -376,6 +390,10 @@ export type ClientAction =
       workdir_id: WorkspaceId
       attachments?: AttachmentRef[]
     }
+  | { type: "telegram_bot_token_set"; token: string }
+  | { type: "telegram_bot_token_clear" }
+  | { type: "telegram_pair_start" }
+  | { type: "telegram_unpair" }
   | { type: "task_star_set"; workdir_id: WorkspaceId; task_id: WorkspaceThreadId; starred: boolean }
   | { type: "task_status_set"; workdir_id: WorkspaceId; task_id: WorkspaceThreadId; task_status: TaskStatus }
   | {
@@ -487,6 +505,7 @@ export type ClientAction =
 
 export type ServerEvent =
   | { type: "app_changed"; rev: number; snapshot: AppSnapshot }
+  | { type: "telegram_pair_ready"; request_id: string; url: string }
   | { type: "task_summaries_changed"; project_id: ProjectId; workdir_id: WorkspaceId; tasks: TaskSummarySnapshot[] }
   | { type: "workdir_tasks_changed"; workdir_id: WorkspaceId; tabs: WorkspaceTabsSnapshot; tasks: ThreadMeta[] }
   | { type: "conversation_changed"; snapshot: ConversationSnapshot }

--- a/web/lib/luban-context.tsx
+++ b/web/lib/luban-context.tsx
@@ -150,6 +150,10 @@ type LubanContextValue = {
   setClaudeEnabled: (enabled: boolean) => void
   setAgentRunner: (runner: AgentRunnerKind) => void
   setAgentAmpMode: (mode: string) => void
+  setTelegramBotToken: (token: string) => void
+  clearTelegramBotToken: () => void
+  startTelegramPairing: () => Promise<string>
+  unpairTelegram: () => void
   setTaskPromptTemplate: (intentKind: TaskIntentKind, template: string) => void
   setSystemPromptTemplate: (kind: SystemTaskKind, template: string) => void
   checkCodex: () => Promise<{ ok: boolean; message: string | null }>
@@ -434,6 +438,10 @@ export function LubanProvider({ children }: { children: React.ReactNode }) {
     setClaudeEnabled: actions.setClaudeEnabled,
     setAgentRunner: actions.setAgentRunner,
     setAgentAmpMode: actions.setAgentAmpMode,
+    setTelegramBotToken: actions.setTelegramBotToken,
+    clearTelegramBotToken: actions.clearTelegramBotToken,
+    startTelegramPairing: actions.startTelegramPairing,
+    unpairTelegram: actions.unpairTelegram,
     setTaskPromptTemplate: actions.setTaskPromptTemplate,
     setSystemPromptTemplate: actions.setSystemPromptTemplate,
     checkCodex: actions.checkCodex,

--- a/web/lib/luban-transport.ts
+++ b/web/lib/luban-transport.ts
@@ -194,6 +194,7 @@ export function useLubanTransport(args: {
             event.type === "add_project_and_open_ready" ||
             event.type === "task_executed" ||
             event.type === "feedback_submitted" ||
+            event.type === "telegram_pair_ready" ||
             event.type === "codex_check_ready" ||
             event.type === "codex_config_tree_ready" ||
             event.type === "codex_config_list_dir_ready" ||
@@ -218,6 +219,7 @@ export function useLubanTransport(args: {
                 pending.resolve({ projectId: event.project_id, workdirId: event.workdir_id })
               if (event.type === "task_executed") pending.resolve(event.result)
               if (event.type === "feedback_submitted") pending.resolve(event.result)
+              if (event.type === "telegram_pair_ready") pending.resolve(event.url)
               if (event.type === "codex_check_ready") pending.resolve({ ok: event.ok, message: event.message })
               if (event.type === "codex_config_tree_ready") pending.resolve(event.tree)
               if (event.type === "codex_config_list_dir_ready")

--- a/web/lib/mock/fixtures.ts
+++ b/web/lib/mock/fixtures.ts
@@ -392,6 +392,13 @@ export function defaultMockFixtures(): MockFixtures {
       active_task_id: task1,
       open_button_selection: "vscode",
     },
+    integrations: {
+      telegram: {
+        enabled: false,
+        has_token: false,
+        config_rev: 0,
+      },
+    },
   }
 
   const tabs1: WorkspaceTabsSnapshot = { open_tabs: [task1, task9, task7, task4, task2, task8, task5, task6], archived_tabs: [], active_tab: task1 }

--- a/web/lib/mock/mock-runtime.ts
+++ b/web/lib/mock/mock-runtime.ts
@@ -392,6 +392,55 @@ export function mockDispatchAction(args: { action: ClientAction; onEvent: (event
   const state = getRuntime()
   const a = args.action
 
+  if (a.type === "telegram_bot_token_set") {
+    const prev = state.app.integrations?.telegram ?? { enabled: false, has_token: false, config_rev: 0 }
+    state.app.integrations = {
+      ...(state.app.integrations ?? { telegram: prev }),
+      telegram: {
+        ...prev,
+        enabled: true,
+        has_token: true,
+        bot_username: "mock_bot",
+        config_rev: (prev.config_rev ?? 0) + 1,
+        last_error: undefined,
+      },
+    }
+    emitAppChanged({ state, onEvent: args.onEvent })
+    return
+  }
+
+  if (a.type === "telegram_bot_token_clear") {
+    const prev = state.app.integrations?.telegram ?? { enabled: false, has_token: false, config_rev: 0 }
+    state.app.integrations = {
+      ...(state.app.integrations ?? { telegram: prev }),
+      telegram: {
+        ...prev,
+        enabled: false,
+        has_token: false,
+        bot_username: undefined,
+        paired_chat_id: undefined,
+        config_rev: (prev.config_rev ?? 0) + 1,
+        last_error: undefined,
+      },
+    }
+    emitAppChanged({ state, onEvent: args.onEvent })
+    return
+  }
+
+  if (a.type === "telegram_unpair") {
+    const prev = state.app.integrations?.telegram ?? { enabled: false, has_token: false, config_rev: 0 }
+    state.app.integrations = {
+      ...(state.app.integrations ?? { telegram: prev }),
+      telegram: {
+        ...prev,
+        paired_chat_id: undefined,
+        config_rev: (prev.config_rev ?? 0) + 1,
+      },
+    }
+    emitAppChanged({ state, onEvent: args.onEvent })
+    return
+  }
+
   if (a.type === "add_project") {
     const projectId: ProjectId = `mock_project_${Math.random().toString(16).slice(2)}`
     state.app.projects.push({
@@ -830,6 +879,11 @@ export async function mockRequest<T>(action: ClientAction): Promise<T> {
     }
 
     return clone(result) as unknown as T
+  }
+
+  if (action.type === "telegram_pair_start") {
+    const username = state.app.integrations?.telegram?.bot_username ?? "mock_bot"
+    return `https://t.me/${username}?start=mock_pairing_code` as unknown as T
   }
 
   if (action.type === "feedback_submit") {

--- a/web/tests/ui/scenarios/settings-panel.mjs
+++ b/web/tests/ui/scenarios/settings-panel.mjs
@@ -2,6 +2,19 @@ export async function runSettingsPanel({ page }) {
   await page.getByTestId('workspace-switcher-button').click();
   await page.getByTestId('open-settings-button').click();
   await page.getByTestId('settings-panel').waitFor({ state: 'visible' });
+
+  await page.getByRole('button', { name: 'Integrations' }).click();
+  await page.getByRole('button', { name: 'Telegram' }).click();
+
+  await page.getByTestId('telegram-bot-token-input').fill('mock_token');
+  await page.getByTestId('telegram-bot-token-save').click();
+
+  await page.getByTestId('telegram-pair-generate').click();
+  const url = (await page.getByTestId('telegram-pair-url').inputValue()).trim();
+  if (!url.startsWith('https://t.me/')) {
+    throw new Error(`expected telegram pair url to start with https://t.me/, got "${url}"`);
+  }
+
   await page.getByRole('button', { name: 'Back' }).click();
   await page.getByTestId('settings-panel').waitFor({ state: 'hidden' });
 }


### PR DESCRIPTION
## User-visible changes
- Adds Telegram bot integration for private chats (reply keyboard navigation + task push updates).
- Adds per-task comment entry via inline button.
- Adds web UI settings to configure Telegram bot token and related settings.

## Contracts
- Updated: `docs/contracts/features/c-http-app.md`, `docs/contracts/features/c-ws-events.md`.
- Progress: `docs/contracts/progress.md`.
- Provider verification: `crates/luban_server/tests/contracts_ws_events_telegram.rs`.

## Verification
- `just fmt && just lint && just test`

## Manual checks
1. Configure Telegram settings in the web UI.
2. Start the Telegram bot and open a private chat.
3. Verify the reply keyboard appears and navigation works.
4. Create/complete a task and verify push notifications arrive.
5. Use the comment button to post a comment to a specific task.

## Risks / rollback
- Risk: Telegram delivery/dedup behavior may differ across clients; revert this PR to disable the feature.
