### PR TITLE
web: use interactive shell terminal mode

### DIFF
--- a/web/components/pty-terminal.tsx
+++ b/web/components/pty-terminal.tsx
@@ -357,7 +357,7 @@ function isValidTerminalSize(cols: number, rows: number): boolean {
   return Number.isFinite(cols) && Number.isFinite(rows) && cols >= 2 && rows >= 2
 }
 
-export function PtyTerminal() {
+export function PtyTerminal({ autoFocus = false }: { autoFocus?: boolean } = {}) {
   const { activeWorkdirId: activeWorkspaceId, activeWorkdir: activeWorkspace } = useLuban()
   const ptyThreadId = 1
   const reconnectToken = activeWorkspaceId != null ? getOrCreateReconnectToken(activeWorkspaceId, ptyThreadId) : null
@@ -369,6 +369,7 @@ export function PtyTerminal() {
       workspaceId={activeWorkspaceId}
       threadId={ptyThreadId}
       reconnectToken={reconnectToken}
+      autoFocus={autoFocus}
       mockWorkspaceLabel={mockWorkspaceLabel}
       mockCwd={mockCwd}
     />
@@ -380,6 +381,7 @@ export function PtyTerminalSession({
   threadId,
   reconnectToken,
   readOnly = false,
+  autoFocus = false,
   initialBase64,
   mockWorkspaceLabel,
   mockCwd,
@@ -391,6 +393,7 @@ export function PtyTerminalSession({
   threadId: number
   reconnectToken?: string | null
   readOnly?: boolean
+  autoFocus?: boolean
   initialBase64?: string | null
   mockWorkspaceLabel?: string | null
   mockCwd?: string | null
@@ -777,6 +780,13 @@ export function PtyTerminalSession({
       }
     }
 
+    if (autoFocus && !readOnly) {
+      window.requestAnimationFrame(() => {
+        if (disposed) return
+        focusCapture?.()
+      })
+    }
+
     keydownCapture = (ev: KeyboardEvent) => {
       if (ev.key === "Backspace" && !ev.altKey && !ev.ctrlKey && !ev.metaKey) {
         ev.preventDefault()
@@ -967,7 +977,7 @@ export function PtyTerminalSession({
       webglAddon?.dispose()
       term.dispose()
     }
-	  }, [workspaceId, threadId, reconnectToken, readOnly, initialBase64, mockWorkspaceLabel, mockCwd])
+	  }, [workspaceId, threadId, reconnectToken, readOnly, autoFocus, initialBase64, mockWorkspaceLabel, mockCwd])
 
 	  return (
 	    <div

--- a/web/tests/ui/scenarios/activity-terminal-command.mjs
+++ b/web/tests/ui/scenarios/activity-terminal-command.mjs
@@ -7,24 +7,9 @@ export async function runActivityTerminalCommand({ page }) {
 
   await page.getByTestId('chat-mode-toggle').click();
 
-  const cmdWithOutput = `echo terminal-smoke-${Date.now()}`;
-  await page.getByTestId('chat-input').fill(cmdWithOutput);
-  await page.getByTestId('chat-send').click();
+  await page.getByTestId('shell-composer').waitFor({ state: 'visible' });
+  await page.getByTestId('pty-terminal').waitFor({ state: 'visible' });
 
-  await page
-    .getByTestId('activity-terminal-command')
-    .filter({ hasText: cmdWithOutput })
-    .first()
-    .waitFor({ state: 'visible' });
-
-  const cmdNoOutput = 'true';
-  await page.getByTestId('chat-input').fill(cmdNoOutput);
-  await page.getByTestId('chat-send').click();
-
-  await page
-    .getByTestId('activity-event')
-    .filter({ hasText: `ran ${cmdNoOutput}` })
-    .first()
-    .waitFor({ state: 'visible' });
+  await page.getByTestId('chat-mode-toggle').click();
+  await page.getByTestId('chat-input').waitFor({ state: 'visible' });
 }
-


### PR DESCRIPTION
## What
- Replace the chat toggle "terminal mode" from a one-shot command runner to a persistent PTY-backed shell pane.
- Auto-focus the terminal when entering shell mode.
- Update UI smoke to cover the new interaction.

## Why
The previous mode behaved like "run a command" rather than a full shell experience. A persistent PTY shell enables normal interactive behavior (e.g. completion, history) as configured by the user's shell.

## Verify
- `just fmt && just lint && just test && just test-ui`
- Manual:
  1) Open a task.
  2) Toggle to shell.
  3) Type `echo ok` in the terminal.
  4) Try `Tab` completion (depends on local shell configuration).
  5) Toggle back to chat.
