### PR TITLE
Persist new-task drafts and composer stash

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -687,6 +687,37 @@ pub struct ContextSnapshot {
     pub items: Vec<ContextItemSnapshot>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewTaskDraftSnapshot {
+    pub id: String,
+    pub text: String,
+    pub project_id: Option<ProjectId>,
+    #[serde(rename = "workdir_id", alias = "workspace_id")]
+    pub workspace_id: Option<WorkspaceId>,
+    pub created_at_unix_ms: u64,
+    pub updated_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewTaskDraftsSnapshot {
+    pub drafts: Vec<NewTaskDraftSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewTaskStashSnapshot {
+    pub text: String,
+    pub project_id: Option<ProjectId>,
+    #[serde(rename = "workdir_id", alias = "workspace_id")]
+    pub workspace_id: Option<WorkspaceId>,
+    pub editing_draft_id: Option<String>,
+    pub updated_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewTaskStashResponse {
+    pub stash: Option<NewTaskStashSnapshot>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MentionItemKind {

--- a/crates/luban_backend/migrations/0022_new_task_drafts.sql
+++ b/crates/luban_backend/migrations/0022_new_task_drafts.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE new_task_drafts (
+  id             TEXT PRIMARY KEY,
+  text           TEXT NOT NULL,
+  project_id     TEXT,
+  workspace_id   INTEGER,
+  created_at_ms  INTEGER NOT NULL,
+  updated_at_ms  INTEGER NOT NULL
+);
+
+CREATE INDEX new_task_drafts_updated_at
+  ON new_task_drafts(updated_at_ms DESC, created_at_ms DESC, id DESC);
+
+CREATE TABLE new_task_stash (
+  id             INTEGER PRIMARY KEY CHECK (id = 1),
+  text           TEXT NOT NULL,
+  project_id     TEXT,
+  workspace_id   INTEGER,
+  editing_draft_id TEXT,
+  updated_at_ms  INTEGER NOT NULL
+);
+

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1042,6 +1042,59 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(anyhow_error_to_string)
     }
 
+    fn list_new_task_drafts(&self) -> Result<Vec<luban_domain::NewTaskDraft>, String> {
+        self.sqlite
+            .list_new_task_drafts()
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn create_new_task_draft(
+        &self,
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+    ) -> Result<luban_domain::NewTaskDraft, String> {
+        self.sqlite
+            .create_new_task_draft(text, project_id, workspace_id)
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn update_new_task_draft(
+        &self,
+        draft_id: String,
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+    ) -> Result<luban_domain::NewTaskDraft, String> {
+        self.sqlite
+            .update_new_task_draft(draft_id, text, project_id, workspace_id)
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn delete_new_task_draft(&self, draft_id: String) -> Result<(), String> {
+        self.sqlite
+            .delete_new_task_draft(draft_id)
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn load_new_task_stash(&self) -> Result<Option<luban_domain::NewTaskStash>, String> {
+        self.sqlite
+            .load_new_task_stash()
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn save_new_task_stash(&self, stash: luban_domain::NewTaskStash) -> Result<(), String> {
+        self.sqlite
+            .save_new_task_stash(stash)
+            .map_err(anyhow_error_to_string)
+    }
+
+    fn clear_new_task_stash(&self) -> Result<(), String> {
+        self.sqlite
+            .clear_new_task_stash()
+            .map_err(anyhow_error_to_string)
+    }
+
     fn run_agent_turn_streamed(
         &self,
         request: RunAgentTurnRequest,

--- a/crates/luban_backend/src/sqlite_store.rs
+++ b/crates/luban_backend/src/sqlite_store.rs
@@ -4,6 +4,7 @@ use luban_domain::{
     ConversationSnapshot, ConversationThreadMeta, PersistedAppState, QueuedPrompt, ThinkingEffort,
     WorkspaceStatus, WorkspaceThreadId,
 };
+use rand::{RngCore as _, rngs::OsRng};
 use rusqlite::{Connection, OptionalExtension as _, params, params_from_iter};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -24,7 +25,7 @@ impl std::fmt::Display for SqliteStoreError {
 
 impl std::error::Error for SqliteStoreError {}
 
-const LATEST_SCHEMA_VERSION: u32 = 21;
+const LATEST_SCHEMA_VERSION: u32 = 22;
 const WORKSPACE_CHAT_SCROLL_PREFIX: &str = "workspace_chat_scroll_y10_";
 const WORKSPACE_CHAT_SCROLL_ANCHOR_PREFIX: &str = "workspace_chat_scroll_anchor_";
 const WORKSPACE_ACTIVE_THREAD_PREFIX: &str = "workspace_active_thread_id_";
@@ -205,6 +206,13 @@ const MIGRATIONS: &[(u32, &str)] = &[
             "/migrations/0021_cleanup_autocreated_thread1.sql"
         )),
     ),
+    (
+        22,
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/migrations/0022_new_task_drafts.sql"
+        )),
+    ),
 ];
 
 #[derive(Clone)]
@@ -365,6 +373,36 @@ enum DbCommand {
         project_slug: String,
         workspace_name: String,
         context_id: u64,
+        reply: mpsc::Sender<anyhow::Result<()>>,
+    },
+    ListNewTaskDrafts {
+        reply: mpsc::Sender<anyhow::Result<Vec<luban_domain::NewTaskDraft>>>,
+    },
+    CreateNewTaskDraft {
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+        reply: mpsc::Sender<anyhow::Result<luban_domain::NewTaskDraft>>,
+    },
+    UpdateNewTaskDraft {
+        draft_id: String,
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+        reply: mpsc::Sender<anyhow::Result<luban_domain::NewTaskDraft>>,
+    },
+    DeleteNewTaskDraft {
+        draft_id: String,
+        reply: mpsc::Sender<anyhow::Result<()>>,
+    },
+    LoadNewTaskStash {
+        reply: mpsc::Sender<anyhow::Result<Option<luban_domain::NewTaskStash>>>,
+    },
+    SaveNewTaskStash {
+        stash: luban_domain::NewTaskStash,
+        reply: mpsc::Sender<anyhow::Result<()>>,
+    },
+    ClearNewTaskStash {
         reply: mpsc::Sender<anyhow::Result<()>>,
     },
 }
@@ -694,6 +732,53 @@ impl SqliteStore {
                                 &workspace_name,
                                 context_id,
                             ));
+                        }
+                        (Ok(db), DbCommand::ListNewTaskDrafts { reply }) => {
+                            let _ = reply.send(db.list_new_task_drafts());
+                        }
+                        (
+                            Ok(db),
+                            DbCommand::CreateNewTaskDraft {
+                                text,
+                                project_id,
+                                workspace_id,
+                                reply,
+                            },
+                        ) => {
+                            let _ = reply.send(db.create_new_task_draft(
+                                &text,
+                                project_id.as_deref(),
+                                workspace_id,
+                            ));
+                        }
+                        (
+                            Ok(db),
+                            DbCommand::UpdateNewTaskDraft {
+                                draft_id,
+                                text,
+                                project_id,
+                                workspace_id,
+                                reply,
+                            },
+                        ) => {
+                            let _ = reply.send(db.update_new_task_draft(
+                                &draft_id,
+                                &text,
+                                project_id.as_deref(),
+                                workspace_id,
+                            ));
+                        }
+                        (Ok(db), DbCommand::DeleteNewTaskDraft { draft_id, reply }) => {
+                            let _ = reply.send(db.delete_new_task_draft(&draft_id));
+                        }
+                        (Ok(db), DbCommand::LoadNewTaskStash { reply }) => {
+                            let _ = reply.send(db.load_new_task_stash());
+                        }
+                        (Ok(db), DbCommand::SaveNewTaskStash { stash, reply }) => {
+                            let _ = reply.send(db.save_new_task_stash(&stash));
+                        }
+                        (Ok(db), DbCommand::ClearNewTaskStash { reply }) => {
+                            let _ = reply.send(db.clear_new_task_stash());
                         }
                         (Err(err), cmd) => {
                             respond_db_open_error(err, cmd);
@@ -1111,6 +1196,90 @@ impl SqliteStore {
             .context("sqlite worker is not running")?;
         reply_rx.recv().context("sqlite worker terminated")?
     }
+
+    pub fn list_new_task_drafts(&self) -> anyhow::Result<Vec<luban_domain::NewTaskDraft>> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::ListNewTaskDrafts { reply: reply_tx })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn create_new_task_draft(
+        &self,
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+    ) -> anyhow::Result<luban_domain::NewTaskDraft> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::CreateNewTaskDraft {
+                text,
+                project_id,
+                workspace_id,
+                reply: reply_tx,
+            })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn update_new_task_draft(
+        &self,
+        draft_id: String,
+        text: String,
+        project_id: Option<String>,
+        workspace_id: Option<u64>,
+    ) -> anyhow::Result<luban_domain::NewTaskDraft> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::UpdateNewTaskDraft {
+                draft_id,
+                text,
+                project_id,
+                workspace_id,
+                reply: reply_tx,
+            })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn delete_new_task_draft(&self, draft_id: String) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::DeleteNewTaskDraft {
+                draft_id,
+                reply: reply_tx,
+            })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn load_new_task_stash(&self) -> anyhow::Result<Option<luban_domain::NewTaskStash>> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::LoadNewTaskStash { reply: reply_tx })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn save_new_task_stash(&self, stash: luban_domain::NewTaskStash) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::SaveNewTaskStash {
+                stash,
+                reply: reply_tx,
+            })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
+
+    pub fn clear_new_task_stash(&self) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(DbCommand::ClearNewTaskStash { reply: reply_tx })
+            .context("sqlite worker is not running")?;
+        reply_rx.recv().context("sqlite worker terminated")?
+    }
 }
 
 fn respond_db_open_error(err: &anyhow::Error, cmd: DbCommand) {
@@ -1180,6 +1349,27 @@ fn respond_db_open_error(err: &anyhow::Error, cmd: DbCommand) {
             let _ = reply.send(Err(anyhow!(message)));
         }
         DbCommand::DeleteContextItem { reply, .. } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::ListNewTaskDrafts { reply } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::CreateNewTaskDraft { reply, .. } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::UpdateNewTaskDraft { reply, .. } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::DeleteNewTaskDraft { reply, .. } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::LoadNewTaskStash { reply } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::SaveNewTaskStash { reply, .. } => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        DbCommand::ClearNewTaskStash { reply } => {
             let _ = reply.send(Err(anyhow!(message)));
         }
     }
