### PR TITLE
Web: key-sequence shortcuts + status picker

### DIFF
--- a/web/components/chat-panel.tsx
+++ b/web/components/chat-panel.tsx
@@ -20,6 +20,7 @@ import type {
   QueuedPromptSnapshot,
   ThinkingEffort,
   ChangedFileSnapshot,
+  ConversationEntry,
 } from "@/lib/luban-api"
 import { attachmentHref } from "@/lib/attachment-href"
 import {
@@ -258,10 +259,10 @@ export function ChatPanel({
   }, [displayMessages])
   const agentActivities = useMemo(() => buildAgentActivities(conversation), [conversation])
   const messageHistory = useMemo(() => {
-    const entries = conversation?.entries ?? []
+    const entries: ConversationEntry[] = conversation?.entries ?? []
     const isUserMessage = (
-      entry: (typeof entries)[number],
-    ): entry is Extract<(typeof entries)[number], { type: "user_event"; event: { type: "message" } }> =>
+      entry: ConversationEntry,
+    ): entry is Extract<ConversationEntry, { type: "user_event" }> & { event: { type: "message"; text: string } } =>
       entry.type === "user_event" && entry.event.type === "message"
     const items = entries
       .filter(isUserMessage)

--- a/web/components/diff-tab-panel.tsx
+++ b/web/components/diff-tab-panel.tsx
@@ -15,6 +15,8 @@ import type { ChangedFileSnapshot } from "@/lib/luban-api"
 
 export type DiffStyle = "split" | "unified"
 
+type ChangedFile = ChangedFileSnapshot
+
 export interface DiffFileData {
   file: ChangedFileSnapshot
   oldFile: FileContents

--- a/web/components/global-sequence-shortcuts.tsx
+++ b/web/components/global-sequence-shortcuts.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName.toLowerCase()
+  if (tag === "input" || tag === "textarea" || tag === "select") return true
+  return target.isContentEditable
+}
+
+function isSuppressedTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.closest(".luban-terminal")) return true
+  if (target.closest('[data-shortcuts-disabled="true"]')) return true
+  return false
+}
+
+function normalizeSequenceKey(raw: string): string | null {
+  if (raw.length !== 1) return null
+  const upper = raw.toUpperCase()
+  if (upper >= "A" && upper <= "Z") return upper
+  if (raw >= "0" && raw <= "9") return raw
+  return null
+}
+
+type TaskListMode = "all" | "active" | "backlog"
+
+export function GlobalSequenceShortcuts({
+  enabled,
+  canGoProjectModes,
+  canOpenStatusPicker,
+  onNewTask,
+  onGoInbox,
+  onSetTaskListMode,
+  onOpenStatusPicker,
+}: {
+  enabled: boolean
+  canGoProjectModes: boolean
+  canOpenStatusPicker: boolean
+  onNewTask: () => void
+  onGoInbox: () => void
+  onSetTaskListMode: (mode: TaskListMode) => void
+  onOpenStatusPicker: () => void
+}) {
+  const goPrefixTimeoutRef = useRef<number | null>(null)
+  const pendingGoRef = useRef(false)
+
+  useEffect(() => {
+    const clearGoPrefix = () => {
+      pendingGoRef.current = false
+      if (goPrefixTimeoutRef.current != null) {
+        window.clearTimeout(goPrefixTimeoutRef.current)
+        goPrefixTimeoutRef.current = null
+      }
+    }
+
+    const armGoPrefix = () => {
+      pendingGoRef.current = true
+      if (goPrefixTimeoutRef.current != null) window.clearTimeout(goPrefixTimeoutRef.current)
+      goPrefixTimeoutRef.current = window.setTimeout(() => clearGoPrefix(), 900)
+    }
+
+    const handler = (e: KeyboardEvent) => {
+      if (!enabled) return
+      if (e.defaultPrevented) return
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      if (e.repeat) return
+      if (isEditableTarget(e.target)) return
+      if (isSuppressedTarget(e.target)) return
+
+      const key = normalizeSequenceKey(e.key)
+
+      if (!key) {
+        if (pendingGoRef.current) clearGoPrefix()
+        return
+      }
+
+      if (pendingGoRef.current) {
+        if (key === "I") {
+          e.preventDefault()
+          e.stopPropagation()
+          clearGoPrefix()
+          onGoInbox()
+          return
+        }
+        if (canGoProjectModes) {
+          if (key === "E") {
+            e.preventDefault()
+            e.stopPropagation()
+            clearGoPrefix()
+            onSetTaskListMode("all")
+            return
+          }
+          if (key === "A") {
+            e.preventDefault()
+            e.stopPropagation()
+            clearGoPrefix()
+            onSetTaskListMode("active")
+            return
+          }
+          if (key === "B") {
+            e.preventDefault()
+            e.stopPropagation()
+            clearGoPrefix()
+            onSetTaskListMode("backlog")
+            return
+          }
+        }
+        clearGoPrefix()
+        return
+      }
+
+      if (key === "G") {
+        e.preventDefault()
+        e.stopPropagation()
+        armGoPrefix()
+        return
+      }
+
+      if (key === "C") {
+        e.preventDefault()
+        e.stopPropagation()
+        onNewTask()
+        return
+      }
+
+      if (key === "S" && canOpenStatusPicker) {
+        e.preventDefault()
+        e.stopPropagation()
+        onOpenStatusPicker()
+        return
+      }
+    }
+
+    window.addEventListener("keydown", handler, { capture: true })
+    return () => {
+      window.removeEventListener("keydown", handler, { capture: true } as AddEventListenerOptions)
+      clearGoPrefix()
+    }
+  }, [canGoProjectModes, canOpenStatusPicker, enabled, onGoInbox, onNewTask, onOpenStatusPicker, onSetTaskListMode])
+
+  return null
+}
+

