### PR TITLE
New Task: do not persist last selected workdir

### DIFF
--- a/web/components/new-task-modal.tsx
+++ b/web/components/new-task-modal.tsx
@@ -169,15 +169,15 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
       void clearNewTaskStash().catch((err) => console.warn("clearNewTaskStash failed", err))
       return
     }
-    const stashedWorkdirId = selectedWorkdirId === -1 ? null : selectedWorkdirId
     void saveNewTaskStash({
       text: input,
       projectId: effectiveProjectId || null,
-      workdirId: stashedWorkdirId,
+      // Do not persist workdir selection; always use the contextual default on next open.
+      workdirId: null,
       editingDraftId,
       updatedAtUnixMs: Date.now(),
     }).catch((err) => console.warn("saveNewTaskStash failed", err))
-  }, [editingDraftId, effectiveProjectId, input, selectedWorkdirId])
+  }, [editingDraftId, effectiveProjectId, input])
 
   useEffect(() => {
     const prev = prevOpenRef.current
@@ -211,8 +211,7 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
           setInput(stash.text)
           setSelectedProjectId(stash.projectId ?? defaultProjectId ?? "")
           setSelectedWorkdirId(
-            stash.workdirId ??
-              (stash.projectId ? pickDefaultWorkdirIdForProjectId(stash.projectId) : null) ??
+            (stash.projectId ? pickDefaultWorkdirIdForProjectId(stash.projectId) : null) ??
               (defaultProjectId ? pickDefaultWorkdirIdForProjectId(defaultProjectId) : null),
           )
           setEditingDraftId(stash.editingDraftId)

--- a/web/tests/ui/scenarios/new-task-modal.mjs
+++ b/web/tests/ui/scenarios/new-task-modal.mjs
@@ -37,7 +37,27 @@ export async function runNewTaskModal({ page }) {
   await workdirSelector.waitFor({ state: 'visible' });
   await waitForDataAttribute(workdirSelector, 'data-selected-workdir-id', '1', 10_000);
 
+  // Changing the workdir and stashing should not persist that selection across opens.
+  await workdirSelector.click();
+  await page.getByRole('menuitem').filter({ hasText: 'feat-ui' }).first().click();
+  await waitForDataAttribute(workdirSelector, 'data-selected-workdir-id', '2', 10_000);
+
   await page.getByTestId('new-task-input').fill('Fix: programmatic agent-browser smoke');
+  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+  await waitForDataAttribute(workdirSelector, 'data-selected-workdir-id', '1', 10_000);
+
+  // Clear stash to avoid interfering with later scenarios.
+  await page.getByTestId('new-task-input').fill('');
+  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
   const pngPath = writeTempPng();
   try {
     await page.getByTestId('new-task-attachment-input').setInputFiles(pngPath);


### PR DESCRIPTION
## What changed
- New Task stash no longer remembers the last selected workdir; each open derives the default from context (active → main → first).

## Verification
- just fmt && just lint && just test
- pnpm -C web install --frozen-lockfile && just test-ui
