### PR TITLE
Fix global New Task stash and draft save

### DIFF
--- a/web/components/new-task-modal.tsx
+++ b/web/components/new-task-modal.tsx
@@ -169,10 +169,11 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
       void clearNewTaskStash().catch((err) => console.warn("clearNewTaskStash failed", err))
       return
     }
+    const stashedWorkdirId = selectedWorkdirId === -1 ? null : selectedWorkdirId
     void saveNewTaskStash({
       text: input,
       projectId: effectiveProjectId || null,
-      workdirId: selectedWorkdirId,
+      workdirId: stashedWorkdirId,
       editingDraftId,
       updatedAtUnixMs: Date.now(),
     }).catch((err) => console.warn("saveNewTaskStash failed", err))
@@ -848,36 +849,37 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
           {/* Right: Expand + Close */}
           <div className="flex items-center gap-1 flex-shrink-0">
             {canSaveDraft && (
-              <button
-                type="button"
-                data-testid="new-task-save-draft-button"
-                className="h-7 px-2.5 text-[12px] transition-colors hover:bg-[#f5f5f5] disabled:opacity-40 disabled:cursor-not-allowed"
-                style={{ color: "#666", borderRadius: "5px", fontWeight: 500 }}
-                onClick={() => {
-                  void (async () => {
-                    const trimmed = input.trim()
-                    if (!trimmed) return
-                    try {
-                      await upsertNewTaskDraft({
-                        id: editingDraftId,
-                        text: input,
-                        projectId: effectiveProjectId || null,
-                        workdirId: selectedWorkdirId,
-                      })
-                      await clearNewTaskStash()
-                      setInput("")
-                      revokeAttachmentUrls(attachments)
-                      setAttachments([])
-                      setSelectedProjectId("")
-                      setSelectedWorkdirId(null)
-                      setEditingDraftId(null)
-                      onOpenChange(false)
-                      toast("Saved to Drafts")
-                    } catch (err) {
-                      toast.error(err instanceof Error ? err.message : String(err))
-                    }
-                  })()
-                }}
+            <button
+              type="button"
+              data-testid="new-task-save-draft-button"
+              className="h-7 px-2.5 text-[12px] transition-colors hover:bg-[#f5f5f5] disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{ color: "#666", borderRadius: "5px", fontWeight: 500 }}
+              onClick={() => {
+                void (async () => {
+                  const trimmed = input.trim()
+	                  if (!trimmed) return
+	                  try {
+	                    const draftWorkdirId = selectedWorkdirId === -1 ? null : selectedWorkdirId
+	                    await upsertNewTaskDraft({
+	                      id: editingDraftId,
+	                      text: input,
+	                      projectId: effectiveProjectId || null,
+	                      workdirId: draftWorkdirId,
+	                    })
+	                    await clearNewTaskStash()
+	                    setInput("")
+	                    revokeAttachmentUrls(attachments)
+	                    setAttachments([])
+	                    setSelectedProjectId("")
+	                    setSelectedWorkdirId(null)
+	                    setEditingDraftId(null)
+	                    onOpenChange(false)
+	                    toast("Saved to Drafts")
+	                    } catch (err) {
+	                      toast.error(err instanceof Error ? err.message : String(err))
+	                    }
+	                  })()
+	                }}
                 disabled={executingMode != null}
                 title="Save as draft"
               >

--- a/web/lib/mock/mock-runtime.ts
+++ b/web/lib/mock/mock-runtime.ts
@@ -248,6 +248,9 @@ export async function mockCreateNewTaskDraft(args: {
   project_id: string | null
   workdir_id: number | null
 }): Promise<NewTaskDraftSnapshot> {
+  if (args.workdir_id != null && (!Number.isInteger(args.workdir_id) || args.workdir_id < 0)) {
+    throw new Error(`mock: invalid workdir_id: ${args.workdir_id}`)
+  }
   const state = getRuntime()
   const now = Date.now()
   const draft: NewTaskDraftSnapshot = {
@@ -266,6 +269,9 @@ export async function mockUpdateNewTaskDraft(
   draftId: string,
   args: { text: string; project_id: string | null; workdir_id: number | null },
 ): Promise<NewTaskDraftSnapshot> {
+  if (args.workdir_id != null && (!Number.isInteger(args.workdir_id) || args.workdir_id < 0)) {
+    throw new Error(`mock: invalid workdir_id: ${args.workdir_id}`)
+  }
   const state = getRuntime()
   const idx = state.newTaskDrafts.findIndex((d) => d.id === draftId)
   if (idx < 0) throw new Error(`mock: unknown draft id: ${draftId}`)
@@ -299,6 +305,9 @@ export async function mockSaveNewTaskStash(args: {
   workdir_id: number | null
   editing_draft_id: string | null
 }): Promise<void> {
+  if (args.workdir_id != null && (!Number.isInteger(args.workdir_id) || args.workdir_id < 0)) {
+    throw new Error(`mock: invalid workdir_id: ${args.workdir_id}`)
+  }
   const state = getRuntime()
   state.newTaskStash = {
     text: args.text,

--- a/web/tests/ui/scenarios/new-task-drafts.mjs
+++ b/web/tests/ui/scenarios/new-task-drafts.mjs
@@ -28,6 +28,9 @@ export async function runNewTaskDrafts({ page }) {
   await page.getByTestId('new-task-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
 
+  await page.getByTestId('new-task-workdir-selector').click();
+  await page.getByRole('menuitem').filter({ hasText: 'Create new...' }).first().click();
+
   await page.getByTestId('new-task-input').fill(title);
   await page.getByTestId('new-task-save-draft-button').waitFor({ state: 'visible' });
   await page.getByTestId('new-task-save-draft-button').click();
@@ -54,12 +57,26 @@ export async function runNewTaskDrafts({ page }) {
 
   await waitForInputContains(page, 'new-task-input', title, 10_000);
 
-  await page.getByTestId('new-task-close-button').click();
+  // Close explicitly discards (clears stash). Use Escape for stashing.
+  await page.keyboard.press('Escape');
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('sidebar-project-mock-project-2').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
 
   await page.getByTestId('new-task-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
 
+  await waitForInputContains(page, 'new-task-input', title, 10_000);
+  await page.getByTestId('new-task-input').fill('');
+  await page.getByTestId('new-task-close-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
   await waitForInputTrimmedEmpty(page, 'new-task-input', 10_000);
   await page.getByTestId('new-task-close-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });


### PR DESCRIPTION
## What changed
- Treat the New Task composer stash as global: implicit dismissals (Esc/overlay/blur) stash and restore across project switches.
- Explicit Close discards: clicking Close clears the stash.
- Fix provider 422 when saving a draft while workdir is set to "Create new..." by normalizing `workdir_id` to `null`.

## Scope
- `web/components/new-task-modal.tsx`
- `web/lib/mock/mock-runtime.ts`
- `web/tests/ui/scenarios/new-task-drafts.mjs`

## Verification
- `just fmt && just lint && just test && just test-ui`

## Manual checks
1. Open New Task, type text, press Esc; switch project; open New Task and confirm the text is restored.
2. Click Close; open New Task and confirm it starts empty.
3. Select workdir "Create new..." and click "Save as draft"; confirm it succeeds without 422.