--- a/web/components/luban-ide.tsx
+++ b/web/components/luban-ide.tsx
@@ -9,6 +9,7 @@ import { InboxView, type InboxNotification } from "./inbox-view"
 import { SettingsPanel } from "./settings-panel"
 import { NewTaskModal } from "./new-task-modal"
 import { NewTaskDraftsDialog } from "./new-task-drafts-dialog"
+import { GlobalSequenceShortcuts } from "./global-sequence-shortcuts"
 import { useLuban } from "@/lib/luban-context"
 import type { TaskSummarySnapshot } from "@/lib/luban-api"
 import { computeProjectDisplayNames } from "@/lib/project-display-names"
@@ -39,6 +40,7 @@ export function LubanIDE() {
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
   const [newTaskDrafts, setNewTaskDrafts] = useState<NewTaskDraft[]>([])
   const [newTaskDraftsOpen, setNewTaskDraftsOpen] = useState(false)
+  const [statusPickerRequestSeq, setStatusPickerRequestSeq] = useState(0)
 
   useEffect(() => {
     const refresh = () => {
@@ -158,6 +160,7 @@ export function LubanIDE() {
       <TaskListView
         activeProjectId={activeProjectId}
         mode={taskListMode}
+        statusPickerRequestSeq={statusPickerRequestSeq}
         onModeChange={(mode) => {
           setActiveView(mode === "all" ? "tasks-all" : mode === "backlog" ? "tasks-backlog" : "tasks")
         }}
@@ -175,6 +178,22 @@ export function LubanIDE() {
 
   return (
     <>
+      <GlobalSequenceShortcuts
+        enabled={!settingsOpen && !newTaskOpen && !newTaskDraftsOpen}
+        canGoProjectModes={activeProjectId != null}
+        canOpenStatusPicker={activeProjectId != null && activeView !== "inbox" && !showDetail}
+        onNewTask={() => {
+          setNewTaskInitialDraft(null)
+          setNewTaskOpen(true)
+        }}
+        onGoInbox={() => handleViewChange("inbox")}
+        onSetTaskListMode={(mode) => {
+          setSelectedTask(null)
+          setShowDetail(false)
+          setActiveView(mode === "all" ? "tasks-all" : mode === "backlog" ? "tasks-backlog" : "tasks")
+        }}
+        onOpenStatusPicker={() => setStatusPickerRequestSeq((prev) => prev + 1)}
+      />
       <LubanLayout
         sidebar={
           <LubanSidebar

--- a/web/components/luban-sidebar.tsx
+++ b/web/components/luban-sidebar.tsx
@@ -19,6 +19,7 @@ import { buildSidebarProjects } from "@/lib/sidebar-view-model"
 import { projectColorClass } from "@/lib/project-colors"
 import { fetchTasks } from "@/lib/luban-http"
 import type { TaskSummarySnapshot } from "@/lib/luban-api"
+import { ShortcutTooltip } from "@/components/shared/shortcut-tooltip"
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -285,15 +286,17 @@ export function LubanSidebar({
           >
             <Search className="w-4 h-4" />
           </button>
-          <button
-            onClick={() => onNewTask?.()}
-            className="p-1.5 rounded-lg transition-colors hover:bg-[#e8e8e8]"
-            style={{ backgroundColor: '#ffffff', color: '#1b1b1b', boxShadow: '0 1px 2px rgba(0,0,0,0.05)' }}
-            title="New task"
-            data-testid="new-task-button"
-          >
-            <SquarePen className="w-4 h-4" />
-          </button>
+          <ShortcutTooltip label="New task" keys="C" side="bottom" align="end">
+            <button
+              onClick={() => onNewTask?.()}
+              className="p-1.5 rounded-lg transition-colors hover:bg-[#e8e8e8]"
+              style={{ backgroundColor: '#ffffff', color: '#1b1b1b', boxShadow: '0 1px 2px rgba(0,0,0,0.05)' }}
+              title="New task"
+              data-testid="new-task-button"
+            >
+              <SquarePen className="w-4 h-4" />
+            </button>
+          </ShortcutTooltip>
         </div>
       </div>
 
@@ -301,14 +304,16 @@ export function LubanSidebar({
       <div className="flex-1 overflow-y-auto overflow-x-hidden py-2 px-2">
         {/* Main Navigation */}
         <div className="space-y-0.5 mb-4">
-          <NavItem
-            icon={<Inbox className="w-4 h-4" />}
-            label="Inbox"
-            badge={inboxUnread}
-            testId="nav-inbox-button"
-            active={activeView === "inbox"}
-            onClick={() => handleNavClick("inbox")}
-          />
+          <ShortcutTooltip label="Go to inbox" keys={["G", "I"]} side="right" align="center">
+            <NavItem
+              icon={<Inbox className="w-4 h-4" />}
+              label="Inbox"
+              badge={inboxUnread}
+              testId="nav-inbox-button"
+              active={activeView === "inbox"}
+              onClick={() => handleNavClick("inbox")}
+            />
+          </ShortcutTooltip>
           {(newTaskDraftCount ?? 0) > 0 && (
             <NavItem
               icon={<FileText className="w-4 h-4" />}

--- a/web/components/shared/shortcut-tooltip.tsx
+++ b/web/components/shared/shortcut-tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+function ShortcutKbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex items-center justify-center rounded-[6px] border px-1.5 py-0.5 text-[11px] font-medium",
+        "min-w-[18px]",
+      )}
+      style={{ backgroundColor: "#fcfcfc", borderColor: "#ebebeb", color: "#6b6b6b" }}
+    >
+      {children}
+    </kbd>
+  )
+}
+
+export function ShortcutTooltip({
+  label,
+  keys,
+  children,
+  side = "bottom",
+  align = "center",
+  delayDuration = 120,
+}: {
+  label: string
+  keys: string | string[]
+  children: React.ReactElement
+  side?: React.ComponentProps<typeof TooltipContent>["side"]
+  align?: React.ComponentProps<typeof TooltipContent>["align"]
+  delayDuration?: number
+}) {
+  const normalized = Array.isArray(keys) ? keys : [keys]
+  return (
+    <TooltipProvider delayDuration={delayDuration}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <div className="flex items-center gap-2">
+            <span className="truncate">{label}</span>
+            <span className="flex items-center gap-1">
+              {normalized.map((k, idx) => (
+                <ShortcutKbd key={`${k}-${idx}`}>{k}</ShortcutKbd>
+              ))}
+            </span>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+

--- a/web/components/shared/task-status-command-menu.tsx
+++ b/web/components/shared/task-status-command-menu.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+import { createPortal } from "react-dom"
+import { Check } from "lucide-react"
+
+import type { TaskStatus } from "@/lib/luban-api"
+import { cn } from "@/lib/utils"
+import { taskStatuses } from "@/components/shared/task-status-selector"
+
+export type AnchorRect = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+function clampPosition(args: { top: number; left: number; width: number; height: number }): { top: number; left: number } {
+  const margin = 8
+  const maxLeft = Math.max(margin, window.innerWidth - args.width - margin)
+  const maxTop = Math.max(margin, window.innerHeight - args.height - margin)
+  return {
+    left: Math.min(Math.max(margin, args.left), maxLeft),
+    top: Math.min(Math.max(margin, args.top), maxTop),
+  }
+}
+
+export function TaskStatusCommandMenu({
+  open,
+  anchorRect,
+  status,
+  onSelect,
+  onClose,
+  testId = "task-status-command-menu",
+}: {
+  open: boolean
+  anchorRect: AnchorRect | null
+  status: TaskStatus
+  onSelect: (next: TaskStatus) => void
+  onClose: () => void
+  testId?: string
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const numbersByStatus = useMemo(() => {
+    const out = new Map<TaskStatus, string>()
+    for (let i = 0; i < taskStatuses.length; i += 1) {
+      const s = taskStatuses[i]
+      if (!s) continue
+      out.set(s.id, String(i + 1))
+    }
+    return out
+  }, [])
+
+  const position = useMemo(() => {
+    if (!open || !anchorRect) return null
+    const width = 320
+    const height = 320
+
+    const desiredTop = anchorRect.top + anchorRect.height + 8
+    const desiredLeft = anchorRect.left
+
+    const clamped = clampPosition({ top: desiredTop, left: desiredLeft, width, height })
+    return { ...clamped, width, height }
+  }, [anchorRect, open])
+
+  useEffect(() => {
+    if (!open) return
+    const el = containerRef.current
+    if (!el) return
+    el.focus()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onPointerDown = (e: PointerEvent) => {
+      const el = containerRef.current
+      if (!el) return
+      if (e.target instanceof Node && el.contains(e.target)) return
+      onClose()
+    }
+
+    const onScroll = () => onClose()
+    const onResize = () => onClose()
+
+    window.addEventListener("pointerdown", onPointerDown, { capture: true })
+    window.addEventListener("scroll", onScroll, { capture: true })
+    window.addEventListener("resize", onResize)
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, { capture: true } as AddEventListenerOptions)
+      window.removeEventListener("scroll", onScroll, { capture: true } as AddEventListenerOptions)
+      window.removeEventListener("resize", onResize)
+    }
+  }, [onClose, open])
+
+  if (!open || !anchorRect || !position) return null
+
+  const content = (
+    <div
+      ref={containerRef}
+      data-testid={testId}
+      data-shortcuts-disabled="true"
+      role="menu"
+      tabIndex={-1}
+      className="fixed z-50 rounded-lg border bg-white shadow-[0_4px_16px_rgba(0,0,0,0.12)] p-1.5 outline-none"
+      style={{
+        top: position.top,
+        left: position.left,
+        width: position.width,
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault()
+          e.stopPropagation()
+          onClose()
+          return
+        }
+
+        if (e.key.length === 1 && e.key >= "1" && e.key <= "9") {
+          const idx = Number.parseInt(e.key, 10) - 1
+          const s = taskStatuses[idx]
+          if (!s) return
+          e.preventDefault()
+          e.stopPropagation()
+          if (s.id !== status) onSelect(s.id)
+          onClose()
+        }
+      }}
+    >
+      <div className="px-2 py-1.5 text-xs font-medium" style={{ color: "#6b6b6b" }}>
+        Change status...
+      </div>
+      {taskStatuses.map((s) => {
+        const isSelected = s.id === status
+        const number = numbersByStatus.get(s.id) ?? ""
+        return (
+          <button
+            key={s.id}
+            type="button"
+            role="menuitem"
+            data-testid={`task-status-command-option-${s.id}`}
+            className={cn(
+              "w-full flex items-center gap-2 px-2 py-1.5 rounded-md transition-colors",
+              "hover:bg-[#f5f5f5]",
+              isSelected && "bg-[#f0f0f0]",
+            )}
+            onClick={() => {
+              if (s.id !== status) onSelect(s.id)
+              onClose()
+            }}
+          >
+            <span className={cn(s.iconClass, "w-[14px] h-[14px] flex-shrink-0")} style={{ color: s.color }} />
+            <span className="flex-1 text-[13px]" style={{ color: "#1b1b1b" }}>
+              {s.label}
+            </span>
+            <span className="flex items-center gap-2">
+              {number ? (
+                <span
+                  className="inline-flex items-center justify-center rounded-[6px] border px-1.5 py-0.5 text-[11px] font-medium"
+                  style={{ backgroundColor: "#fcfcfc", borderColor: "#ebebeb", color: "#6b6b6b" }}
+                  aria-hidden="true"
+                >
+                  {number}
+                </span>
+              ) : null}
+              {isSelected ? <Check className="w-3.5 h-3.5 flex-shrink-0" style={{ color: "#9b9b9b" }} /> : null}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+
+  return createPortal(content, document.body)
+}
+

--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -1289,7 +1289,7 @@ function ActivityStreamSection({
         ),
       }
     })
-  }, [agentTurnUiStateById, expandedGroups, groups, onCancelAgentTurn, toggleGroup, workspaceId])
+  }, [agentTurnUiStateById, expandedGroups, groups, onCancelAgentTurn, taskId, toggleGroup, workspaceId])
 
   const shouldWindow = items.length > 200
 

--- a/web/components/ui/tooltip.tsx
+++ b/web/components/ui/tooltip.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+export const TooltipProvider = TooltipPrimitive.Provider
+export const Tooltip = TooltipPrimitive.Root
+export const TooltipTrigger = TooltipPrimitive.Trigger
+
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & { sideOffset?: number }
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border px-2.5 py-1.5 text-xs shadow-md",
+        "bg-white text-[#1b1b1b] border-[#ebebeb]",
+        "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -36,6 +36,7 @@ import { runTaskListNavigation } from './scenarios/task-list-navigation.mjs';
 import { runTaskSummariesEventsRefresh } from './scenarios/task-summaries-events-refresh.mjs';
 import { runQueuedPrompts } from './scenarios/queued-prompts.mjs';
 import { runProjectAllTasksView } from './scenarios/project-all-tasks-view.mjs';
+import { runKeyboardSequenceShortcuts } from './scenarios/keyboard-sequence-shortcuts.mjs';
 
 async function canRun(command, args) {
   const proc = spawn(command, args, { stdio: 'ignore' });
@@ -178,10 +179,11 @@ async function main() {
 			    await runStarFavorites({ page, baseUrl });
     await runNewTaskDefaultProjectFollowsContext({ page, baseUrl });
     await runSettingsPanel({ page, baseUrl });
-    await runTaskListNavigation({ page, baseUrl });
-    await runTaskStatusChange({ page, baseUrl });
-    await runQueuedPrompts({ page, baseUrl });
-    await runLatestEventsVisible({ page, baseUrl });
+	    await runTaskListNavigation({ page, baseUrl });
+	    await runTaskStatusChange({ page, baseUrl });
+	    await runKeyboardSequenceShortcuts({ page, baseUrl });
+	    await runQueuedPrompts({ page, baseUrl });
+	    await runLatestEventsVisible({ page, baseUrl });
     await runActivityWindowing({ page, baseUrl });
     await runAgentRunnerIcons({ page, baseUrl });
     await runEscapeDoesNotLeakFromChatInput({ page, baseUrl });

--- a/web/tests/ui/scenarios/keyboard-sequence-shortcuts.mjs
+++ b/web/tests/ui/scenarios/keyboard-sequence-shortcuts.mjs
@@ -1,0 +1,52 @@
+import { waitForDataAttribute } from '../lib/utils.mjs';
+
+export async function runKeyboardSequenceShortcuts({ page }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  // Ensure the task list container owns focus so key presses have a stable target.
+  await page.getByTestId('task-list-view').click();
+
+  // C: open new task modal.
+  await page.keyboard.press('c');
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+  await page.keyboard.press('Escape');
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+
+  // G -> I: go to inbox.
+  await page.keyboard.press('g');
+  await page.keyboard.press('i');
+  await page.getByTestId('inbox-view').waitFor({ state: 'visible' });
+
+  // G -> A: go back to active tasks.
+  await page.keyboard.press('g');
+  await page.keyboard.press('a');
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  // G -> B: switch to backlog view.
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+  await page.getByText('Mock task 2').first().waitFor({ state: 'visible' });
+
+  // G -> E: switch to all tasks view.
+  await page.keyboard.press('g');
+  await page.keyboard.press('e');
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  // S: open status menu for hovered task, then numeric selection.
+  const trigger = page.getByTestId('task-status-selector-1-1');
+  await trigger.waitFor({ state: 'visible' });
+
+  const row = page.getByTestId('task-list-view').locator('div.group', { hasText: 'Mock task 1' }).first();
+  await row.waitFor({ state: 'visible' });
+  await row.hover();
+  await page.getByTestId('task-list-view').focus();
+
+  await page.keyboard.press('s');
+  await page.getByTestId('task-status-command-menu').waitFor({ state: 'visible' });
+  await page.keyboard.press('3'); // Iterating
+
+  await page.getByTestId('task-status-command-menu').waitFor({ state: 'hidden' });
+  await waitForDataAttribute(trigger, 'title', 'Status: Iterating', 20_000);
+}


### PR DESCRIPTION
Summary:
- Add Linear-style key-sequence shortcuts (no modifiers): C, G→I, G→E/A/B, and S for task status.
- Show shortcut hints via tooltip on key buttons/tabs.
- Add a status command menu with numeric selection (1-6).

Behavior changes:
- Press `C` to open the new task modal.
- Press `G` then `I` to open Inbox.
- In a project task list, press `G` then `E/A/B` to switch All/Active/Backlog.
- Hover (or arrow-key select) a task row and press `S`, then press `1-6` to set status.

Verification:
- just fmt && just lint && just test
- just test-ui

Notes:
- UI-only change; no contracts updated.
