### PR TITLE
fix(web): prevent Escape leaking from inputs

### DIFF
--- a/web/lib/use-agent-cancel-hotkey.ts
+++ b/web/lib/use-agent-cancel-hotkey.ts
@@ -47,6 +47,8 @@ export function useAgentCancelHotkey(args: {
       if (e.key !== "Escape") return
       if (!args.enabled) return
       if (args.blocked) return
+      if (e.defaultPrevented) return
+      if (isTextInputTarget(e.target)) return
 
       if (escHintVisibleRef.current) {
         e.preventDefault()
@@ -55,9 +57,7 @@ export function useAgentCancelHotkey(args: {
         return
       }
 
-      if (!isTextInputTarget(e.target)) {
-        e.preventDefault()
-      }
+      e.preventDefault()
 
       setEscHintVisible(true)
       if (escTimeoutRef.current != null) {
@@ -81,4 +81,3 @@ export function useAgentCancelHotkey(args: {
 
   return { escHintVisible, escTimeoutMs, clearEscHint }
 }
-

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -17,6 +17,7 @@ import { runLatestEventsVisible } from './scenarios/latest-events-visible.mjs';
 import { runActivityWindowing } from './scenarios/activity-windowing.mjs';
 import { runAgentRunnerIcons } from './scenarios/agent-runner-icons.mjs';
 import { runAgentRunningEventNoChevron } from './scenarios/agent-running-event-no-chevron.mjs';
+import { runEscapeDoesNotLeakFromChatInput } from './scenarios/escape-does-not-leak-from-chat-input.mjs';
 import { runNewTaskModal } from './scenarios/new-task-modal.mjs';
 import { runNewTaskDoubleSubmitNoDuplicate } from './scenarios/new-task-double-submit-no-duplicate.mjs';
 import { runNewTaskDefaultProjectFollowsContext } from './scenarios/new-task-default-project-follows-context.mjs';
@@ -178,6 +179,7 @@ async function main() {
     await runLatestEventsVisible({ page, baseUrl });
     await runActivityWindowing({ page, baseUrl });
     await runAgentRunnerIcons({ page, baseUrl });
+    await runEscapeDoesNotLeakFromChatInput({ page, baseUrl });
     await runAgentRunningEventNoChevron({ page, baseUrl });
     await runNewTaskDoubleSubmitNoDuplicate({ page, baseUrl });
     await runTaskSummariesEventsRefresh({ page, baseUrl });

--- a/web/tests/ui/scenarios/escape-does-not-leak-from-chat-input.mjs
+++ b/web/tests/ui/scenarios/escape-does-not-leak-from-chat-input.mjs
@@ -1,0 +1,26 @@
+import { sleep } from '../lib/utils.mjs';
+
+export async function runEscapeDoesNotLeakFromChatInput({ page }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+  await page.getByText('PR: pending').first().click();
+
+  await page.getByTestId('chat-scroll-container').waitFor({ state: 'visible' });
+
+  const hint = page.getByTestId('esc-cancel-hint');
+  const beforeCount = await hint.count();
+  if (beforeCount !== 0) {
+    throw new Error(`expected no esc cancel hint before test, got ${beforeCount}`);
+  }
+
+  await page.getByTestId('chat-input').click();
+  await page.keyboard.press('Escape');
+
+  await sleep(150);
+
+  const afterCount = await hint.count();
+  if (afterCount !== 0) {
+    throw new Error(`expected escape in chat input not to show esc cancel hint, got ${afterCount}`);
+  }
+}
+


### PR DESCRIPTION
Summary:
- Prevent the global Escape cancel hotkey from firing when focus is inside a text input (input/textarea/contentEditable).
- Add a UI smoke scenario to ensure Escape inside the chat input does not show the cancel hint.

Testing:
- just fmt
- just lint
- just test
- just test-ui
