### PR TITLE
web: auto-scroll to latest on task open

### DIFF
--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -1236,6 +1236,90 @@ export function TaskActivityView({
     scrollContainerRef.current = el
     setScrollContainerEl(el)
   }, [])
+  const contentWrapperRef = useRef<HTMLDivElement | null>(null)
+  const [contentWrapperEl, setContentWrapperEl] = useState<HTMLDivElement | null>(null)
+  const setContentWrapper = useCallback((el: HTMLDivElement | null) => {
+    contentWrapperRef.current = el
+    setContentWrapperEl(el)
+  }, [])
+  const autoScrollRef = useRef<{ epoch: number; untilMs: number; maxUntilMs: number; raf: number | null } | null>(null)
+
+  const stopAutoScrollToLatest = useCallback(() => {
+    const pending = autoScrollRef.current
+    if (pending?.raf != null) {
+      window.cancelAnimationFrame(pending.raf)
+    }
+    autoScrollRef.current = null
+  }, [])
+
+  const startAutoScrollToLatest = useCallback(
+    ({ durationMs, maxDurationMs }: { durationMs: number; maxDurationMs: number }) => {
+      if (workspaceId == null || taskId == null) return
+      const el = scrollContainerRef.current
+      if (!el) return
+
+      const prev = autoScrollRef.current
+      const epoch = (prev?.epoch ?? 0) + 1
+      const startedAt = Date.now()
+      const maxUntilMs = startedAt + maxDurationMs
+      const untilMs = Math.min(maxUntilMs, startedAt + durationMs)
+
+      if (prev?.raf != null) window.cancelAnimationFrame(prev.raf)
+      autoScrollRef.current = { epoch, untilMs, maxUntilMs, raf: null }
+
+      const tick = () => {
+        const pending = autoScrollRef.current
+        if (!pending || pending.epoch !== epoch) return
+        const root = scrollContainerRef.current
+        if (root) {
+          root.scrollTop = root.scrollHeight
+        }
+        if (Date.now() >= pending.untilMs) {
+          stopAutoScrollToLatest()
+          return
+        }
+        pending.raf = window.requestAnimationFrame(tick)
+      }
+
+      autoScrollRef.current.raf = window.requestAnimationFrame(tick)
+    },
+    [stopAutoScrollToLatest, taskId, workspaceId],
+  )
+
+  useEffect(() => {
+    if (!scrollContainerEl) return
+    if (workspaceId == null || taskId == null) return
+    startAutoScrollToLatest({ durationMs: 400, maxDurationMs: 2000 })
+    return () => stopAutoScrollToLatest()
+  }, [listKey, scrollContainerEl, startAutoScrollToLatest, stopAutoScrollToLatest, taskId, workspaceId])
+
+  useEffect(() => {
+    const el = scrollContainerEl
+    if (!el) return
+    const onUserScrollIntent = () => stopAutoScrollToLatest()
+    el.addEventListener("wheel", onUserScrollIntent, { passive: true })
+    el.addEventListener("touchstart", onUserScrollIntent, { passive: true })
+    el.addEventListener("pointerdown", onUserScrollIntent)
+    return () => {
+      el.removeEventListener("wheel", onUserScrollIntent)
+      el.removeEventListener("touchstart", onUserScrollIntent)
+      el.removeEventListener("pointerdown", onUserScrollIntent)
+    }
+  }, [scrollContainerEl, stopAutoScrollToLatest])
+
+  useEffect(() => {
+    const wrapper = contentWrapperEl
+    if (!wrapper) return
+    const observer = new ResizeObserver(() => {
+      const pending = autoScrollRef.current
+      if (!pending) return
+      const now = Date.now()
+      if (now >= pending.maxUntilMs) return
+      pending.untilMs = Math.min(pending.maxUntilMs, now + 250)
+    })
+    observer.observe(wrapper)
+    return () => observer.disconnect()
+  }, [contentWrapperEl, listKey])
 
   return (
     <div 
@@ -1249,7 +1333,11 @@ export function TaskActivityView({
         data-testid="chat-scroll-container"
         style={{ padding: "0 60px" }}
       >
-        <div data-testid="chat-content-wrapper" style={{ maxWidth: "686px", margin: "0 auto" }}>
+        <div
+          ref={setContentWrapper}
+          data-testid="chat-content-wrapper"
+          style={{ maxWidth: "686px", margin: "0 auto" }}
+        >
           {/* Task header with title and description */}
           <TaskHeaderSection
             title={title}

--- a/web/tests/ui/scenarios/activity-windowing.mjs
+++ b/web/tests/ui/scenarios/activity-windowing.mjs
@@ -6,7 +6,11 @@ export async function runActivityWindowing({ page }) {
   const scrollContainer = page.getByTestId('chat-scroll-container');
   await scrollContainer.waitFor({ state: 'visible' });
 
-  await page.getByText('Assistant message 0').first().waitFor({ state: 'visible' });
+  await page.getByText('Assistant message 319').first().waitFor({ state: 'visible' });
+  const distanceToBottom = await scrollContainer.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
+  if (distanceToBottom > 5) {
+    throw new Error(`expected to start at the latest activity (near bottom), got distanceToBottom=${distanceToBottom}`);
+  }
 
   const userCount = await page.getByTestId('activity-user-message-content').count();
   const agentCount = await page.getByTestId('activity-agent-message-content').count();
@@ -14,11 +18,4 @@ export async function runActivityWindowing({ page }) {
   if (total > 200) {
     throw new Error(`expected windowed activity stream to keep DOM bounded, got ${total} message nodes`);
   }
-
-  await scrollContainer.evaluate((el) => {
-    el.scrollTop = el.scrollHeight;
-  });
-
-  await page.getByText('Assistant message 319').first().waitFor({ state: 'visible' });
 }
-


### PR DESCRIPTION
## Behavior
- When a task is opened (any entry point) or switched, the activity view automatically scrolls to the latest events (bottom).
- For long conversations (windowed list + incremental measurement), the view stays pinned to bottom for a short window so the final layout reliably lands at the latest event.
- Auto-scroll is cancelled immediately when the user shows scroll intent (wheel/touch/pointer).

## Changes
- `web/components/task-activity-view.tsx`: add short-lived auto-scroll-to-latest on task open/switch, extend pin window on content resize, cancel on user scroll intent.
- `web/tests/ui/scenarios/activity-windowing.mjs`: assert the long conversation opens near the bottom (latest message visible) and DOM windowing remains bounded.

## Verification
- `just fmt`
- `just lint`
- `just test`
- `cd web && pnpm install --frozen-lockfile`
- `just test-ui`

## Manual checks
1. Open a task from Task List and confirm the view lands at the latest activity.
2. Open a task from Inbox preview/full view and confirm the view lands at the latest activity.
3. Immediately scroll up after opening and confirm the UI does not keep forcing you back to the bottom.

## Risk / Rollback
- Risk: brief auto-scroll-to-bottom may surprise users who intended to read older content immediately after opening.
- Mitigation: any user scroll intent cancels auto-scroll.
- Rollback: revert commit `ad33b41`.

## Contracts
- No web/server integration surface changes.
