### PR TITLE
Inbox: show only runner spinner while running

### DIFF
--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -133,20 +133,32 @@ function InboxTaskStatusIndicator({
   hasUnreadCompletion: boolean
 }) {
   const label = taskStatusConfig[lifecycleStatus]?.label ?? lifecycleStatus
+
+  if (isRunning) {
+    return (
+      <div
+        className="flex items-center justify-end"
+        title="Agent: running"
+        data-testid="inbox-notification-status-indicator"
+      >
+        <Loader2
+          className="w-[14px] h-[14px] animate-spin"
+          style={{ color: "#5e6ad2" }}
+          data-testid="inbox-notification-runner-spinner"
+          aria-label="Agent running"
+        />
+      </div>
+    )
+  }
+
   return (
     <div
       className="flex items-center justify-end gap-1"
-      title={isRunning ? `Task status: ${label} (runner running)` : `Task status: ${label}`}
+      title={`Task status: ${label}`}
       data-testid="inbox-notification-status-indicator"
     >
       <TaskStatusIcon status={lifecycleStatus} size="xs" className="w-[14px] h-[14px]" />
-      {isRunning ? (
-        <Loader2
-          className="w-[12px] h-[12px] animate-spin"
-          style={{ color: "#5e6ad2" }}
-          data-testid="inbox-notification-runner-spinner"
-        />
-      ) : hasUnreadCompletion ? (
+      {hasUnreadCompletion ? (
         <span
           className="w-[6px] h-[6px] rounded-full"
           style={{ backgroundColor: "#5e6ad2" }}

--- a/web/tests/ui/scenarios/cancel-task-clears-running.mjs
+++ b/web/tests/ui/scenarios/cancel-task-clears-running.mjs
@@ -26,11 +26,21 @@ async function waitForNotRunning(row, timeoutMs = 20_000) {
   throw new Error('timeout waiting for running icon to clear');
 }
 
+async function assertRunningShowsOnlySpinner(row) {
+  const status = row.getByTestId('inbox-notification-task-status-icon');
+  await status.getByTestId('inbox-notification-runner-spinner').waitFor({ state: 'visible' });
+  const taskGlyphs = await status.locator('[class*="icon-[tabler--"]').count();
+  if (taskGlyphs !== 0) {
+    throw new Error(`expected no task status icon while running, found ${taskGlyphs}`);
+  }
+}
+
 export async function runCancelTaskClearsRunning({ page }) {
   await page.getByTestId('nav-inbox-button').click();
   await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
 
   const row = await findInboxRowByTitle(page, 'PR: pending');
+  await assertRunningShowsOnlySpinner(row);
   await row.click();
 
   const trigger = page.getByTestId('inbox-task-status-trigger');
@@ -43,4 +53,3 @@ export async function runCancelTaskClearsRunning({ page }) {
   const updatedRow = await findInboxRowByTitle(page, 'PR: pending');
   await waitForNotRunning(updatedRow);
 }
-


### PR DESCRIPTION
## What
- When an agent is running, Inbox rows render only the runner spinner (task lifecycle icon is hidden).
- Keeps the existing unread completion dot behavior for non-running rows.

## Why
- During an active agent run, the run state is the primary signal; task lifecycle status is secondary noise.

## Tests
- Updated: `web/tests/ui/scenarios/cancel-task-clears-running.mjs`
- Ran: `just fmt && just lint && just test && just test-ui`

## Manual verification
1. Open **Inbox**.
2. Locate a row with a running agent.
3. Confirm the status area shows only a spinner (no task status glyph).
4. Cancel/finish the task.
5. Confirm the spinner clears and the task status glyph returns.
