### PR TITLE
Treat done/canceled tasks as archived

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -426,6 +426,22 @@ mod task_status_tests {
     }
 }
 
+#[cfg(test)]
+mod conversation_system_event_tests {
+    use super::ConversationSystemEvent;
+
+    #[test]
+    fn conversation_system_event_archived_roundtrips() {
+        let json =
+            serde_json::to_string(&ConversationSystemEvent::TaskArchived).expect("serialize");
+        assert_eq!(json, "{\"event_type\":\"task_archived\"}");
+
+        let parsed: ConversationSystemEvent =
+            serde_json::from_str("{\"event_type\":\"task_archived\"}").expect("deserialize");
+        assert!(matches!(parsed, ConversationSystemEvent::TaskArchived));
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TurnStatus {
@@ -603,6 +619,7 @@ pub struct ConversationSystemEventEntry {
 #[serde(tag = "event_type", rename_all = "snake_case")]
 pub enum ConversationSystemEvent {
     TaskCreated,
+    TaskArchived,
     TaskStatusChanged {
         from: TaskStatus,
         to: TaskStatus,

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -578,15 +578,49 @@ impl ProjectWorkspaceService for GitWorkspaceService {
         &self,
         project_path: PathBuf,
         worktree_path: PathBuf,
+        branch_name: String,
     ) -> Result<(), String> {
         let result: anyhow::Result<()> = (|| {
             let path_str = worktree_path
                 .to_str()
                 .ok_or_else(|| anyhow!("invalid worktree path"))?;
-            self.run_git(&project_path, ["worktree", "remove", "--force", path_str])
-                .with_context(|| {
-                    format!("failed to remove worktree at {}", worktree_path.display())
-                })?;
+
+            let remove_result =
+                self.run_git(&project_path, ["worktree", "remove", "--force", path_str]);
+            if let Err(err) = remove_result {
+                let message = format!("{err:#}");
+                let missing = message.contains("not a working tree")
+                    || message.contains("is not a working tree")
+                    || message.contains("is not a git repository")
+                    || message.contains("no such file or directory")
+                    || message.contains("No such file or directory");
+                if !missing {
+                    return Err(err).with_context(|| {
+                        format!("failed to remove worktree at {}", worktree_path.display())
+                    });
+                }
+            }
+
+            let branch_name = branch_name.trim();
+            if branch_name.starts_with("luban/") && branch_name != "main" {
+                let is_checked_out_elsewhere = (|| -> anyhow::Result<bool> {
+                    let raw = self
+                        .run_git(&project_path, ["worktree", "list", "--porcelain"])
+                        .context("failed to list worktrees")?;
+                    let needle = format!("refs/heads/{branch_name}");
+                    Ok(raw
+                        .lines()
+                        .any(|line| line.trim() == format!("branch {needle}")))
+                })()
+                .unwrap_or(false);
+
+                if !is_checked_out_elsewhere && branch_exists(&project_path, branch_name) {
+                    self.run_git(&project_path, ["branch", "-D", branch_name])
+                        .with_context(|| {
+                            format!("failed to delete local branch '{branch_name}'")
+                        })?;
+                }
+            }
             Ok(())
         })();
         result.map_err(anyhow_error_to_string)
@@ -3667,9 +3701,81 @@ mod tests {
             &service,
             repo_path.clone(),
             worktree_path.clone(),
+            branch_name.clone(),
         )
         .expect("archive_workspace should remove dirty worktree with --force");
         assert!(!worktree_path.exists(), "worktree path should be removed");
+
+        drop(service);
+        let _ = std::fs::remove_dir_all(&base_dir);
+    }
+
+    #[test]
+    fn archive_workspace_deletes_luban_branch_after_removing_worktree() {
+        let unique = unix_epoch_nanos_now();
+        let base_dir = std::env::temp_dir().join(format!(
+            "luban-archive-workspace-branch-delete-{}-{}",
+            std::process::id(),
+            unique
+        ));
+
+        std::fs::create_dir_all(&base_dir).expect("temp dir should be created");
+
+        let repo_path = base_dir.join("repo");
+        std::fs::create_dir_all(&repo_path).expect("repo dir should be created");
+
+        assert_git_success(&repo_path, &["init"]);
+        assert_git_success(&repo_path, &["config", "user.name", "Test User"]);
+        assert_git_success(&repo_path, &["config", "user.email", "test@example.com"]);
+
+        let tracked_file = repo_path.join("tracked.txt");
+        std::fs::write(&tracked_file, "hello\n").expect("write should succeed");
+        assert_git_success(&repo_path, &["add", "."]);
+        assert_git_success(&repo_path, &["commit", "-m", "init"]);
+
+        let worktree_path = base_dir.join("worktree");
+        let branch_name = format!("luban/test-branch-{unique}");
+        assert_git_success(
+            &repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                &branch_name,
+                worktree_path
+                    .to_str()
+                    .expect("worktree path should be utf-8"),
+            ],
+        );
+
+        assert!(
+            branch_exists(&repo_path, &branch_name),
+            "expected local branch to exist before archive"
+        );
+
+        let sqlite =
+            SqliteStore::new(paths::sqlite_path(&base_dir)).expect("sqlite init should work");
+        let service = GitWorkspaceService {
+            worktrees_root: paths::worktrees_root(&base_dir),
+            conversations_root: paths::conversations_root(&base_dir),
+            task_prompts_root: paths::task_prompts_root(&base_dir),
+            sqlite,
+            claude_processes: Mutex::new(HashMap::new()),
+        };
+
+        ProjectWorkspaceService::archive_workspace(
+            &service,
+            repo_path.clone(),
+            worktree_path.clone(),
+            branch_name.clone(),
+        )
+        .expect("archive_workspace should remove worktree and delete local luban branch");
+
+        assert!(!worktree_path.exists(), "worktree path should be removed");
+        assert!(
+            !branch_exists(&repo_path, &branch_name),
+            "expected local branch to be deleted after archive"
+        );
 
         drop(service);
         let _ = std::fs::remove_dir_all(&base_dir);

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -275,6 +275,7 @@ pub trait ProjectWorkspaceService: Send + Sync {
         &self,
         project_path: PathBuf,
         worktree_path: PathBuf,
+        branch_name: String,
     ) -> Result<(), String>;
 
     fn rename_workspace_branch(

--- a/crates/luban_domain/src/effects.rs
+++ b/crates/luban_domain/src/effects.rs
@@ -129,4 +129,12 @@ pub enum Effect {
     LoadWorkspaceThreads {
         workspace_id: WorkspaceId,
     },
+
+    /// After a task is moved to a closed state (`done`/`canceled`), the provider may be able to
+    /// cleanup the workspace worktree/branch and mark the workdir as archived.
+    ///
+    /// The engine decides whether cleanup is safe (for example: all threads are closed + idle).
+    MaybeAutoArchiveWorkspace {
+        workspace_id: WorkspaceId,
+    },
 }

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -868,6 +868,13 @@ impl AppState {
                 tabs.activate(thread_id);
 
                 let conversation = self.ensure_conversation_mut(workspace_id, thread_id);
+                if matches!(
+                    conversation.task_status,
+                    crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                ) {
+                    self.last_error = Some("Task is archived".to_owned());
+                    return Vec::new();
+                }
                 conversation.draft.clear();
                 conversation.draft_attachments.clear();
 
@@ -1009,6 +1016,13 @@ impl AppState {
                 tabs.activate(thread_id);
 
                 let conversation = self.ensure_conversation_mut(workspace_id, thread_id);
+                if matches!(
+                    conversation.task_status,
+                    crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                ) {
+                    self.last_error = Some("Task is archived".to_owned());
+                    return Vec::new();
+                }
                 conversation.draft.clear();
                 conversation.draft_attachments.clear();
 
@@ -1674,6 +1688,19 @@ impl AppState {
                 workspace_id,
                 thread_id,
             } => {
+                if self
+                    .conversations
+                    .get(&(workspace_id, thread_id))
+                    .is_some_and(|c| {
+                        matches!(
+                            c.task_status,
+                            crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                        )
+                    })
+                {
+                    self.last_error = Some("Task is archived".to_owned());
+                    return Vec::new();
+                }
                 let tabs = self.ensure_workspace_tabs_mut(workspace_id);
                 tabs.activate(thread_id);
                 self.ensure_conversation_mut(workspace_id, thread_id);
@@ -1715,6 +1742,19 @@ impl AppState {
                 workspace_id,
                 thread_id,
             } => {
+                if self
+                    .conversations
+                    .get(&(workspace_id, thread_id))
+                    .is_some_and(|c| {
+                        matches!(
+                            c.task_status,
+                            crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                        )
+                    })
+                {
+                    self.last_error = Some("Task is archived".to_owned());
+                    return Vec::new();
+                }
                 let tabs = self.ensure_workspace_tabs_mut(workspace_id);
                 let previous_active = tabs.active_tab;
                 tabs.restore_tab(thread_id, true);
@@ -2292,23 +2332,87 @@ impl AppState {
                 thread_id,
                 task_status,
             } => {
-                let Some(conversation) = self.conversations.get_mut(&(workspace_id, thread_id))
+                let Some(existing_status) = self
+                    .conversations
+                    .get(&(workspace_id, thread_id))
+                    .map(|c| c.task_status)
                 else {
                     return Vec::new();
                 };
-                if conversation.task_status == task_status {
+                if existing_status == task_status {
                     return Vec::new();
                 }
-                let from_status = conversation.task_status;
-                conversation.task_status = task_status;
-                conversation.push_entry(ConversationEntry::SystemEvent {
-                    entry_id: format!("sys_{}", conversation.entries_total.saturating_add(1)),
-                    created_at_unix_ms: now_unix_ms(),
-                    event: crate::ConversationSystemEvent::TaskStatusChanged {
-                        from: from_status,
-                        to: task_status,
-                    },
-                });
+                if matches!(
+                    existing_status,
+                    crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                ) {
+                    self.last_error = Some("Task is archived".to_owned());
+                    return Vec::new();
+                }
+
+                let should_close_task = matches!(
+                    task_status,
+                    crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                );
+                let mut run_id_to_cancel: Option<u64> = None;
+
+                {
+                    let conversation = self
+                        .conversations
+                        .get_mut(&(workspace_id, thread_id))
+                        .expect("conversation status already resolved; conversation should exist");
+                    let from_status = conversation.task_status;
+                    conversation.task_status = task_status;
+                    conversation.push_entry(ConversationEntry::SystemEvent {
+                        entry_id: format!("sys_{}", conversation.entries_total.saturating_add(1)),
+                        created_at_unix_ms: now_unix_ms(),
+                        event: crate::ConversationSystemEvent::TaskStatusChanged {
+                            from: from_status,
+                            to: task_status,
+                        },
+                    });
+
+                    if should_close_task {
+                        conversation.pending_prompts.clear();
+                        conversation.queue_paused = true;
+                        run_id_to_cancel = cancel_running_turn(conversation);
+                    }
+                }
+
+                let mut did_update_tabs = false;
+                if should_close_task {
+                    let (is_open, open_len, archived_tabs) = {
+                        let tabs = self.ensure_workspace_tabs_mut(workspace_id);
+                        (
+                            tabs.open_tabs.contains(&thread_id),
+                            tabs.open_tabs.len(),
+                            tabs.archived_tabs.clone(),
+                        )
+                    };
+
+                    if is_open && open_len > 1 {
+                        let tabs = self.ensure_workspace_tabs_mut(workspace_id);
+                        tabs.archive_tab(thread_id);
+                        did_update_tabs = true;
+                    } else if is_open {
+                        let candidate = archived_tabs.into_iter().find(|id| {
+                            self.conversations
+                                .get(&(workspace_id, *id))
+                                .is_some_and(|c| {
+                                    !matches!(
+                                        c.task_status,
+                                        crate::TaskStatus::Done | crate::TaskStatus::Canceled
+                                    )
+                                })
+                        });
+                        if let Some(candidate) = candidate {
+                            let tabs = self.ensure_workspace_tabs_mut(workspace_id);
+                            tabs.restore_tab(candidate, true);
+                            tabs.archive_tab(thread_id);
+                            did_update_tabs = true;
+                        }
+                    }
+                }
                 let mut effects = vec![
                     Effect::StoreConversationTaskStatus {
                         workspace_id,
@@ -2317,9 +2421,19 @@ impl AppState {
                     },
                     Effect::LoadWorkspaceThreads { workspace_id },
                 ];
-                if task_status == crate::TaskStatus::Canceled
-                    && let Some(run_id) = cancel_running_turn(conversation)
-                {
+                if did_update_tabs {
+                    effects.push(Effect::SaveAppState);
+                }
+
+                if should_close_task {
+                    effects.push(Effect::CleanupClaudeProcess {
+                        workspace_id,
+                        thread_id,
+                    });
+                    effects.push(Effect::MaybeAutoArchiveWorkspace { workspace_id });
+                }
+
+                if let Some(run_id) = run_id_to_cancel {
                     effects.push(Effect::CancelAgentTurn {
                         workspace_id,
                         thread_id,
@@ -5372,6 +5486,90 @@ mod tests {
                 }
             )
         }));
+    }
+
+    #[test]
+    fn task_status_done_cancels_running_turn_and_triggers_auto_archive_check() {
+        let mut state = AppState::demo();
+        let workspace_id = first_non_main_workspace_id(&state);
+        let thread_id = default_thread_id();
+
+        state.apply(Action::SendAgentMessage {
+            workspace_id,
+            thread_id,
+            text: "Hello".to_owned(),
+            attachments: Vec::new(),
+            runner: None,
+            amp_mode: None,
+        });
+        let run_id = state
+            .workspace_thread_conversation(workspace_id, thread_id)
+            .expect("missing conversation")
+            .active_run_id
+            .expect("missing active run id");
+
+        let effects = state.apply(Action::TaskStatusSet {
+            workspace_id,
+            thread_id,
+            task_status: crate::TaskStatus::Done,
+        });
+
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::CancelAgentTurn { workspace_id: wid, thread_id: tid, run_id: rid }
+                    if *wid == workspace_id && *tid == thread_id && *rid == run_id
+            )),
+            "expected CancelAgentTurn effect"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::MaybeAutoArchiveWorkspace { workspace_id: wid } if *wid == workspace_id
+            )),
+            "expected MaybeAutoArchiveWorkspace effect"
+        );
+
+        let conversation = state
+            .workspace_thread_conversation(workspace_id, thread_id)
+            .expect("missing conversation");
+        assert_eq!(conversation.task_status, crate::TaskStatus::Done);
+        assert_eq!(conversation.run_status, OperationStatus::Idle);
+        assert_eq!(conversation.active_run_id, None);
+        assert!(conversation.queue_paused);
+    }
+
+    #[test]
+    fn send_agent_message_is_blocked_for_archived_tasks() {
+        let mut state = AppState::demo();
+        let workspace_id = first_non_main_workspace_id(&state);
+        let thread_id = default_thread_id();
+
+        state.apply(Action::SendAgentMessage {
+            workspace_id,
+            thread_id,
+            text: "Hello".to_owned(),
+            attachments: Vec::new(),
+            runner: None,
+            amp_mode: None,
+        });
+
+        state.apply(Action::TaskStatusSet {
+            workspace_id,
+            thread_id,
+            task_status: crate::TaskStatus::Done,
+        });
+
+        let effects = state.apply(Action::SendAgentMessage {
+            workspace_id,
+            thread_id,
+            text: "Should be blocked".to_owned(),
+            attachments: Vec::new(),
+            runner: None,
+            amp_mode: None,
+        });
+        assert!(effects.is_empty());
+        assert_eq!(state.last_error.as_deref(), Some("Task is archived"));
     }
 
     #[test]

--- a/crates/luban_domain/src/state/conversation.rs
+++ b/crates/luban_domain/src/state/conversation.rs
@@ -11,6 +11,7 @@ use std::collections::VecDeque;
 #[serde(tag = "event_type", rename_all = "snake_case")]
 pub enum ConversationSystemEvent {
     TaskCreated,
+    TaskArchived,
     TaskStatusChanged {
         from: TaskStatus,
         to: TaskStatus,

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -325,6 +325,7 @@ pub struct Engine {
     pull_requests: HashMap<WorkspaceId, PullRequestCacheEntry>,
     pull_requests_in_flight: HashSet<WorkspaceId>,
     workspace_threads_cache: HashMap<WorkspaceId, Vec<ConversationThreadMeta>>,
+    auto_archive_workspaces: HashSet<WorkspaceId>,
     telegram_pairing: Option<TelegramPairingState>,
 }
 
@@ -375,6 +376,7 @@ impl Engine {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -414,6 +416,65 @@ impl Engine {
     async fn bootstrap(&mut self) {
         self.process_action_queue(Action::AppStarted).await;
         self.reconcile_stale_running_turns().await;
+        self.auto_archive_closed_workspaces().await;
+    }
+
+    async fn auto_archive_closed_workspaces(&mut self) {
+        let mut candidates = Vec::new();
+        for project in &self.state.projects {
+            if !project.is_git {
+                continue;
+            }
+            for workspace in &project.workspaces {
+                let is_main = workspace.workspace_name == "main";
+                if is_main {
+                    continue;
+                }
+                if workspace.archive_status == luban_domain::OperationStatus::Running {
+                    continue;
+                }
+                candidates.push((
+                    workspace.id,
+                    WorkspaceScope {
+                        project_slug: project.slug.clone(),
+                        workspace_name: workspace.workspace_name.clone(),
+                    },
+                ));
+            }
+        }
+
+        for (workspace_id, scope) in candidates {
+            let services = self.services.clone();
+            let project_slug = scope.project_slug.clone();
+            let workspace_name = scope.workspace_name.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let threads = services.list_conversation_threads(project_slug, workspace_name)?;
+                if threads.is_empty() {
+                    return Ok(false);
+                }
+                let all_closed_and_idle = threads.iter().all(|t| {
+                    matches!(
+                        t.task_status,
+                        luban_domain::TaskStatus::Done | luban_domain::TaskStatus::Canceled
+                    ) && t.turn_status == luban_domain::TurnStatus::Idle
+                });
+                Ok(all_closed_and_idle)
+            })
+            .await
+            .ok()
+            .unwrap_or_else(|| Err("failed to join auto archive scan task".to_owned()));
+
+            let Ok(should_archive) = result else {
+                continue;
+            };
+            if !should_archive {
+                continue;
+            }
+
+            self.auto_archive_workspaces.insert(workspace_id);
+            self.process_action_queue(Action::ArchiveWorkspace { workspace_id })
+                .await;
+        }
     }
 
     async fn reconcile_stale_running_turns(&mut self) {
@@ -3898,7 +3959,8 @@ impl Engine {
                 }
             }
             Effect::ArchiveWorkspace { workspace_id } => {
-                if let Some(scope) = workspace_scope(&self.state, workspace_id) {
+                let scope = workspace_scope(&self.state, workspace_id);
+                if let Some(scope) = scope.as_ref() {
                     for (wid, thread_id) in self.state.conversations.keys() {
                         if *wid != workspace_id {
                             continue;
@@ -3913,12 +3975,14 @@ impl Engine {
 
                 let mut project_path: Option<PathBuf> = None;
                 let mut worktree_path: Option<PathBuf> = None;
+                let mut branch_name: Option<String> = None;
 
                 for project in &self.state.projects {
                     for workspace in &project.workspaces {
                         if workspace.id == workspace_id {
                             project_path = Some(project.path.clone());
                             worktree_path = Some(workspace.worktree_path.clone());
+                            branch_name = Some(workspace.branch_name.clone());
                             break;
                         }
                     }
@@ -3927,7 +3991,8 @@ impl Engine {
                     }
                 }
 
-                let (Some(project_path), Some(worktree_path)) = (project_path, worktree_path)
+                let (Some(project_path), Some(worktree_path), Some(branch_name)) =
+                    (project_path, worktree_path, branch_name)
                 else {
                     return Ok(VecDeque::from([Action::WorkspaceArchiveFailed {
                         workspace_id,
@@ -3936,15 +4001,80 @@ impl Engine {
                 };
 
                 let services = self.services.clone();
+                let should_emit_task_archived_events =
+                    self.auto_archive_workspaces.contains(&workspace_id);
+                let project_slug = scope
+                    .as_ref()
+                    .map(|s| s.project_slug.clone())
+                    .unwrap_or_default();
+                let workspace_name = scope
+                    .as_ref()
+                    .map(|s| s.workspace_name.clone())
+                    .unwrap_or_default();
                 let result = tokio::task::spawn_blocking(move || {
-                    services.archive_workspace(project_path, worktree_path)
+                    services.archive_workspace(project_path, worktree_path, branch_name)?;
+                    if !should_emit_task_archived_events {
+                        return Ok(());
+                    }
+                    if project_slug.is_empty() || workspace_name.is_empty() {
+                        return Ok(());
+                    }
+
+                    let threads = services
+                        .list_conversation_threads(project_slug.clone(), workspace_name.clone())?;
+                    for meta in threads {
+                        if !matches!(
+                            meta.task_status,
+                            luban_domain::TaskStatus::Done | luban_domain::TaskStatus::Canceled
+                        ) {
+                            continue;
+                        }
+
+                        let recent = services.load_conversation_page(
+                            project_slug.clone(),
+                            workspace_name.clone(),
+                            meta.thread_id.as_u64(),
+                            None,
+                            32,
+                        )?;
+                        let already_archived = recent.entries.iter().any(|entry| {
+                            matches!(
+                                entry,
+                                luban_domain::ConversationEntry::SystemEvent { event, .. }
+                                    if matches!(
+                                        event,
+                                        luban_domain::ConversationSystemEvent::TaskArchived
+                                    )
+                            )
+                        });
+                        if already_archived {
+                            continue;
+                        }
+
+                        services.append_conversation_entries(
+                            project_slug.clone(),
+                            workspace_name.clone(),
+                            meta.thread_id.as_u64(),
+                            vec![luban_domain::ConversationEntry::SystemEvent {
+                                entry_id: String::new(),
+                                created_at_unix_ms: now_unix_ms(),
+                                event: luban_domain::ConversationSystemEvent::TaskArchived,
+                            }],
+                        )?;
+                    }
+                    Ok(())
                 })
                 .await
                 .ok()
                 .unwrap_or_else(|| Err("failed to join archive workspace task".to_owned()));
 
                 let action = match result {
-                    Ok(()) => Action::WorkspaceArchived { workspace_id },
+                    Ok(()) => {
+                        if should_emit_task_archived_events {
+                            self.auto_archive_workspaces.remove(&workspace_id);
+                        }
+                        Action::WorkspaceArchived { workspace_id }
+                    }
                     Err(message) => Action::WorkspaceArchiveFailed {
                         workspace_id,
                         message,
@@ -3952,6 +4082,67 @@ impl Engine {
                 };
 
                 Ok(VecDeque::from([action]))
+            }
+            Effect::MaybeAutoArchiveWorkspace { workspace_id } => {
+                let Some(scope) = workspace_scope(&self.state, workspace_id) else {
+                    return Ok(VecDeque::new());
+                };
+
+                let mut project_is_git = false;
+                let mut workspace_is_main = false;
+                let mut workspace_status = None;
+                let mut archive_status = None;
+                for project in &self.state.projects {
+                    for workspace in &project.workspaces {
+                        if workspace.id != workspace_id {
+                            continue;
+                        }
+                        project_is_git = project.is_git;
+                        workspace_is_main = workspace.workspace_name == "main";
+                        workspace_status = Some(workspace.status);
+                        archive_status = Some(workspace.archive_status);
+                        break;
+                    }
+                }
+
+                if !project_is_git
+                    || workspace_is_main
+                    || workspace_status != Some(luban_domain::WorkspaceStatus::Active)
+                    || archive_status == Some(luban_domain::OperationStatus::Running)
+                {
+                    return Ok(VecDeque::new());
+                }
+
+                let services = self.services.clone();
+                let project_slug = scope.project_slug.clone();
+                let workspace_name = scope.workspace_name.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    let threads =
+                        services.list_conversation_threads(project_slug, workspace_name)?;
+                    if threads.is_empty() {
+                        return Ok(false);
+                    }
+                    let all_closed_and_idle = threads.iter().all(|t| {
+                        matches!(
+                            t.task_status,
+                            luban_domain::TaskStatus::Done | luban_domain::TaskStatus::Canceled
+                        ) && t.turn_status == luban_domain::TurnStatus::Idle
+                    });
+                    Ok(all_closed_and_idle)
+                })
+                .await
+                .ok()
+                .unwrap_or_else(|| Err("failed to join maybe archive workspace task".to_owned()));
+
+                let Ok(should_archive) = result else {
+                    return Ok(VecDeque::new());
+                };
+                if !should_archive {
+                    return Ok(VecDeque::new());
+                }
+
+                self.auto_archive_workspaces.insert(workspace_id);
+                Ok(VecDeque::from([Action::ArchiveWorkspace { workspace_id }]))
             }
         }
     }
@@ -4753,7 +4944,7 @@ fn queue_state_key_for_action(action: &Action) -> Option<(WorkspaceId, Workspace
         Action::TaskStatusSet {
             workspace_id,
             thread_id,
-            task_status: luban_domain::TaskStatus::Canceled,
+            task_status: luban_domain::TaskStatus::Canceled | luban_domain::TaskStatus::Done,
         } => Some((*workspace_id, *thread_id)),
         Action::AgentEventReceived {
             workspace_id,
@@ -5027,6 +5218,9 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
             event: match event {
                 luban_domain::ConversationSystemEvent::TaskCreated => {
                     luban_api::ConversationSystemEvent::TaskCreated
+                }
+                luban_domain::ConversationSystemEvent::TaskArchived => {
+                    luban_api::ConversationSystemEvent::TaskArchived
                 }
                 luban_domain::ConversationSystemEvent::TaskStatusChanged { from, to } => {
                     luban_api::ConversationSystemEvent::TaskStatusChanged {
@@ -5663,6 +5857,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -5831,6 +6026,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -6108,6 +6304,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -6283,6 +6480,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -6346,6 +6544,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -6496,6 +6695,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -6698,6 +6898,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -6795,6 +6996,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -6910,6 +7112,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
         engine.workspace_threads_cache.insert(workspace_id, metas);
@@ -6999,6 +7202,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
         engine.workspace_threads_cache.insert(workspace_id, metas);
@@ -7075,6 +7279,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -7167,6 +7372,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -7317,6 +7523,7 @@ mod tests {
             &self,
             project_path: PathBuf,
             worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             if let Some(cancel_flag) = &self.cancel_flag
                 && !cancel_flag.load(Ordering::SeqCst)
@@ -7514,6 +7721,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -7602,6 +7810,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -7699,6 +7908,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -7879,6 +8089,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -7927,6 +8138,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -8009,6 +8221,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -8218,6 +8431,7 @@ mod tests {
             &self,
             _project_path: PathBuf,
             _worktree_path: PathBuf,
+            _branch_name: String,
         ) -> Result<(), String> {
             Err("unimplemented".to_owned())
         }
@@ -8395,6 +8609,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -8461,6 +8676,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -8519,6 +8735,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -8592,6 +8809,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 
@@ -8662,6 +8880,7 @@ mod tests {
             pull_requests: HashMap::new(),
             pull_requests_in_flight: HashSet::new(),
             workspace_threads_cache: HashMap::new(),
+            auto_archive_workspaces: HashSet::new(),
             telegram_pairing: None,
         };
 

--- a/docs/contracts/features/c-http-conversation.md
+++ b/docs/contracts/features/c-http-conversation.md
@@ -47,7 +47,10 @@ The event payload is structured:
 - `type`: `system_event`
 - `entry_id`: stable string identifier (unique within the conversation)
 - `created_at_unix_ms`: millisecond timestamp
-- `event.event_type`: `task_created` | `task_status_changed` | `task_status_suggestion`
+- `event.event_type`: `task_created` | `task_archived` | `task_status_changed` | `task_status_suggestion`
+  - `task_archived` indicates the provider has completed archival cleanup for a closed task (for
+    example: removing the worktree and deleting the local `luban/*` branch). Clients should treat
+    archived tasks as read-only.
 
 For `event.event_type=task_status_suggestion`:
 

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -66,6 +66,7 @@ Legend:
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=system_event` may include `event_type=task_status_suggestion` to recommend a status change; clients apply via `ClientAction::TaskStatusSet`.
+- `C-HTTP-CONVERSATION`: `ConversationEntry.type=system_event` may include `event_type=task_archived` after provider cleanup for a closed task.
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=user_event` supports `event.type=message`, `terminal_command_started`, and `terminal_command_finished`.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.title` matches `ThreadMeta.title` and may be updated after the first user message.
 - `C-HTTP-TASKS`: `TaskSummarySnapshot` includes `is_starred` for rendering Favorites and in-view star toggles.

--- a/docs/task-and-turn-status.md
+++ b/docs/task-and-turn-status.md
@@ -25,6 +25,10 @@ Enum values:
 Notes:
 
 - Archive is intentionally not modeled as a task status.
+- Closed tasks (`done` / `canceled`) are treated as archived for UX and cleanup purposes:
+  - Clients must treat them as read-only (no new turns/messages).
+  - Providers may cleanup the workspace worktree/branch asynchronously and append a `system_event`
+    marker (see `ConversationSystemEvent::TaskArchived`).
 - Task status changes are triggered by explicit user actions (including sending a message, which is treated as an explicit start-work action).
 - Legacy values `in_progress` and `in_review` may exist in persisted data and are treated as aliases for `iterating` and `validating` respectively.
 

--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -429,6 +429,7 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
       const workdir = workdirById.get(t.workdir_id) ?? null
       if (!workdir) return false
       if (workdir.status !== "active") return false
+      if (t.task_status === "done" || t.task_status === "canceled") return false
       return true
     })
 
@@ -659,6 +660,10 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
                     variant="pill"
                     size="sm"
                     triggerTestId="inbox-task-status-trigger"
+                    disabled={
+                      selectedNotification.taskLifecycleStatus === "done" ||
+                      selectedNotification.taskLifecycleStatus === "canceled"
+                    }
                   />
                 </div>
               }

--- a/web/components/task-list-view.tsx
+++ b/web/components/task-list-view.tsx
@@ -74,9 +74,10 @@ function TaskRow({
   onStatusChange,
   agentRunner,
 }: TaskRowProps & { agentRunner: AgentRunnerKind | null | undefined }) {
+  const isArchived = task.status === "done" || task.status === "canceled"
   return (
     <div
-      onClick={onClick}
+      onClick={isArchived ? undefined : onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       data-task-row-id={task.id}
@@ -91,6 +92,7 @@ function TaskRow({
           status={task.status}
           onStatusChange={onStatusChange}
           size="sm"
+          disabled={isArchived}
           triggerTestId={`task-status-selector-${task.workspaceId}-${task.taskId}`}
         />
       </div>

--- a/web/lib/conversation-ui.ts
+++ b/web/lib/conversation-ui.ts
@@ -31,7 +31,13 @@ export type AgentTurnStatus = "running" | "done" | "canceled" | "error"
 export interface SystemEvent {
   id: string
   type: "event"
-  eventType: "task_created" | "task_started" | "task_completed" | "task_cancelled" | "status_changed"
+  eventType:
+    | "task_created"
+    | "task_archived"
+    | "task_started"
+    | "task_completed"
+    | "task_cancelled"
+    | "status_changed"
   title: string
   timestamp?: string
 }
@@ -55,7 +61,13 @@ export interface Message {
     duration?: string
   }
   codeReferences?: { file: string; line: number }[]
-  eventType?: "task_created" | "task_started" | "task_completed" | "task_cancelled" | "status_changed"
+  eventType?:
+    | "task_created"
+    | "task_archived"
+    | "task_started"
+    | "task_completed"
+    | "task_cancelled"
+    | "status_changed"
   terminalCommand?: {
     id: string
     command: string
@@ -473,11 +485,13 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
 
       const eventType = (() => {
         if (ev?.event_type === "task_created") return "task_created" as const
+        if (ev?.event_type === "task_archived") return "task_archived" as const
         if (ev?.event_type === "task_status_changed") return "status_changed" as const
         return "status_changed" as const
       })()
       const content = (() => {
         if (ev?.event_type === "task_created") return "created the task"
+        if (ev?.event_type === "task_archived") return "archived the task"
         if (ev?.event_type === "task_status_changed") {
           const from = taskStatusLabel(String(ev.from ?? ""))
           const to = taskStatusLabel(String(ev.to ?? ""))
@@ -790,11 +804,13 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
 
       const eventType = (() => {
         if (ev?.event_type === "task_created") return "task_created" as const
+        if (ev?.event_type === "task_archived") return "task_archived" as const
         if (ev?.event_type === "task_status_changed") return "status_changed" as const
         return "status_changed" as const
       })()
       const content = (() => {
         if (ev?.event_type === "task_created") return "created the task"
+        if (ev?.event_type === "task_archived") return "archived the task"
         if (ev?.event_type === "task_status_changed") {
           const from = taskStatusLabel(String(ev.from ?? ""))
           const to = taskStatusLabel(String(ev.to ?? ""))

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -238,6 +238,7 @@ export type ConversationSnapshot = {
 
 export type ConversationSystemEvent =
   | { event_type: "task_created" }
+  | { event_type: "task_archived" }
   | { event_type: "task_status_changed"; from: TaskStatus; to: TaskStatus }
   | {
       event_type: "task_status_suggestion"

--- a/web/lib/mock/fixtures.ts
+++ b/web/lib/mock/fixtures.ts
@@ -165,6 +165,7 @@ function systemEvent(args: {
   createdAtUnixMs: number
   event:
     | { event_type: "task_created" }
+    | { event_type: "task_archived" }
     | { event_type: "task_status_changed"; from: TaskStatus; to: TaskStatus }
     | {
         event_type: "task_status_suggestion"


### PR DESCRIPTION
## Summary
- Treat `done` and `canceled` tasks as archived (read-only).
- When a task is closed, clear/pause queued work, cancel any running turn, and trigger workspace cleanup.
- After workspace cleanup completes, append a `task_archived` system event to the task activity.
- Hide closed tasks in Inbox and disable the composer/status changes for closed tasks.

## Contracts
- Updated contracts to include `event_type=task_archived`.

## Verification
- `just fmt`
- `just lint`
- `just test`
- `just test-ui`

## Manual checks
1. Create a task and send a message.
2. Mark the task as `done` and confirm the composer is disabled and no new messages can be sent.
3. Confirm the task disappears from Inbox (done/canceled are hidden).
4. Confirm an `archived` activity event appears after cleanup completes.
5. Reopen the app and confirm historical done/canceled workspaces are cleaned up and annotated.

## Risk / rollback
- Workspace cleanup removes the git worktree and may delete a local `luban/*` branch if it is not used by any worktree.
- Rollback: restore the branch via `git reflog` if needed and disable/avoid auto-archival by not transitioning tasks to `done`/`canceled`.