@@ -3720,6 +3910,196 @@ impl SqliteDatabase {
         )?;
         Ok(())
     }
+
+    fn list_new_task_drafts(&mut self) -> anyhow::Result<Vec<luban_domain::NewTaskDraft>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, text, project_id, workspace_id, created_at_ms, updated_at_ms
+             FROM new_task_drafts
+             ORDER BY updated_at_ms DESC, created_at_ms DESC, id DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let id = row.get::<_, String>(0)?;
+            let text = row.get::<_, String>(1)?;
+            let project_id = row.get::<_, Option<String>>(2)?;
+            let workspace_id = row
+                .get::<_, Option<i64>>(3)?
+                .and_then(|v| u64::try_from(v).ok());
+            let created_at_unix_ms = row.get::<_, i64>(4)? as u64;
+            let updated_at_unix_ms = row.get::<_, i64>(5)? as u64;
+            Ok(luban_domain::NewTaskDraft {
+                id,
+                text,
+                project_id,
+                workspace_id,
+                created_at_unix_ms,
+                updated_at_unix_ms,
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    fn create_new_task_draft(
+        &mut self,
+        text: &str,
+        project_id: Option<&str>,
+        workspace_id: Option<u64>,
+    ) -> anyhow::Result<luban_domain::NewTaskDraft> {
+        let now = now_unix_millis();
+        let mut bytes = [0u8; 16];
+        OsRng.fill_bytes(&mut bytes);
+        let id = hex_lower(&bytes);
+
+        self.conn.execute(
+            "INSERT INTO new_task_drafts
+             (id, text, project_id, workspace_id, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                text,
+                project_id,
+                workspace_id.map(|v| v as i64),
+                now as i64,
+                now as i64
+            ],
+        )?;
+
+        Ok(luban_domain::NewTaskDraft {
+            id,
+            text: text.to_owned(),
+            project_id: project_id.map(str::to_owned),
+            workspace_id,
+            created_at_unix_ms: now,
+            updated_at_unix_ms: now,
+        })
+    }
+
+    fn update_new_task_draft(
+        &mut self,
+        draft_id: &str,
+        text: &str,
+        project_id: Option<&str>,
+        workspace_id: Option<u64>,
+    ) -> anyhow::Result<luban_domain::NewTaskDraft> {
+        let (created_at_unix_ms,): (i64,) = self
+            .conn
+            .query_row(
+                "SELECT created_at_ms FROM new_task_drafts WHERE id = ?1",
+                params![draft_id],
+                |row| Ok((row.get::<_, i64>(0)?,)),
+            )
+            .optional()
+            .context("failed to load new task draft")?
+            .ok_or_else(|| anyhow!("draft not found"))?;
+
+        let now = now_unix_millis();
+        let updated = self.conn.execute(
+            "UPDATE new_task_drafts
+             SET text = ?2,
+                 project_id = ?3,
+                 workspace_id = ?4,
+                 updated_at_ms = ?5
+             WHERE id = ?1",
+            params![
+                draft_id,
+                text,
+                project_id,
+                workspace_id.map(|v| v as i64),
+                now as i64
+            ],
+        )?;
+
+        if updated == 0 {
+            return Err(anyhow!("draft not found"));
+        }
+
+        Ok(luban_domain::NewTaskDraft {
+            id: draft_id.to_owned(),
+            text: text.to_owned(),
+            project_id: project_id.map(str::to_owned),
+            workspace_id,
+            created_at_unix_ms: created_at_unix_ms as u64,
+            updated_at_unix_ms: now,
+        })
+    }
+
+    fn delete_new_task_draft(&mut self, draft_id: &str) -> anyhow::Result<()> {
+        self.conn.execute(
+            "DELETE FROM new_task_drafts WHERE id = ?1",
+            params![draft_id],
+        )?;
+        Ok(())
+    }
+
+    fn load_new_task_stash(&mut self) -> anyhow::Result<Option<luban_domain::NewTaskStash>> {
+        self.conn
+            .query_row(
+                "SELECT text, project_id, workspace_id, editing_draft_id, updated_at_ms
+                 FROM new_task_stash
+                 WHERE id = 1",
+                [],
+                |row| {
+                    let text = row.get::<_, String>(0)?;
+                    let project_id = row.get::<_, Option<String>>(1)?;
+                    let workspace_id = row
+                        .get::<_, Option<i64>>(2)?
+                        .and_then(|v| u64::try_from(v).ok());
+                    let editing_draft_id = row.get::<_, Option<String>>(3)?;
+                    let updated_at_unix_ms = row.get::<_, i64>(4)? as u64;
+                    Ok(luban_domain::NewTaskStash {
+                        text,
+                        project_id,
+                        workspace_id,
+                        editing_draft_id,
+                        updated_at_unix_ms,
+                    })
+                },
+            )
+            .optional()
+            .context("failed to load new task stash")
+    }
+
+    fn save_new_task_stash(&mut self, stash: &luban_domain::NewTaskStash) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO new_task_stash
+             (id, text, project_id, workspace_id, editing_draft_id, updated_at_ms)
+             VALUES (1, ?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(id) DO UPDATE SET
+                text = excluded.text,
+                project_id = excluded.project_id,
+                workspace_id = excluded.workspace_id,
+                editing_draft_id = excluded.editing_draft_id,
+                updated_at_ms = excluded.updated_at_ms",
+            params![
+                stash.text,
+                stash.project_id,
+                stash.workspace_id.map(|v| v as i64),
+                stash.editing_draft_id,
+                stash.updated_at_unix_ms as i64
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn clear_new_task_stash(&mut self) -> anyhow::Result<()> {
+        self.conn
+            .execute("DELETE FROM new_task_stash WHERE id = 1", [])?;
+        Ok(())
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn configure_connection(conn: &mut Connection) -> anyhow::Result<()> {

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -229,6 +229,25 @@ pub struct ClaudeConfigEntry {
     pub children: Vec<ClaudeConfigEntry>,
 }
 
+#[derive(Clone, Debug)]
+pub struct NewTaskDraft {
+    pub id: String,
+    pub text: String,
+    pub project_id: Option<String>,
+    pub workspace_id: Option<u64>,
+    pub created_at_unix_ms: u64,
+    pub updated_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewTaskStash {
+    pub text: String,
+    pub project_id: Option<String>,
+    pub workspace_id: Option<u64>,
+    pub editing_draft_id: Option<String>,
+    pub updated_at_unix_ms: u64,
+}
+
 pub trait ProjectWorkspaceService: Send + Sync {
     fn load_app_state(&self) -> Result<PersistedAppState, String>;
 
@@ -401,6 +420,45 @@ pub trait ProjectWorkspaceService: Send + Sync {
         workspace_name: String,
         context_id: u64,
     ) -> Result<(), String>;
+
+    fn list_new_task_drafts(&self) -> Result<Vec<NewTaskDraft>, String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn create_new_task_draft(
+        &self,
+        _text: String,
+        _project_id: Option<String>,
+        _workspace_id: Option<u64>,
+    ) -> Result<NewTaskDraft, String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn update_new_task_draft(
+        &self,
+        _draft_id: String,
+        _text: String,
+        _project_id: Option<String>,
+        _workspace_id: Option<u64>,
+    ) -> Result<NewTaskDraft, String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn delete_new_task_draft(&self, _draft_id: String) -> Result<(), String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn load_new_task_stash(&self) -> Result<Option<NewTaskStash>, String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn save_new_task_stash(&self, _stash: NewTaskStash) -> Result<(), String> {
+        Err("unimplemented".to_owned())
+    }
+
+    fn clear_new_task_stash(&self) -> Result<(), String> {
+        Err("unimplemented".to_owned())
+    }
 
     fn run_agent_turn_streamed(
         &self,

--- a/crates/luban_domain/src/lib.rs
+++ b/crates/luban_domain/src/lib.rs
@@ -15,9 +15,10 @@ pub use agent_thread::{
 mod adapters;
 pub use adapters::{
     AmpConfigEntry, AmpConfigEntryKind, ClaudeConfigEntry, ClaudeConfigEntryKind, CodexConfigEntry,
-    CodexConfigEntryKind, ContextImage, CreatedWorkspace, OpenTarget, ProjectIdentity,
-    ProjectWorkspaceService, PullRequestCiState, PullRequestInfo, PullRequestState,
-    RunAgentTurnRequest, TaskIntentKind, TaskIssueInfo, TaskStatusAutoUpdateSuggestion,
+    CodexConfigEntryKind, ContextImage, CreatedWorkspace, NewTaskDraft, NewTaskStash, OpenTarget,
+    ProjectIdentity, ProjectWorkspaceService, PullRequestCiState, PullRequestInfo,
+    PullRequestState, RunAgentTurnRequest, TaskIntentKind, TaskIssueInfo,
+    TaskStatusAutoUpdateSuggestion,
 };
 mod context_tokens;
 pub use context_tokens::{

--- a/docs/contracts/features/c-http-new-task-draft.md
+++ b/docs/contracts/features/c-http-new-task-draft.md
@@ -1,0 +1,38 @@
+# C-HTTP-NEW-TASK-DRAFT
+
+Status: Draft
+Verification: Mock=yes, Provider=yes, CI=yes
+
+## Surface
+
+- Methods: `PUT`, `DELETE`
+- Path: `/api/new_task/drafts/{draft_id}`
+
+## Purpose
+
+Update or delete an existing New Task draft.
+
+## Request
+
+### `PUT`
+
+- JSON body:
+  - `text: string` (required, non-empty)
+  - `project_id: string | null`
+  - `workdir_id: number | null`
+
+## Response
+
+### `PUT`
+
+- `200 OK`
+- JSON body: `NewTaskDraftSnapshot`
+
+### `DELETE`
+
+- `204 No Content`
+
+## Web usage
+
+- `web/lib/luban-http.ts`: `updateNewTaskDraft`, `deleteNewTaskDraft`
+

--- a/docs/contracts/features/c-http-new-task-drafts.md
+++ b/docs/contracts/features/c-http-new-task-drafts.md
@@ -1,0 +1,39 @@
+# C-HTTP-NEW-TASK-DRAFTS
+
+Status: Draft
+Verification: Mock=yes, Provider=yes, CI=yes
+
+## Surface
+
+- Methods: `GET`, `POST`
+- Path: `/api/new_task/drafts`
+
+## Purpose
+
+List and create persisted drafts for the New Task composer.
+
+## Request
+
+### `POST`
+
+- JSON body:
+  - `text: string` (required, non-empty)
+  - `project_id: string | null`
+  - `workdir_id: number | null`
+
+## Response
+
+### `GET`
+
+- `200 OK`
+- JSON body: `NewTaskDraftsSnapshot`
+
+### `POST`
+
+- `200 OK`
+- JSON body: `NewTaskDraftSnapshot`
+
+## Web usage
+
+- `web/lib/luban-http.ts`: `fetchNewTaskDrafts`, `createNewTaskDraft`
+

--- a/docs/contracts/features/c-http-new-task-stash.md
+++ b/docs/contracts/features/c-http-new-task-stash.md
@@ -1,0 +1,43 @@
+# C-HTTP-NEW-TASK-STASH
+
+Status: Draft
+Verification: Mock=yes, Provider=yes, CI=yes
+
+## Surface
+
+- Methods: `GET`, `PUT`, `DELETE`
+- Path: `/api/new_task/stash`
+
+## Purpose
+
+Persist the implicit New Task composer stash used for focus-loss/Esc dismissal recovery.
+
+## Request
+
+### `PUT`
+
+- JSON body:
+  - `text: string` (required, non-empty)
+  - `project_id: string | null`
+  - `workdir_id: number | null`
+  - `editing_draft_id: string | null`
+
+## Response
+
+### `GET`
+
+- `200 OK`
+- JSON body: `NewTaskStashResponse` (nullable `stash`)
+
+### `PUT`
+
+- `204 No Content`
+
+### `DELETE`
+
+- `204 No Content`
+
+## Web usage
+
+- `web/lib/luban-http.ts`: `fetchNewTaskStash`, `saveNewTaskStash`, `clearNewTaskStash`
+

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -33,6 +33,9 @@ Legend:
 | C-HTTP-CODEX-PROMPTS | `GET /api/codex/prompts` | `crates/luban_server/src/server.rs:get_codex_prompts` | `web/lib/luban-http.ts:fetchCodexCustomPrompts` | Draft | ✅ | ✅ | ✅ |
 | C-HTTP-WORKDIR-TASKS | `GET /api/workdirs/{workdir_id}/tasks` | `crates/luban_server/src/server.rs:get_threads` | `web/lib/luban-http.ts:fetchThreads` | Draft | ✅ | ✅ | ✅ |
 | C-HTTP-TASKS | `GET /api/tasks` | `crates/luban_server/src/server.rs:get_tasks` | `web/lib/luban-http.ts:fetchTasks` | Draft | ✅ | ✅ | ✅ |
+| C-HTTP-NEW-TASK-DRAFTS | `GET /api/new_task/drafts` | `crates/luban_server/src/server.rs:list_new_task_drafts` | `web/lib/luban-http.ts:fetchNewTaskDrafts` | Draft | ✅ | ✅ | ✅ |
+| C-HTTP-NEW-TASK-DRAFT | `DELETE /api/new_task/drafts/{draft_id}` | `crates/luban_server/src/server.rs:delete_new_task_draft` | `web/lib/luban-http.ts:deleteNewTaskDraft` | Draft | ✅ | ✅ | ✅ |
+| C-HTTP-NEW-TASK-STASH | `GET /api/new_task/stash` | `crates/luban_server/src/server.rs:get_new_task_stash` | `web/lib/luban-http.ts:fetchNewTaskStash` | Draft | ✅ | ✅ | ✅ |
 | C-HTTP-CONVERSATION | `GET /api/workdirs/{workdir_id}/conversations/{task_id}` | `crates/luban_server/src/server.rs:get_conversation` | `web/lib/luban-http.ts:fetchConversation` | Draft | ✅ | ✅ | ✅ |
 | C-HTTP-CHANGES | `GET /api/workdirs/{workdir_id}/changes` | `crates/luban_server/src/server.rs:get_changes` | `web/lib/luban-http.ts:fetchWorkspaceChanges` | Draft | ✅ | ✅ | ✅ |
 | C-HTTP-DIFF | `GET /api/workdirs/{workdir_id}/diff` | `crates/luban_server/src/server.rs:get_diff` | `web/lib/luban-http.ts:fetchWorkspaceDiff` | Draft | ✅ | ✅ | ✅ |

--- a/web/components/luban-ide.tsx
+++ b/web/components/luban-ide.tsx
@@ -12,6 +12,7 @@ import { useLuban } from "@/lib/luban-context"
 import type { TaskSummarySnapshot } from "@/lib/luban-api"
 import { computeProjectDisplayNames } from "@/lib/project-display-names"
 import { projectColorClass } from "@/lib/project-colors"
+import type { NewTaskDraft } from "@/lib/new-task-drafts"
 
 /**
  * Luban IDE main layout
@@ -31,6 +32,7 @@ export function LubanIDE() {
   const [showDetail, setShowDetail] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [newTaskOpen, setNewTaskOpen] = useState(false)
+  const [newTaskInitialDraft, setNewTaskInitialDraft] = useState<NewTaskDraft | null>(null)
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
 
   const handleViewChange = (view: NavView) => {
@@ -99,7 +101,15 @@ export function LubanIDE() {
 
   const renderContent = () => {
     if (activeView === "inbox") {
-      return <InboxView onOpenFullView={handleOpenFullViewFromInbox} />
+      return (
+        <InboxView
+          onOpenFullView={handleOpenFullViewFromInbox}
+          onOpenDraft={(draft) => {
+            setNewTaskInitialDraft(draft)
+            setNewTaskOpen(true)
+          }}
+        />
+      )
     }
 
     if (showDetail) {
@@ -142,7 +152,10 @@ export function LubanIDE() {
             onViewChange={handleViewChange}
             activeProjectId={activeProjectId}
             onProjectSelected={(projectId) => setActiveProjectId(projectId)}
-            onNewTask={() => setNewTaskOpen(true)}
+            onNewTask={() => {
+              setNewTaskInitialDraft(null)
+              setNewTaskOpen(true)
+            }}
             onFavoriteTaskSelected={(task) => {
               void (async () => {
                 await openWorkspace(task.workdir_id)
@@ -164,8 +177,10 @@ export function LubanIDE() {
       <NewTaskModal
         open={newTaskOpen}
         activeProjectId={activeProjectId}
+        initialDraft={newTaskInitialDraft}
         onOpenChange={(open) => {
           setNewTaskOpen(open)
+          if (!open) setNewTaskInitialDraft(null)
           if (!open) setShowDetail(true)
         }}
       />

--- a/web/components/new-task-drafts-dialog.tsx
+++ b/web/components/new-task-drafts-dialog.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+
+import type { NewTaskDraft } from "@/lib/new-task-drafts"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+function formatDraftTitle(text: string): string {
+  const firstLine = text.split("\n")[0] ?? ""
+  const trimmed = firstLine.trim()
+  if (!trimmed) return "Untitled draft"
+  return trimmed.length > 72 ? `${trimmed.slice(0, 72)}…` : trimmed
+}
+
+export function NewTaskDraftsDialog({
+  open,
+  onOpenChange,
+  drafts,
+  onOpenDraft,
+  onDeleteDraft,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  drafts: NewTaskDraft[]
+  onOpenDraft: (draft: NewTaskDraft) => void
+  onDeleteDraft: (draftId: string) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]" data-testid="new-task-drafts-dialog">
+        <DialogHeader>
+          <DialogTitle>Drafts</DialogTitle>
+        </DialogHeader>
+
+        {drafts.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No drafts saved.</div>
+        ) : (
+          <div className="max-h-[420px] overflow-y-auto border rounded-md">
+            {drafts.map((draft, idx) => (
+              <div
+                key={draft.id}
+                data-testid={`new-task-drafts-row-${idx}`}
+                data-draft-id={draft.id}
+                className="flex items-center justify-between gap-2 px-3 py-2 border-b last:border-b-0 hover:bg-muted/30"
+              >
+                <button
+                  type="button"
+                  className="flex-1 text-left min-w-0"
+                  data-testid={`new-task-drafts-open-${idx}`}
+                  onClick={() => onOpenDraft(draft)}
+                >
+                  <div className="text-sm font-medium truncate">{formatDraftTitle(draft.text)}</div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    Updated {new Date(draft.updatedAtUnixMs).toLocaleString()}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  className="w-8 h-8 rounded-md hover:bg-muted flex items-center justify-center"
+                  data-testid={`new-task-drafts-delete-${idx}`}
+                  title="Delete draft"
+                  onClick={() => onDeleteDraft(draft.id)}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -311,6 +311,31 @@ export type TaskExecuteResult = {
   mode: TaskExecuteMode
 }
 
+export type NewTaskDraftSnapshot = {
+  id: string
+  text: string
+  project_id: ProjectId | null
+  workdir_id: WorkspaceId | null
+  created_at_unix_ms: number
+  updated_at_unix_ms: number
+}
+
+export type NewTaskDraftsSnapshot = {
+  drafts: NewTaskDraftSnapshot[]
+}
+
+export type NewTaskStashSnapshot = {
+  text: string
+  project_id: ProjectId | null
+  workdir_id: WorkspaceId | null
+  editing_draft_id: string | null
+  updated_at_unix_ms: number
+}
+
+export type NewTaskStashResponse = {
+  stash: NewTaskStashSnapshot | null
+}
+
 export type CodexConfigEntryKind = "file" | "folder"
 
 export type CodexConfigEntrySnapshot = {

--- a/web/lib/luban-http.ts
+++ b/web/lib/luban-http.ts
@@ -5,6 +5,9 @@ import type {
   CodexCustomPromptSnapshot,
   ConversationSnapshot,
   MentionItemSnapshot,
+  NewTaskDraftSnapshot,
+  NewTaskDraftsSnapshot,
+  NewTaskStashResponse,
   TasksSnapshot,
   ThreadsSnapshot,
   WorkspaceChangesSnapshot,
@@ -20,6 +23,13 @@ import {
   mockFetchThreads,
   mockFetchWorkspaceChanges,
   mockFetchWorkspaceDiff,
+  mockCreateNewTaskDraft,
+  mockDeleteNewTaskDraft,
+  mockFetchNewTaskDrafts,
+  mockFetchNewTaskStash,
+  mockSaveNewTaskStash,
+  mockUpdateNewTaskDraft,
+  mockClearNewTaskStash,
   mockUploadAttachment,
 } from "./mock/mock-runtime"
 
@@ -144,4 +154,74 @@ export async function fetchTasks(args: { projectId?: string } = {}): Promise<Tas
   const res = await fetch(`/api/tasks${suffix}`)
   if (!res.ok) throw new Error(`GET /api/tasks failed: ${res.status}`)
   return (await res.json()) as TasksSnapshot
+}
+
+export async function fetchNewTaskDrafts(): Promise<NewTaskDraftsSnapshot> {
+  if (isMockMode()) return await mockFetchNewTaskDrafts()
+  const res = await fetch("/api/new_task/drafts")
+  if (!res.ok) throw new Error(`GET /api/new_task/drafts failed: ${res.status}`)
+  return (await res.json()) as NewTaskDraftsSnapshot
+}
+
+export async function createNewTaskDraft(args: {
+  text: string
+  project_id: string | null
+  workdir_id: number | null
+}): Promise<NewTaskDraftSnapshot> {
+  if (isMockMode()) return await mockCreateNewTaskDraft(args)
+  const res = await fetch("/api/new_task/drafts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  })
+  if (!res.ok) throw new Error(`POST /api/new_task/drafts failed: ${res.status}`)
+  return (await res.json()) as NewTaskDraftSnapshot
+}
+
+export async function updateNewTaskDraft(
+  draftId: string,
+  args: { text: string; project_id: string | null; workdir_id: number | null },
+): Promise<NewTaskDraftSnapshot> {
+  if (isMockMode()) return await mockUpdateNewTaskDraft(draftId, args)
+  const res = await fetch(`/api/new_task/drafts/${encodeURIComponent(draftId)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  })
+  if (!res.ok) throw new Error(`PUT /api/new_task/drafts/${draftId} failed: ${res.status}`)
+  return (await res.json()) as NewTaskDraftSnapshot
+}
+
+export async function deleteNewTaskDraft(draftId: string): Promise<void> {
+  if (isMockMode()) return await mockDeleteNewTaskDraft(draftId)
+  const res = await fetch(`/api/new_task/drafts/${encodeURIComponent(draftId)}`, { method: "DELETE" })
+  if (!res.ok) throw new Error(`DELETE /api/new_task/drafts/${draftId} failed: ${res.status}`)
+}
+
+export async function fetchNewTaskStash(): Promise<NewTaskStashResponse> {
+  if (isMockMode()) return await mockFetchNewTaskStash()
+  const res = await fetch("/api/new_task/stash")
+  if (!res.ok) throw new Error(`GET /api/new_task/stash failed: ${res.status}`)
+  return (await res.json()) as NewTaskStashResponse
+}
+
+export async function saveNewTaskStash(args: {
+  text: string
+  project_id: string | null
+  workdir_id: number | null
+  editing_draft_id: string | null
+}): Promise<void> {
+  if (isMockMode()) return await mockSaveNewTaskStash(args)
+  const res = await fetch("/api/new_task/stash", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  })
+  if (!res.ok) throw new Error(`PUT /api/new_task/stash failed: ${res.status}`)
+}
+
+export async function clearNewTaskStash(): Promise<void> {
+  if (isMockMode()) return await mockClearNewTaskStash()
+  const res = await fetch("/api/new_task/stash", { method: "DELETE" })
+  if (!res.ok) throw new Error(`DELETE /api/new_task/stash failed: ${res.status}`)
 }

--- a/web/lib/new-task-drafts.ts
+++ b/web/lib/new-task-drafts.ts
@@ -1,0 +1,102 @@
+"use client"
+
+import type { NewTaskDraftSnapshot, NewTaskStashSnapshot } from "@/lib/luban-api"
+import {
+  clearNewTaskStash as httpClearNewTaskStash,
+  createNewTaskDraft as httpCreateNewTaskDraft,
+  deleteNewTaskDraft as httpDeleteNewTaskDraft,
+  fetchNewTaskDrafts,
+  fetchNewTaskStash,
+  saveNewTaskStash as httpSaveNewTaskStash,
+  updateNewTaskDraft as httpUpdateNewTaskDraft,
+} from "@/lib/luban-http"
+
+export type NewTaskDraft = {
+  id: string
+  text: string
+  projectId: string | null
+  workdirId: number | null
+  createdAtUnixMs: number
+  updatedAtUnixMs: number
+}
+
+export type NewTaskStash = {
+  text: string
+  projectId: string | null
+  workdirId: number | null
+  editingDraftId: string | null
+  updatedAtUnixMs: number
+}
+
+export const NEW_TASK_DRAFTS_CHANGED_EVENT = "luban:new-task-drafts-changed"
+
+function draftFromSnapshot(value: NewTaskDraftSnapshot): NewTaskDraft {
+  return {
+    id: value.id,
+    text: value.text,
+    projectId: value.project_id,
+    workdirId: value.workdir_id,
+    createdAtUnixMs: value.created_at_unix_ms,
+    updatedAtUnixMs: value.updated_at_unix_ms,
+  }
+}
+
+function stashFromSnapshot(value: NewTaskStashSnapshot): NewTaskStash {
+  return {
+    text: value.text,
+    projectId: value.project_id,
+    workdirId: value.workdir_id,
+    editingDraftId: value.editing_draft_id,
+    updatedAtUnixMs: value.updated_at_unix_ms,
+  }
+}
+
+export function notifyNewTaskDraftsChanged() {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new Event(NEW_TASK_DRAFTS_CHANGED_EVENT))
+}
+
+export async function loadNewTaskDrafts(): Promise<NewTaskDraft[]> {
+  const snap = await fetchNewTaskDrafts()
+  return (snap.drafts ?? []).map(draftFromSnapshot)
+}
+
+export async function upsertNewTaskDraft(args: {
+  id?: string | null
+  text: string
+  projectId: string | null
+  workdirId: number | null
+}): Promise<NewTaskDraft> {
+  const payload = { text: args.text, project_id: args.projectId, workdir_id: args.workdirId }
+
+  const snap = args.id
+    ? await httpUpdateNewTaskDraft(args.id, payload)
+    : await httpCreateNewTaskDraft(payload)
+
+  notifyNewTaskDraftsChanged()
+  return draftFromSnapshot(snap)
+}
+
+export async function deleteNewTaskDraft(id: string): Promise<void> {
+  await httpDeleteNewTaskDraft(id)
+  notifyNewTaskDraftsChanged()
+}
+
+export async function loadNewTaskStash(): Promise<NewTaskStash | null> {
+  const resp = await fetchNewTaskStash()
+  return resp.stash ? stashFromSnapshot(resp.stash) : null
+}
+
+export async function saveNewTaskStash(value: NewTaskStash): Promise<void> {
+  await httpSaveNewTaskStash({
+    text: value.text,
+    project_id: value.projectId,
+    workdir_id: value.workdirId,
+    editing_draft_id: value.editingDraftId,
+  })
+}
+
+export async function clearNewTaskStash(): Promise<void> {
+  await httpClearNewTaskStash()
+}
+

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -21,6 +21,7 @@ import { runNewTaskDoubleSubmitNoDuplicate } from './scenarios/new-task-double-s
 import { runNewTaskDefaultProjectFollowsContext } from './scenarios/new-task-default-project-follows-context.mjs';
 import { runNewTaskGitProjectWithoutWorkdirs } from './scenarios/new-task-git-project-without-workdirs.mjs';
 import { runNewTaskProjectAvatars } from './scenarios/new-task-project-avatars.mjs';
+import { runNewTaskDrafts } from './scenarios/new-task-drafts.mjs';
 import { runSettingsPanel } from './scenarios/settings-panel.mjs';
 import { runSidebarProjectAvatars } from './scenarios/sidebar-project-avatars.mjs';
 import { runStarFavorites } from './scenarios/star-favorites.mjs';
@@ -157,6 +158,7 @@ async function main() {
 	
 	    await runSidebarProjectAvatars({ page, baseUrl });
 	    await runNewTaskModal({ page, baseUrl });
+	    await runNewTaskDrafts({ page, baseUrl });
 	    await runNewTaskProjectAvatars({ page, baseUrl });
 	    await runNewTaskGitProjectWithoutWorkdirs({ page, baseUrl });
 	    await runActivityAttachments({ page, baseUrl });

--- a/web/tests/ui/scenarios/new-task-default-project-follows-context.mjs
+++ b/web/tests/ui/scenarios/new-task-default-project-follows-context.mjs
@@ -32,7 +32,7 @@ export async function runNewTaskDefaultProjectFollowsContext({ page }) {
   await projectSelector.waitFor({ state: 'visible' });
   await waitForDataAttribute(projectSelector, 'data-selected-project-id', 'mock-project-1', 10_000);
 
-  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-close-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
 
   await page.getByTestId('nav-inbox-button').click();

--- a/web/tests/ui/scenarios/new-task-drafts.mjs
+++ b/web/tests/ui/scenarios/new-task-drafts.mjs
@@ -1,0 +1,80 @@
+import { sleep } from '../lib/utils.mjs';
+
+async function waitForInputContains(page, testId, needle, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const value = await page.getByTestId(testId).inputValue();
+    if (value.includes(needle)) return value;
+    await sleep(100);
+  }
+  const value = await page.getByTestId(testId).inputValue();
+  throw new Error(`expected ${testId} to include "${needle}", got: ${value.slice(0, 64)}`);
+}
+
+async function waitForInputTrimmedEmpty(page, testId, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const value = await page.getByTestId(testId).inputValue();
+    if (value.trim() === '') return value;
+    await sleep(100);
+  }
+  const value = await page.getByTestId(testId).inputValue();
+  throw new Error(`expected ${testId} to be empty, got: ${value.slice(0, 64)}`);
+}
+
+export async function runNewTaskDrafts({ page }) {
+  const title = `Draft smoke ${Date.now()}`;
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
+  await page.getByTestId('new-task-input').fill(title);
+  await page.getByTestId('new-task-save-draft-button').waitFor({ state: 'visible' });
+  await page.getByTestId('new-task-save-draft-button').click();
+
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('nav-inbox-button').click();
+  await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
+
+  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'visible' });
+  await page.getByTestId('inbox-drafts-button').click();
+  await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'visible' });
+
+  await page.getByTestId('new-task-drafts-open-0').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
+  await waitForInputContains(page, 'new-task-input', title, 10_000);
+
+  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
+  await waitForInputContains(page, 'new-task-input', title, 10_000);
+
+  await page.getByTestId('new-task-close-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
+  await waitForInputTrimmedEmpty(page, 'new-task-input', 10_000);
+  await page.getByTestId('new-task-close-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('nav-inbox-button').click();
+  await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
+
+  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'visible' });
+  await page.getByTestId('inbox-drafts-button').click();
+  await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'visible' });
+
+  await page.getByTestId('new-task-drafts-delete-0').click();
+  await page.getByText('No drafts saved.').waitFor({ state: 'visible' });
+  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'hidden' });
+}

--- a/web/tests/ui/scenarios/new-task-modal.mjs
+++ b/web/tests/ui/scenarios/new-task-modal.mjs
@@ -51,6 +51,13 @@ export async function runNewTaskModal({ page }) {
     fs.rmSync(pngPath, { force: true });
   }
   await sleep(500);
-  await page.keyboard.press('Escape');
+  const closeButton = page.getByTestId('new-task-close-button');
+  await closeButton.waitFor({ state: 'attached', timeout: 10_000 });
+  const closeVisible = await closeButton.isVisible();
+  if (!closeVisible) {
+    const modalVisible = await page.getByTestId('new-task-modal').isVisible().catch(() => false);
+    throw new Error(`new-task-close-button not visible (modalVisible=${modalVisible})`);
+  }
+  await closeButton.click({ timeout: 10_000 });
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
 }

--- a/web/tests/ui/scenarios/new-task-project-avatars.mjs
+++ b/web/tests/ui/scenarios/new-task-project-avatars.mjs
@@ -18,8 +18,9 @@ export async function runNewTaskProjectAvatars({ page }) {
     throw new Error(`expected mock avatar data URL, got: ${src.slice(0, 64)}`);
   }
 
-  await page.keyboard.press('Escape');
-  await page.keyboard.press('Escape');
+  // Close the dropdown before clicking the modal close button (Radix captures pointer events while open).
+  await gitProject.click();
+
+  await page.getByTestId('new-task-close-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
 }
-


### PR DESCRIPTION
## Summary
- Persist New Task drafts and the implicit composer stash to SQLite.
- Expose CRUD endpoints under `/api/new_task/*`.
- Wire the web UI to save/list/open/delete drafts and to stash on dismiss.

## User-visible behavior
- When the user starts typing in the New Task composer, a **Save as draft** button appears (top-right, left of Expand). Clicking it saves to Drafts.
- When Drafts exist, the Inbox header shows a **Drafts** button. Users can open or delete drafts.
- If the user dismisses the composer via **Esc**, **window blur**, or clicking the overlay, the input is stashed and restored next time. Clicking the explicit Close button clears the stash.

## Verification
- `just fmt && just lint && just test`
- `LUBAN_AGENT_BROWSER_PORT=3333 just test-ui`

## Contracts
- Updated: `docs/contracts/features/c-http-new-task-drafts.md`, `docs/contracts/features/c-http-new-task-draft.md`, `docs/contracts/features/c-http-new-task-stash.md`
- Progress: `docs/contracts/progress.md`
- Provider enforcement: `crates/luban_server/tests/contracts_http.rs`

## Risk / rollback
- Low risk: schema adds new tables only.
- Rollback: revert code; new tables can remain without affecting older versions.
