### PR TITLE
Replace task status auto-update with suggestions

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -603,7 +603,18 @@ pub struct ConversationSystemEventEntry {
 #[serde(tag = "event_type", rename_all = "snake_case")]
 pub enum ConversationSystemEvent {
     TaskCreated,
-    TaskStatusChanged { from: TaskStatus, to: TaskStatus },
+    TaskStatusChanged {
+        from: TaskStatus,
+        to: TaskStatus,
+    },
+    TaskStatusSuggestion {
+        from: TaskStatus,
+        to: TaskStatus,
+        #[serde(default)]
+        title: String,
+        #[serde(default)]
+        explanation_markdown: String,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -935,14 +935,14 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(anyhow_error_to_string)
     }
 
-    fn mark_conversation_tasks_done_for_merged_pr(
+    fn list_conversation_tasks_for_merged_pr(
         &self,
         project_slug: String,
         workspace_name: String,
         pr_number: u64,
     ) -> Result<Vec<u64>, String> {
         self.sqlite
-            .mark_conversation_tasks_done_for_merged_pr(project_slug, workspace_name, pr_number)
+            .list_conversation_tasks_for_merged_pr(project_slug, workspace_name, pr_number)
             .map_err(anyhow_error_to_string)
     }
 

--- a/crates/luban_domain/src/actions.rs
+++ b/crates/luban_domain/src/actions.rs
@@ -391,11 +391,13 @@ pub enum Action {
         thread_id: WorkspaceThreadId,
         task_status: TaskStatus,
     },
-    TaskStatusAutoUpdateSuggested {
+    TaskStatusSuggestionCreated {
         workspace_id: WorkspaceId,
         thread_id: WorkspaceThreadId,
         expected_current_task_status: TaskStatus,
         suggested_task_status: TaskStatus,
+        title: String,
+        explanation_markdown: String,
     },
 
     SidebarProjectOrderChanged {

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -169,6 +169,7 @@ pub struct TaskStatusAutoUpdateSuggestion {
     pub task_status: TaskStatus,
     pub validation_pr_number: Option<u64>,
     pub validation_pr_url: Option<String>,
+    pub explanation_markdown: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -388,7 +389,7 @@ pub trait ProjectWorkspaceService: Send + Sync {
         Ok(())
     }
 
-    fn mark_conversation_tasks_done_for_merged_pr(
+    fn list_conversation_tasks_for_merged_pr(
         &self,
         _project_slug: String,
         _workspace_name: String,
@@ -607,6 +608,7 @@ pub trait ProjectWorkspaceService: Send + Sync {
             task_status,
             validation_pr_number: None,
             validation_pr_url: None,
+            explanation_markdown: None,
         })
     }
 

--- a/crates/luban_domain/src/state/conversation.rs
+++ b/crates/luban_domain/src/state/conversation.rs
@@ -11,7 +11,18 @@ use std::collections::VecDeque;
 #[serde(tag = "event_type", rename_all = "snake_case")]
 pub enum ConversationSystemEvent {
     TaskCreated,
-    TaskStatusChanged { from: TaskStatus, to: TaskStatus },
+    TaskStatusChanged {
+        from: TaskStatus,
+        to: TaskStatus,
+    },
+    TaskStatusSuggestion {
+        from: TaskStatus,
+        to: TaskStatus,
+        #[serde(default)]
+        title: String,
+        #[serde(default)]
+        explanation_markdown: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/luban_domain/src/system_prompts.rs
+++ b/crates/luban_domain/src/system_prompts.rs
@@ -30,7 +30,7 @@ impl SystemTaskKind {
             SystemTaskKind::InferType => "Infer Type",
             SystemTaskKind::RenameBranch => "Rename Branch",
             SystemTaskKind::AutoTitleThread => "Auto Title Thread",
-            SystemTaskKind::AutoUpdateTaskStatus => "Auto Update Task Status",
+            SystemTaskKind::AutoUpdateTaskStatus => "Suggest Task Status",
         }
     }
 }
@@ -127,11 +127,11 @@ Rules:
 - Do NOT run commands.
 - Do NOT modify files.
 - Output ONLY a single JSON object, no markdown, no extra text.
-- Do NOT include rationale, notes, or any extra fields in the output.
 - Always output a result, even if the input is vague: keep the current status.
 - Prefer conservative updates: do not mark as "done" unless the task is clearly finished.
 - If the conversation indicates the work has been submitted as a pull request, you should generally use task_status="validating".
 - When you output task_status="validating", you must try to extract the pull request number (and URL if present) from the conversation context, so the system can auto-complete the task when that PR is merged later.
+- Include a short user-facing explanation in explanation_markdown. Do NOT reveal hidden chain-of-thought; keep it to observable signals.
 
 Allowed task_status values:
 - backlog
@@ -151,7 +151,8 @@ Output JSON schema:
 {
   "task_status": "<one of the allowed values>",
   "validation_pr_number": "<integer or null>",
-  "validation_pr_url": "<string; empty if validation_pr_number is null>"
+  "validation_pr_url": "<string; empty if validation_pr_number is null>",
+  "explanation_markdown": "<string; may be empty>"
 }
 
 Validation PR rules:
@@ -159,6 +160,11 @@ Validation PR rules:
 - Only set validation_pr_number if task_status="validating" and the conversation clearly references the PR number.
 - If you cannot identify a PR number, set validation_pr_number to null and validation_pr_url to an empty string.
 - If you set validation_pr_number, set validation_pr_url if and only if a URL is present in the conversation.
+
+explanation_markdown rules:
+- Keep it concise (prefer 2-6 bullets).
+- Mention only concrete evidence (e.g., "opened PR #123", "tests failing", "waiting on review").
+- If you keep the current status, still explain why.
 "#
             .to_owned()
         }

--- a/docs/contracts/features/c-http-conversation.md
+++ b/docs/contracts/features/c-http-conversation.md
@@ -47,7 +47,19 @@ The event payload is structured:
 - `type`: `system_event`
 - `entry_id`: stable string identifier (unique within the conversation)
 - `created_at_unix_ms`: millisecond timestamp
-- `event.event_type`: `task_created` | `task_status_changed`
+- `event.event_type`: `task_created` | `task_status_changed` | `task_status_suggestion`
+
+For `event.event_type=task_status_suggestion`:
+
+- `event.from`: `TaskStatus`
+- `event.to`: `TaskStatus`
+- `event.title`: string (may be empty)
+- `event.explanation_markdown`: string (may be empty; markdown is allowed)
+
+Semantics:
+
+- The provider emits this when it has analyzed the conversation progress and recommends updating the explicit `snapshot.task_status`.
+- The provider does not apply the change automatically; the client may apply it via `ClientAction::TaskStatusSet`.
 
 ### User events
 

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -67,6 +67,7 @@ These enums are part of the wire surface. Adding/removing variants must update t
   - `infer-type`
   - `rename-branch`
   - `auto-title-thread`
+  - `auto-update-task-status`
 
 ## Web usage
 

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -65,6 +65,7 @@ Legend:
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).
+- `C-HTTP-CONVERSATION`: `ConversationEntry.type=system_event` may include `event_type=task_status_suggestion` to recommend a status change; clients apply via `ClientAction::TaskStatusSet`.
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=user_event` supports `event.type=message`, `terminal_command_started`, and `terminal_command_finished`.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.title` matches `ThreadMeta.title` and may be updated after the first user message.
 - `C-HTTP-TASKS`: `TaskSummarySnapshot` includes `is_starred` for rendering Favorites and in-view star toggles.

--- a/web/components/settings-panel.tsx
+++ b/web/components/settings-panel.tsx
@@ -124,9 +124,9 @@ const systemTaskTypes: TaskTypeConfig[] = [
   { id: "auto-title-thread", label: "Auto Title Thread", icon: Type, description: "Generate a short thread title from the first user message" },
   {
     id: "auto-update-task-status",
-    label: "Auto Update Task Status",
+    label: "Suggest Task Status",
     icon: CheckCircle2,
-    description: "Update task status based on the latest agent progress",
+    description: "Suggest task status based on the latest agent progress (manual apply)",
   },
 ]
 

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -239,6 +239,13 @@ export type ConversationSnapshot = {
 export type ConversationSystemEvent =
   | { event_type: "task_created" }
   | { event_type: "task_status_changed"; from: TaskStatus; to: TaskStatus }
+  | {
+      event_type: "task_status_suggestion"
+      from: TaskStatus
+      to: TaskStatus
+      title: string
+      explanation_markdown: string
+    }
 
 export type ConversationSystemEventEntry = {
   entry_id: string

--- a/web/lib/mock/fixtures.ts
+++ b/web/lib/mock/fixtures.ts
@@ -166,6 +166,13 @@ function systemEvent(args: {
   event:
     | { event_type: "task_created" }
     | { event_type: "task_status_changed"; from: TaskStatus; to: TaskStatus }
+    | {
+        event_type: "task_status_suggestion"
+        from: TaskStatus
+        to: TaskStatus
+        title: string
+        explanation_markdown: string
+      }
 }): ConversationEntry {
   return {
     type: "system_event",


### PR DESCRIPTION
## Summary
- Remove all automatic task status updates.
- Emit a `task_status_suggestion` system event (expandable card) after status analysis.
- Apply is explicit: user clicks **Apply** to send `TaskStatusSet`.

## User-Visible Behavior
- Task status no longer changes automatically after an agent turn.
- The timeline shows a Task Status Suggestion card with an explanation; status changes only after Apply.

## Contracts
- Updated: `docs/contracts/features/c-http-conversation.md`, `docs/contracts/features/c-ws-events.md`, `docs/contracts/progress.md`.

## Verification
- `just fmt && just lint && just test`
- `cd web && pnpm test:ui`

## Notes
- This keeps `TaskStatus` and `AgentStatus` conceptually separate while removing the confusing implicit coupling caused by auto-updates.
