### PR TITLE
web: show Drafts in sidebar

### DIFF
--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -24,9 +24,6 @@ import { projectColorClass } from "@/lib/project-colors"
 import { fetchConversation, fetchTasks } from "@/lib/luban-http"
 import type { ConversationSnapshot, OperationStatus, TaskStatus, TasksSnapshot, TurnResult, TurnStatus } from "@/lib/luban-api"
 import { isMockMode } from "@/lib/luban-mode"
-import type { NewTaskDraft } from "@/lib/new-task-drafts"
-import { NEW_TASK_DRAFTS_CHANGED_EVENT, deleteNewTaskDraft, loadNewTaskDrafts } from "@/lib/new-task-drafts"
-import { NewTaskDraftsDialog } from "./new-task-drafts-dialog"
 
 export interface InboxNotification {
   id: string
@@ -53,7 +50,6 @@ export interface InboxNotification {
 
 interface InboxViewProps {
   onOpenFullView?: (notification: InboxNotification) => void
-  onOpenDraft?: (draft: NewTaskDraft) => void
 }
 
 function escapeXmlText(raw: string): string {
@@ -228,7 +224,7 @@ function EmptyState({ unreadCount }: { unreadCount: number }) {
   )
 }
 
-export function InboxView({ onOpenFullView, onOpenDraft }: InboxViewProps) {
+export function InboxView({ onOpenFullView }: InboxViewProps) {
   const { app, wsConnected, subscribeServerEvents, openWorkdir, activateTask, setTaskStarred, setTaskStatus } = useLuban()
   const [tasksSnapshot, setTasksSnapshot] = useState<TasksSnapshot | null>(null)
   const [selectedNotificationId, setSelectedNotificationId] = useState<string | null>(null)
@@ -241,23 +237,6 @@ export function InboxView({ onOpenFullView, onOpenDraft }: InboxViewProps) {
   const previewInFlightRef = useRef<Set<string>>(new Set())
   const prevWsConnectedRef = useRef(false)
   const stableUpdatedAtByTaskRef = useRef<Map<string, number>>(new Map())
-  const [drafts, setDrafts] = useState<NewTaskDraft[]>([])
-  const [draftsOpen, setDraftsOpen] = useState(false)
-
-  useEffect(() => {
-    const refresh = () => {
-      void (async () => {
-        try {
-          setDrafts(await loadNewTaskDrafts())
-        } catch (err) {
-          console.warn("loadNewTaskDrafts failed", err)
-        }
-      })()
-    }
-    refresh()
-    window.addEventListener(NEW_TASK_DRAFTS_CHANGED_EVENT, refresh)
-    return () => window.removeEventListener(NEW_TASK_DRAFTS_CHANGED_EVENT, refresh)
-  }, [])
 
   useEffect(() => {
     previewByNotificationIdRef.current = previewByNotificationId
@@ -537,18 +516,6 @@ export function InboxView({ onOpenFullView, onOpenDraft }: InboxViewProps) {
             <span className="text-[13px] font-medium" style={{ color: '#1b1b1b' }}>
               Inbox
             </span>
-            {drafts.length > 0 && (
-              <button
-                type="button"
-                data-testid="inbox-drafts-button"
-                className="h-6 px-2 text-[12px] rounded-[5px] hover:bg-[#eeeeee] transition-colors"
-                style={{ color: "#6b6b6b", fontWeight: 500 }}
-                title="Drafts"
-                onClick={() => setDraftsOpen(true)}
-              >
-                Drafts
-              </button>
-            )}
             <button
               className="w-5 h-5 flex items-center justify-center rounded hover:bg-[#eeeeee] transition-colors"
               style={{ color: '#9b9b9b' }}
@@ -628,17 +595,6 @@ export function InboxView({ onOpenFullView, onOpenDraft }: InboxViewProps) {
           })}
         </div>
       </div>
-
-      <NewTaskDraftsDialog
-        open={draftsOpen}
-        onOpenChange={setDraftsOpen}
-        drafts={drafts}
-        onOpenDraft={(draft) => {
-          setDraftsOpen(false)
-          onOpenDraft?.(draft)
-        }}
-        onDeleteDraft={(draftId) => deleteNewTaskDraft(draftId)}
-      />
 
       {/* Right: Preview Panel */}
       <div className="flex-1 flex flex-col min-w-0">

--- a/web/components/luban-sidebar.tsx
+++ b/web/components/luban-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   Inbox,
+  FileText,
   Search,
   Plus,
   Layers,
@@ -36,6 +37,8 @@ interface LubanSidebarProps {
   onProjectSelected?: (projectId: string | null) => void
   onNewTask?: () => void
   onFavoriteTaskSelected?: (task: TaskSummarySnapshot) => void
+  newTaskDraftCount?: number
+  onOpenNewTaskDrafts?: () => void
 }
 
 interface NavItemProps {
@@ -214,6 +217,8 @@ export function LubanSidebar({
   onProjectSelected,
   onNewTask,
   onFavoriteTaskSelected,
+  newTaskDraftCount,
+  onOpenNewTaskDrafts,
 }: LubanSidebarProps) {
   const {
     app,
@@ -346,6 +351,16 @@ export function LubanSidebar({
             active={activeView === "inbox"}
             onClick={() => handleNavClick("inbox")}
           />
+          {(newTaskDraftCount ?? 0) > 0 && (
+            <NavItem
+              icon={<FileText className="w-4 h-4" />}
+              label="Drafts"
+              badge={newTaskDraftCount}
+              testId="nav-drafts-button"
+              active={false}
+              onClick={() => onOpenNewTaskDrafts?.()}
+            />
+          )}
         </div>
 
         {/* Favorites Section (only shown when non-empty) */}

--- a/web/tests/ui/scenarios/new-task-drafts.mjs
+++ b/web/tests/ui/scenarios/new-task-drafts.mjs
@@ -37,13 +37,11 @@ export async function runNewTaskDrafts({ page }) {
 
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
 
-  await page.getByTestId('nav-inbox-button').click();
-  await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
-
-  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'visible' });
-  await page.getByTestId('inbox-drafts-button').click();
+  await page.getByTestId('nav-drafts-button').waitFor({ state: 'visible' });
+  await page.getByTestId('nav-drafts-button').click();
   await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'visible' });
 
+  await page.getByTestId('new-task-drafts-open-0').waitFor({ state: 'visible' });
   await page.getByTestId('new-task-drafts-open-0').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
 
@@ -81,17 +79,14 @@ export async function runNewTaskDrafts({ page }) {
   await page.getByTestId('new-task-close-button').click();
   await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
 
-  await page.getByTestId('nav-inbox-button').click();
-  await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
-
-  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'visible' });
-  await page.getByTestId('inbox-drafts-button').click();
+  await page.getByTestId('nav-drafts-button').click();
   await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'visible' });
 
+  await page.getByTestId('new-task-drafts-delete-0').waitFor({ state: 'visible' });
   await page.getByTestId('new-task-drafts-delete-0').click();
   await page.getByText('No drafts saved.').waitFor({ state: 'visible' });
   await page.keyboard.press('Escape');
   await page.getByTestId('new-task-drafts-dialog').waitFor({ state: 'hidden' });
 
-  await page.getByTestId('inbox-drafts-button').waitFor({ state: 'hidden' });
+  await page.getByTestId('nav-drafts-button').waitFor({ state: 'hidden' });
 }


### PR DESCRIPTION
## What changed
- Move **Drafts** entry to the left sidebar (parallel to Inbox), and only show it when at least one draft exists.
- Remove the inbox-internal Drafts entry.

## How to verify
- `just fmt && just lint && just test && just test-ui`

## Manual checks
1) Create a new task draft (New Task -> Save as draft).
2) Confirm `Drafts` appears in the left sidebar.
3) Click `Drafts`, open a draft, confirm it pre-fills the New Task modal.
4) Delete the last draft, confirm `Drafts` disappears from the left sidebar.

## Tests updated
- UI smoke: `web/tests/ui/scenarios/new-task-drafts.mjs`

## Risk / rollback
- Low risk (UI-only navigation and dialog wiring). Roll back by reverting commit `1382e53`.
