### PR TITLE
Fix Tasks project icon to use avatar

### DIFF
--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -602,7 +602,11 @@ export function InboxView({ onOpenFullView }: InboxViewProps) {
             <TaskHeader
               title={selectedNotification.taskTitle}
               workdir={selectedNotification.workdir}
-              project={{ name: selectedNotification.projectName, color: selectedNotification.projectColor }}
+              project={{
+                name: selectedNotification.projectName,
+                color: selectedNotification.projectColor,
+                avatarUrl: selectedNotification.projectAvatarUrl,
+              }}
               actionBar={
                 <div className="flex items-center gap-2 min-w-0">
                   <TaskStatusSelector

--- a/web/components/shared/task-header.tsx
+++ b/web/components/shared/task-header.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { MoreHorizontal, Star } from "lucide-react"
 import { OpenButton } from "./open-button"
 
@@ -8,6 +9,8 @@ export interface ProjectInfo {
   name: string
   /** Tailwind background color class (e.g., "bg-violet-500") */
   color: string
+  /** Optional project avatar URL (e.g., git provider avatar). */
+  avatarUrl?: string
 }
 
 interface TaskHeaderProps {
@@ -32,12 +35,34 @@ interface TaskHeaderProps {
 }
 
 /**
- * Project icon component - displays a colored square with the first letter
+ * Project icon component - displays an avatar image when available, otherwise a colored square with the first letter.
  * Exported for use in other components (e.g., TaskListView header)
  */
-export function ProjectIcon({ name, color }: ProjectInfo) {
+export function ProjectIcon({ name, color, avatarUrl, testId }: ProjectInfo & { testId?: string }) {
+  const [avatarLoadFailed, setAvatarLoadFailed] = useState(false)
+
+  useEffect(() => {
+    setAvatarLoadFailed(false)
+  }, [avatarUrl])
+
+  if (avatarUrl && !avatarLoadFailed) {
+    return (
+      <img
+        data-testid={testId}
+        src={avatarUrl}
+        alt=""
+        aria-hidden="true"
+        width={14}
+        height={14}
+        className="w-[14px] h-[14px] rounded-[3px] overflow-hidden flex-shrink-0"
+        onError={() => setAvatarLoadFailed(true)}
+      />
+    )
+  }
+
   return (
     <span
+      data-testid={testId}
       className={`w-[14px] h-[14px] rounded-[3px] flex items-center justify-center text-[9px] font-semibold text-white flex-shrink-0 ${color}`}
     >
       {name.charAt(0).toUpperCase()}
@@ -72,7 +97,7 @@ export function TaskHeader({
                 onClick={onProjectClick}
                 className="flex items-center gap-1 hover:opacity-70 transition-opacity flex-shrink-0"
               >
-                <ProjectIcon name={project.name} color={project.color} />
+                <ProjectIcon name={project.name} color={project.color} avatarUrl={project.avatarUrl} />
                 <span className="text-[13px] font-medium" style={{ color: "#1b1b1b" }}>
                   {project.name}
                 </span>

--- a/web/components/task-detail-view.tsx
+++ b/web/components/task-detail-view.tsx
@@ -6,6 +6,7 @@ import { TaskHeader } from "./shared/task-header"
 import { useLuban } from "@/lib/luban-context"
 import { getActiveProjectInfo } from "@/lib/active-project-info"
 import { projectColorClass } from "@/lib/project-colors"
+import { buildSidebarProjects } from "@/lib/sidebar-view-model"
 import { fetchTasks } from "@/lib/luban-http"
 
 interface TaskDetailViewProps {
@@ -47,6 +48,18 @@ export function TaskDetailView({ taskId, taskTitle, workdir, projectName, projec
     return "bg-violet-500"
   })()
 
+  const resolvedProjectAvatarUrl = (() => {
+    if (!app || activeWorkspaceId == null) return undefined
+    const projectId = (() => {
+      for (const p of app.projects) {
+        if (p.workdirs.some((w) => w.id === activeWorkspaceId)) return p.id
+      }
+      return null
+    })()
+    if (!projectId) return undefined
+    return buildSidebarProjects(app).find((p) => p.id === projectId)?.avatarUrl
+  })()
+
   useEffect(() => {
     if (!app || activeWorkspaceId == null || activeThreadId == null) {
       setIsStarred(false)
@@ -83,7 +96,7 @@ export function TaskDetailView({ taskId, taskTitle, workdir, projectName, projec
       <TaskHeader
         title={resolvedTitle}
         workdir={resolvedWorkdir}
-        project={{ name: resolvedProjectName, color: resolvedProjectColor }}
+        project={{ name: resolvedProjectName, color: resolvedProjectColor, avatarUrl: resolvedProjectAvatarUrl }}
         onProjectClick={onBack}
         showFullActions
         isStarred={isStarred}

--- a/web/components/task-list-view.tsx
+++ b/web/components/task-list-view.tsx
@@ -15,6 +15,7 @@ import { useLuban } from "@/lib/luban-context"
 import { agentRunnerLabel } from "@/lib/conversation-ui"
 import { computeProjectDisplayNames } from "@/lib/project-display-names"
 import { projectColorClass } from "@/lib/project-colors"
+import { buildSidebarProjects } from "@/lib/sidebar-view-model"
 import { fetchTasks } from "@/lib/luban-http"
 import type {
   AgentRunnerKind,
@@ -430,8 +431,17 @@ export function TaskListView({ activeProjectId, mode = "active", onModeChange, o
 
   const headerProject: ProjectInfo = useMemo(() => {
     if (!app) return { name: "Projects", color: "bg-violet-500" }
-    const displayNames = computeProjectDisplayNames(app.projects.map((p) => ({ path: p.path, name: p.name })))
     if (activeProjectId) {
+      const sidebarVm = buildSidebarProjects(app).find((p) => p.id === activeProjectId) ?? null
+      if (sidebarVm) {
+        return {
+          name: sidebarVm.displayName,
+          color: projectColorClass(sidebarVm.id),
+          avatarUrl: sidebarVm.avatarUrl,
+        }
+      }
+
+      const displayNames = computeProjectDisplayNames(app.projects.map((p) => ({ path: p.path, name: p.name })))
       const p = app.projects.find((p) => p.id === activeProjectId)
       if (p) return { name: displayNames.get(p.path) ?? p.slug, color: projectColorClass(p.id) }
     }
@@ -451,10 +461,15 @@ export function TaskListView({ activeProjectId, mode = "active", onModeChange, o
       <div
         className="flex items-center h-[39px] flex-shrink-0"
         style={{ padding: '0 24px 0 20px', borderBottom: '1px solid #ebebeb' }}
-      >
+        >
         {/* Project Indicator */}
         <div className="flex items-center gap-1">
-          <ProjectIcon name={headerProject.name} color={headerProject.color} />
+          <ProjectIcon
+            testId="task-list-project-icon"
+            name={headerProject.name}
+            color={headerProject.color}
+            avatarUrl={headerProject.avatarUrl}
+          />
           <span className="text-[13px] font-medium" style={{ color: '#1b1b1b' }}>
             {headerProject.name}
           </span>

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -28,6 +28,7 @@ import { runNewTaskDrafts } from './scenarios/new-task-drafts.mjs';
 import { runNoRightSidebar } from './scenarios/no-right-sidebar.mjs';
 import { runSettingsPanel } from './scenarios/settings-panel.mjs';
 import { runSidebarProjectAvatars } from './scenarios/sidebar-project-avatars.mjs';
+import { runTaskListProjectIcon } from './scenarios/task-list-project-icon.mjs';
 import { runStarFavorites } from './scenarios/star-favorites.mjs';
 import { runTaskStatusChange } from './scenarios/task-status-change.mjs';
 import { runTaskListNavigation } from './scenarios/task-list-navigation.mjs';
@@ -161,6 +162,7 @@ async function main() {
 	    await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
 	
 	    await runSidebarProjectAvatars({ page, baseUrl });
+      await runTaskListProjectIcon({ page, baseUrl });
       await runProjectArchiveMenu({ page, baseUrl });
 	    await runNewTaskModal({ page, baseUrl });
 	    await runNewTaskDrafts({ page, baseUrl });

--- a/web/tests/ui/scenarios/task-list-project-icon.mjs
+++ b/web/tests/ui/scenarios/task-list-project-icon.mjs
@@ -1,0 +1,25 @@
+export async function runTaskListProjectIcon({ page }) {
+  const settingsPanel = page.getByTestId('settings-panel');
+  if (await settingsPanel.isVisible()) {
+    await settingsPanel.getByText('Back').click();
+    await settingsPanel.waitFor({ state: 'hidden' });
+  }
+
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const icon = page.getByTestId('task-list-project-icon');
+  await icon.waitFor({ state: 'visible' });
+
+  const tagName = await icon.evaluate((el) => el.tagName);
+  if (tagName !== 'IMG') {
+    throw new Error(`expected task list project icon to be an IMG, got: ${tagName}`);
+  }
+
+  const box = await icon.boundingBox();
+  if (!box) throw new Error('missing task list project icon bounding box');
+  if (Math.round(box.width) !== 14 || Math.round(box.height) !== 14) {
+    throw new Error(`expected task list project icon to be 14x14, got ${box.width}x${box.height}`);
+  }
+}
+


### PR DESCRIPTION
## What
- Tasks page header project icon shows the project avatar (same source as the sidebar) instead of always falling back to the first letter.
- Task detail header and inbox preview header reuse the same `ProjectIcon` behavior.

## Why
- The Tasks header was rendering a letter-based fallback even when a project avatar was available.

## Verification
- `just fmt && just lint && just test && just test-ui`

## Manual check
1. Open Tasks view.
2. Select a git project that has an avatar.
3. Confirm the header project icon renders an image (14x14).
4. Open a task and confirm the task header project icon matches.

## Risk / Rollback
- Risk: avatar URL load failures fall back to the letter icon.
- Rollback: revert commit `719c209`.
