### PR TITLE
Add task archive view and auto-prune archived tasks

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -824,6 +824,17 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         Ok(snapshot)
     }
 
+    fn delete_conversation_thread(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+        thread_id: u64,
+    ) -> Result<(), String> {
+        self.sqlite
+            .delete_conversation_thread(project_slug, workspace_name, thread_id)
+            .map_err(anyhow_error_to_string)
+    }
+
     fn save_conversation_queue_state(
         &self,
         project_slug: String,

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -268,6 +268,15 @@ pub enum Action {
         workspace_id: WorkspaceId,
         message: String,
     },
+    /// Internal maintenance action: remove local UI state for deleted threads.
+    ///
+    /// This does not delete persisted conversation data by itself; callers are expected to
+    /// delete the thread from persistence first, then dispatch this to drop any in-memory and
+    /// UI references.
+    WorkspaceThreadsPurged {
+        workspace_id: WorkspaceId,
+        thread_ids: Vec<WorkspaceThreadId>,
+    },
 
     ToggleTerminalPane,
     TerminalPaneWidthChanged {

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -292,6 +292,15 @@ pub trait ProjectWorkspaceService: Send + Sync {
         limit: u64,
     ) -> Result<ConversationSnapshot, String>;
 
+    fn delete_conversation_thread(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+        _thread_id: u64,
+    ) -> Result<(), String> {
+        Err("unimplemented".to_owned())
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn save_conversation_queue_state(
         &self,

--- a/crates/luban_domain/src/state/tabs.rs
+++ b/crates/luban_domain/src/state/tabs.rs
@@ -101,6 +101,21 @@ impl WorkspaceTabs {
         self.open_tabs.insert(target, tab);
         true
     }
+
+    pub fn remove_thread(&mut self, thread_id: WorkspaceThreadId) {
+        let was_active = self.active_tab == thread_id;
+        self.remove_open(thread_id);
+        self.remove_archived(thread_id);
+
+        if was_active {
+            if let Some(next) = self.open_tabs.first().copied() {
+                self.active_tab = next;
+            } else if let Some(next) = self.archived_tabs.first().copied() {
+                self.active_tab = next;
+                self.restore_tab(next, true);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -226,6 +226,7 @@ pub enum EngineCommand {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
     },
+    PruneArchivedTasks,
     WorkspaceThreadsInvalidated {
         workspace_id: WorkspaceId,
     },
@@ -258,6 +259,11 @@ const PULL_REQUEST_REFRESH_INTERVAL_EMPTY_MAX: Duration = Duration::from_secs(10
 
 const TASK_STATUS_AUTO_UPDATE_BACKFILL_MAX_PER_SNAPSHOT: usize = 20;
 const TASK_STATUS_AUTO_UPDATE_BACKFILL_TAIL_LIMIT: u64 = 250;
+
+const TASK_ARCHIVE_AFTER_SECONDS: u64 = 7 * 24 * 60 * 60;
+const TASK_PURGE_AFTER_SECONDS: u64 = 2 * TASK_ARCHIVE_AFTER_SECONDS;
+const TASK_PURGE_TICK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const TASK_PURGE_STARTUP_DELAY: Duration = Duration::from_secs(60);
 
 fn pull_request_refresh_jitter(workspace_id: WorkspaceId) -> Duration {
     let window = PULL_REQUEST_REFRESH_JITTER_WINDOW_SECS.max(1);
@@ -494,6 +500,17 @@ impl Engine {
             }
         });
 
+        let purge_tx = tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(TASK_PURGE_STARTUP_DELAY).await;
+            let mut interval = tokio::time::interval(TASK_PURGE_TICK_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                let _ = purge_tx.send(EngineCommand::PruneArchivedTasks).await;
+            }
+        });
+
         tokio::spawn(async move {
             engine.bootstrap().await;
             while let Some(cmd) = rx.recv().await {
@@ -506,6 +523,108 @@ impl Engine {
 
     async fn bootstrap(&mut self) {
         self.process_action_queue(Action::AppStarted).await;
+    }
+
+    async fn prune_archived_tasks(&mut self) {
+        let now = now_unix_seconds();
+        let purge_cutoff = now.saturating_sub(TASK_PURGE_AFTER_SECONDS);
+
+        let mut workspaces = Vec::new();
+        for project in &self.state.projects {
+            for workspace in &project.workspaces {
+                let is_main = workspace.workspace_name == "main";
+                workspaces.push((
+                    project.is_git,
+                    is_main,
+                    workspace.status,
+                    workspace.id,
+                    WorkspaceScope {
+                        project_slug: project.slug.clone(),
+                        workspace_name: workspace.workspace_name.clone(),
+                    },
+                ));
+            }
+        }
+
+        for (project_is_git, workspace_is_main, workspace_status, workspace_id, scope) in workspaces
+        {
+            let services = self.services.clone();
+            let project_slug = scope.project_slug.clone();
+            let workspace_name = scope.workspace_name.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let threads = services
+                    .list_conversation_threads(project_slug.clone(), workspace_name.clone())?;
+                let purge_candidates = threads
+                    .iter()
+                    .filter(|t| {
+                        matches!(
+                            t.task_status,
+                            luban_domain::TaskStatus::Done | luban_domain::TaskStatus::Canceled
+                        ) && t.updated_at_unix_seconds <= purge_cutoff
+                            && t.turn_status == luban_domain::TurnStatus::Idle
+                    })
+                    .map(|t| t.thread_id)
+                    .collect::<Vec<_>>();
+
+                if purge_candidates.is_empty() {
+                    return Ok((Vec::new(), threads));
+                }
+
+                let mut deleted = Vec::new();
+                for thread_id in purge_candidates {
+                    if services
+                        .delete_conversation_thread(
+                            project_slug.clone(),
+                            workspace_name.clone(),
+                            thread_id.as_u64(),
+                        )
+                        .is_ok()
+                    {
+                        deleted.push(thread_id);
+                    }
+                }
+
+                let remaining = services.list_conversation_threads(project_slug, workspace_name)?;
+                Ok((deleted, remaining))
+            })
+            .await
+            .ok()
+            .unwrap_or_else(|| Err("failed to join archived task prune task".to_owned()));
+
+            let Ok((deleted_thread_ids, remaining_threads)) = result else {
+                continue;
+            };
+            if deleted_thread_ids.is_empty() {
+                continue;
+            }
+
+            tracing::info!(
+                workspace_id = workspace_id.as_u64(),
+                deleted = deleted_thread_ids.len(),
+                "pruned archived tasks"
+            );
+
+            self.process_action_queue(Action::WorkspaceThreadsPurged {
+                workspace_id,
+                thread_ids: deleted_thread_ids,
+            })
+            .await;
+            let workspace_empty = remaining_threads.is_empty();
+            self.process_action_queue(Action::WorkspaceThreadsLoaded {
+                workspace_id,
+                threads: remaining_threads,
+            })
+            .await;
+
+            if workspace_empty
+                && project_is_git
+                && !workspace_is_main
+                && workspace_status == luban_domain::WorkspaceStatus::Active
+            {
+                self.process_action_queue(Action::ArchiveWorkspace { workspace_id })
+                    .await;
+            }
+        }
     }
 
     async fn telegram_pair_start(&mut self, request_id: String) -> Result<(), String> {
@@ -1990,6 +2109,9 @@ impl Engine {
             } => {
                 self.task_status_auto_update_backfill_in_flight
                     .remove(&(workspace_id, thread_id));
+            }
+            EngineCommand::PruneArchivedTasks => {
+                self.prune_archived_tasks().await;
             }
             EngineCommand::WorkspaceThreadsInvalidated { workspace_id } => {
                 self.workspace_threads_cache.remove(&workspace_id);
@@ -4905,6 +5027,13 @@ fn to_base36(mut n: u64) -> String {
     }
     out.reverse();
     String::from_utf8(out).unwrap_or_else(|_| "0".to_owned())
+}
+
+fn now_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn map_workspace_tabs_snapshot(tabs: &luban_domain::WorkspaceTabs) -> WorkspaceTabsSnapshot {

--- a/web/components/luban-ide.tsx
+++ b/web/components/luban-ide.tsx
@@ -118,9 +118,14 @@ export function LubanIDE() {
       )
     }
 
+    const taskListMode = activeView === "archive" ? "archive" : "active"
     return (
       <TaskListView
         activeProjectId={activeProjectId}
+        mode={taskListMode}
+        onModeChange={(mode) => {
+          setActiveView(mode === "archive" ? "archive" : "tasks")
+        }}
         onTaskClick={(task) => {
           void (async () => {
             await openWorkspace(task.workspaceId)

--- a/web/components/luban-sidebar.tsx
+++ b/web/components/luban-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Star,
   Settings,
   SquarePen,
+  MoreHorizontal,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useLuban } from "@/lib/luban-context"
@@ -108,45 +109,100 @@ interface ProjectItemProps {
   active?: boolean
   testId?: string
   onClick?: () => void
+  onOpenArchive?: () => void
 }
 
-function ProjectItem({ name, color = "bg-[#5e6ad2]", avatarUrl, active, testId, onClick }: ProjectItemProps) {
+function ProjectItem({
+  name,
+  color = "bg-[#5e6ad2]",
+  avatarUrl,
+  active,
+  testId,
+  onClick,
+  onOpenArchive,
+}: ProjectItemProps) {
   const [avatarLoadFailed, setAvatarLoadFailed] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     setAvatarLoadFailed(false)
   }, [avatarUrl])
 
   return (
-    <button
-      data-testid={testId}
-      onClick={onClick}
+    <div
       className={cn(
-        "w-full flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors",
-        active ? "bg-[#e8e8e8]" : "hover:bg-[#eeeeee]"
+        "group w-full flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors",
+        active ? "bg-[#e8e8e8]" : "hover:bg-[#eeeeee]",
       )}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenuOpen(true)
+      }}
     >
-      {avatarUrl && !avatarLoadFailed ? (
-        <img
-          src={avatarUrl}
-          alt=""
-          width={18}
-          height={18}
-          className="w-[18px] h-[18px] rounded overflow-hidden flex-shrink-0"
-          onError={() => setAvatarLoadFailed(true)}
-        />
-      ) : (
-        <span
-          className={cn(
-            "w-[18px] h-[18px] rounded flex items-center justify-center text-[10px] font-semibold text-white flex-shrink-0",
-            color
-          )}
-        >
-          {name.charAt(0).toUpperCase()}
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={onClick}
+        className="flex-1 min-w-0 flex items-center gap-2 outline-none"
+      >
+        {avatarUrl && !avatarLoadFailed ? (
+          <img
+            src={avatarUrl}
+            alt=""
+            width={18}
+            height={18}
+            className="w-[18px] h-[18px] rounded overflow-hidden flex-shrink-0"
+            onError={() => setAvatarLoadFailed(true)}
+          />
+        ) : (
+          <span
+            className={cn(
+              "w-[18px] h-[18px] rounded flex items-center justify-center text-[10px] font-semibold text-white flex-shrink-0",
+              color,
+            )}
+          >
+            {name.charAt(0).toUpperCase()}
+          </span>
+        )}
+        <span className="text-[13px] truncate" style={{ color: "#1b1b1b" }}>
+          {name}
         </span>
-      )}
-      <span className="text-[13px] truncate" style={{ color: '#1b1b1b' }}>{name}</span>
-    </button>
+      </button>
+
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="p-1 rounded hover:bg-[#e8e8e8] transition-colors opacity-60 hover:opacity-100"
+            style={{ color: "#9b9b9b" }}
+            title="Project menu"
+            data-testid={testId ? `${testId}-menu` : undefined}
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+            onPointerDown={(e) => {
+              e.stopPropagation()
+            }}
+          >
+            <MoreHorizontal className="w-4 h-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          sideOffset={6}
+          className="w-[200px] rounded-lg border-[#e5e5e5] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.12)] p-1.5"
+        >
+          <DropdownMenuItem
+            onClick={() => onOpenArchive?.()}
+            className="flex items-center gap-2.5 px-2.5 py-2 text-[13px] rounded-md cursor-pointer hover:bg-[#f5f5f5] focus:bg-[#f5f5f5]"
+            style={{ color: "#1b1b1b" }}
+            data-testid={testId ? `${testId}-open-archive` : undefined}
+          >
+            Open Archive
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }
 
@@ -324,6 +380,10 @@ export function LubanSidebar({
                   onClick={() => {
                     onProjectSelected?.(p.id)
                     onViewChange?.("tasks")
+                  }}
+                  onOpenArchive={() => {
+                    onProjectSelected?.(p.id)
+                    onViewChange?.("archive")
                   }}
                 />
               </div>

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -29,6 +29,7 @@ import { runTaskListNavigation } from './scenarios/task-list-navigation.mjs';
 import { runTaskSummariesEventsRefresh } from './scenarios/task-summaries-events-refresh.mjs';
 import { runQueuedPrompts } from './scenarios/queued-prompts.mjs';
 import { runRightSidebarNoContextTab } from './scenarios/right-sidebar-no-context-tab.mjs';
+import { runProjectArchiveMenu } from './scenarios/project-archive-menu.mjs';
 
 async function canRun(command, args) {
   const proc = spawn(command, args, { stdio: 'ignore' });
@@ -156,6 +157,7 @@ async function main() {
 	    await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
 	
 	    await runSidebarProjectAvatars({ page, baseUrl });
+      await runProjectArchiveMenu({ page, baseUrl });
 	    await runNewTaskModal({ page, baseUrl });
 	    await runNewTaskProjectAvatars({ page, baseUrl });
 	    await runNewTaskGitProjectWithoutWorkdirs({ page, baseUrl });

--- a/web/tests/ui/scenarios/project-archive-menu.mjs
+++ b/web/tests/ui/scenarios/project-archive-menu.mjs
@@ -1,0 +1,26 @@
+export async function runProjectArchiveMenu({ page }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const archivedTaskTitle = 'Done: completed successfully';
+  if ((await page.getByText(archivedTaskTitle).count()) !== 0) {
+    throw new Error('expected archived tasks not to appear in active view');
+  }
+
+  await page.getByTestId('sidebar-project-mock-project-1-menu').click();
+  await page.getByTestId('sidebar-project-mock-project-1-open-archive').click();
+
+  await page.getByTestId('task-view-tab-archive').waitFor({ state: 'visible' });
+
+  const row = page.getByText(archivedTaskTitle).first();
+  await row.waitFor({ state: 'attached' });
+  await row.scrollIntoViewIfNeeded();
+  await row.waitFor({ state: 'visible' });
+
+  await page.getByTestId('task-view-tab-active').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  if ((await page.getByText(archivedTaskTitle).count()) !== 0) {
+    throw new Error('expected archived tasks not to appear after switching back to active view');
+  }
+}


### PR DESCRIPTION
## What
- UI: Add project context menu entry "Open Archive" and an archive view for tasks.
- Server: Periodically prune archived idle tasks older than 14 days; if a pruned workspace becomes empty and is a non-main git workspace, archive the workspace (worktree removal is forced).
- Backend: Add adapter + SQLite support to delete a conversation thread.

## Behavior changes
- Tasks in Done/Canceled that haven't been updated for 7+ days are shown in Archive (UI-derived, no API change).
- Archived tasks older than an additional 7 days (14+ days total) are auto-pruned server-side (conversation data removed).

## Verification
- `just fmt && just lint && just test`
- `LUBAN_AGENT_BROWSER_PORT=4011 just test-ui`

## Risk / Rollback
- Pruning deletes conversation data in SQLite.
- Worktree removal uses `git worktree remove --force`; uncommitted changes may be lost.
- Rollback: disable/adjust maintenance tick or revert this PR.
