### PR TITLE
feat: add conversation entry timestamps

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -621,6 +621,8 @@ pub enum ConversationSystemEvent {
 pub struct UserEventEntry {
     #[serde(default)]
     pub entry_id: String,
+    #[serde(default)]
+    pub created_at_unix_ms: u64,
     pub event: UserEvent,
 }
 
@@ -660,6 +662,8 @@ pub struct TerminalCommandFinished {
 pub struct AgentEventEntry {
     #[serde(default)]
     pub entry_id: String,
+    #[serde(default)]
+    pub created_at_unix_ms: u64,
     pub event: AgentEvent,
 }
 

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1178,6 +1178,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 thread_local_id,
                 vec![ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 0,
                     event: luban_domain::UserEvent::Message {
                         text: prompt.clone(),
                         attachments: attachments.clone(),
@@ -1280,6 +1281,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             CodexThreadItem::AgentMessage { id, text } => {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
+                                                    created_at_unix_ms: 0,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1288,6 +1290,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             }
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1320,6 +1323,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1338,6 +1342,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1360,6 +1365,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1378,6 +1384,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1400,6 +1407,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1479,6 +1487,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             CodexThreadItem::AgentMessage { id, text } => {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
+                                                    created_at_unix_ms: 0,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1487,6 +1496,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             }
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1519,6 +1529,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1537,6 +1548,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1559,6 +1571,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1577,6 +1590,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1599,6 +1613,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1674,6 +1689,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             CodexThreadItem::AgentMessage { id, text } => {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
+                                                    created_at_unix_ms: 0,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1682,6 +1698,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             }
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1714,6 +1731,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1732,6 +1750,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1754,6 +1773,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1772,6 +1792,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         thread_local_id,
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
+                                            created_at_unix_ms: 0,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1794,6 +1815,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             thread_local_id,
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
+                                                created_at_unix_ms: 0,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1828,6 +1850,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                         thread_local_id,
                         vec![ConversationEntry::AgentEvent {
                             entry_id: String::new(),
+                            created_at_unix_ms: 0,
                             event: luban_domain::AgentEvent::TurnDuration { duration_ms },
                         }],
                     )?;
@@ -1839,6 +1862,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                     thread_local_id,
                     vec![ConversationEntry::AgentEvent {
                         entry_id: String::new(),
+                        created_at_unix_ms: 0,
                         event: luban_domain::AgentEvent::TurnCanceled,
                     }],
                 )?;
@@ -1868,6 +1892,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                     thread_local_id,
                     vec![ConversationEntry::AgentEvent {
                         entry_id: String::new(),
+                        created_at_unix_ms: 0,
                         event: luban_domain::AgentEvent::TurnDuration { duration_ms },
                     }],
                 );
@@ -1879,6 +1904,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 thread_local_id,
                 vec![ConversationEntry::AgentEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 0,
                     event: luban_domain::AgentEvent::TurnError {
                         message: format!("{err:#}"),
                     },

--- a/crates/luban_backend/src/services/conversations.rs
+++ b/crates/luban_backend/src/services/conversations.rs
@@ -86,16 +86,19 @@ fn migrate_legacy_entry(entry: LegacyConversationEntry) -> Option<ConversationEn
         LegacyConversationEntry::UserMessage { text, attachments } => {
             Some(ConversationEntry::UserEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: UserEvent::Message { text, attachments },
             })
         }
         LegacyConversationEntry::CodexItem { item } => match *item {
             CodexThreadItem::AgentMessage { id, text } => Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: AgentEvent::Message { id, text },
             }),
             other => Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: AgentEvent::Item {
                     item: Box::new(other),
                 },
@@ -105,15 +108,18 @@ fn migrate_legacy_entry(entry: LegacyConversationEntry) -> Option<ConversationEn
         LegacyConversationEntry::TurnDuration { duration_ms } => {
             Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: AgentEvent::TurnDuration { duration_ms },
             })
         }
         LegacyConversationEntry::TurnCanceled => Some(ConversationEntry::AgentEvent {
             entry_id: String::new(),
+            created_at_unix_ms: 0,
             event: AgentEvent::TurnCanceled,
         }),
         LegacyConversationEntry::TurnError { message } => Some(ConversationEntry::AgentEvent {
             entry_id: String::new(),
+            created_at_unix_ms: 0,
             event: AgentEvent::TurnError { message },
         }),
     }
@@ -610,6 +616,7 @@ mod tests {
         let broken_entries = vec![
             ConversationEntry::UserEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: UserEvent::Message {
                     text: "u1".to_owned(),
                     attachments: Vec::new(),
@@ -617,6 +624,7 @@ mod tests {
             },
             ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: AgentEvent::Message {
                     id: "item_0".to_owned(),
                     text: "A".to_owned(),
@@ -624,6 +632,7 @@ mod tests {
             },
             ConversationEntry::UserEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: UserEvent::Message {
                     text: "u2".to_owned(),
                     attachments: Vec::new(),
@@ -631,6 +640,7 @@ mod tests {
             },
             ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: 0,
                 event: AgentEvent::Message {
                     id: "item_0".to_owned(),
                     text: "B".to_owned(),

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -42,6 +42,7 @@ fn cancel_running_turn(conversation: &mut WorkspaceConversation) -> Option<u64> 
     conversation.run_finished_at_unix_ms = Some(now_unix_ms());
     conversation.push_entry(ConversationEntry::AgentEvent {
         entry_id: String::new(),
+        created_at_unix_ms: 0,
         event: crate::AgentEvent::TurnCanceled,
     });
     Some(run_id)
@@ -822,6 +823,7 @@ impl AppState {
                 let conversation = self.ensure_conversation_mut(workspace_id, thread_id);
                 conversation.push_entry(ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 0,
                     event: crate::UserEvent::TerminalCommandStarted {
                         id: command_id,
                         command,
@@ -845,6 +847,7 @@ impl AppState {
                 let conversation = self.ensure_conversation_mut(workspace_id, thread_id);
                 conversation.push_entry(ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 0,
                     event: crate::UserEvent::TerminalCommandFinished {
                         id: command_id,
                         command,
@@ -1506,6 +1509,7 @@ impl AppState {
                             }
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
+                                created_at_unix_ms: 0,
                                 event: crate::AgentEvent::TurnDuration { duration_ms },
                             });
                             Vec::new()
@@ -1526,6 +1530,7 @@ impl AppState {
                             let error_message = error.message.clone();
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
+                                created_at_unix_ms: 0,
                                 event: crate::AgentEvent::TurnError {
                                     message: error_message.clone(),
                                 },
@@ -1581,6 +1586,7 @@ impl AppState {
                             }
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
+                                created_at_unix_ms: 0,
                                 event: crate::AgentEvent::TurnError {
                                     message: message.clone(),
                                 },
@@ -2834,6 +2840,7 @@ fn start_agent_run(
 
     conversation.push_entry(ConversationEntry::UserEvent {
         entry_id: String::new(),
+        created_at_unix_ms: 0,
         event: crate::UserEvent::Message {
             text: text.clone(),
             attachments: attachments.clone(),
@@ -3716,6 +3723,7 @@ mod tests {
             entries: (1..=8)
                 .map(|idx| ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: idx as u64,
                     event: crate::UserEvent::Message {
                         text: format!("Message {idx}"),
                         attachments: Vec::new(),
@@ -4462,6 +4470,7 @@ mod tests {
                 ConversationEntry::AgentEvent {
                     entry_id,
                     event: crate::AgentEvent::Item { item },
+                    ..
                 } => Some((entry_id.as_str(), codex_item_id(item.as_ref()))),
                 _ => None,
             })
@@ -5032,6 +5041,7 @@ mod tests {
                 amp_mode: None,
                 entries: vec![ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 1,
                     event: crate::UserEvent::Message {
                         text: "Hello".to_owned(),
                         attachments: Vec::new(),
@@ -5089,6 +5099,7 @@ mod tests {
                 amp_mode: None,
                 entries: vec![ConversationEntry::UserEvent {
                     entry_id: String::new(),
+                    created_at_unix_ms: 1,
                     event: crate::UserEvent::Message {
                         text: "Hello".to_owned(),
                         attachments: Vec::new(),
@@ -5117,6 +5128,7 @@ mod tests {
                 entries: vec![
                     ConversationEntry::UserEvent {
                         entry_id: String::new(),
+                        created_at_unix_ms: 1,
                         event: crate::UserEvent::Message {
                             text: "Hello".to_owned(),
                             attachments: Vec::new(),
@@ -5124,6 +5136,7 @@ mod tests {
                     },
                     ConversationEntry::AgentEvent {
                         entry_id: String::new(),
+                        created_at_unix_ms: 2,
                         event: crate::AgentEvent::TurnDuration { duration_ms: 1234 },
                     },
                 ],

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -466,6 +466,7 @@ impl Engine {
                         meta.thread_id.as_u64(),
                         vec![luban_domain::ConversationEntry::AgentEvent {
                             entry_id: String::new(),
+                            created_at_unix_ms: 0,
                             event: luban_domain::AgentEvent::TurnError {
                                 message: "Agent run interrupted by server restart.".to_owned(),
                             },
@@ -5079,7 +5080,11 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
                 },
             },
         }),
-        ConversationEntry::UserEvent { entry_id, event } => {
+        ConversationEntry::UserEvent {
+            entry_id,
+            created_at_unix_ms,
+            event,
+        } => {
             let event = match event {
                 luban_domain::UserEvent::Message { text, attachments } => {
                     luban_api::UserEvent::Message(luban_api::UserMessage {
@@ -5116,10 +5121,15 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
             };
             luban_api::ConversationEntry::UserEvent(luban_api::UserEventEntry {
                 entry_id: entry_id.clone(),
+                created_at_unix_ms: *created_at_unix_ms,
                 event,
             })
         }
-        ConversationEntry::AgentEvent { entry_id, event } => {
+        ConversationEntry::AgentEvent {
+            entry_id,
+            created_at_unix_ms,
+            event,
+        } => {
             let event = match event {
                 luban_domain::AgentEvent::Message { id, text } => {
                     luban_api::AgentEvent::Message(luban_api::AgentMessage {
@@ -5148,6 +5158,7 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
             };
             luban_api::ConversationEntry::AgentEvent(luban_api::AgentEventEntry {
                 entry_id: entry_id.clone(),
+                created_at_unix_ms: *created_at_unix_ms,
                 event,
             })
         }
@@ -5887,6 +5898,7 @@ mod tests {
                 amp_mode: None,
                 entries: vec![ConversationEntry::UserEvent {
                     entry_id: "e_1".to_owned(),
+                    created_at_unix_ms: 1,
                     event: luban_domain::UserEvent::Message {
                         text: "hi".to_owned(),
                         attachments: Vec::new(),
@@ -6468,6 +6480,7 @@ mod tests {
         for i in 0..7000u32 {
             convo.entries.push(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
+                created_at_unix_ms: i as u64,
                 event: luban_domain::AgentEvent::Item {
                     item: Box::new(CodexThreadItem::CommandExecution {
                         id: format!("cmd_{i}"),

--- a/crates/luban_server/src/telegram.rs
+++ b/crates/luban_server/src/telegram.rs
@@ -3043,6 +3043,7 @@ mod tests {
     fn format_conversation_entry_skips_turn_duration() {
         let entry = ConversationEntry::AgentEvent(luban_api::AgentEventEntry {
             entry_id: "e".to_owned(),
+            created_at_unix_ms: 0,
             event: luban_api::AgentEvent::TurnDuration { duration_ms: 123 },
         });
         assert_eq!(format_conversation_entry_for_telegram(&entry), None);

--- a/crates/luban_server/tests/contracts_http.rs
+++ b/crates/luban_server/tests/contracts_http.rs
@@ -993,6 +993,19 @@ async fn http_contracts_smoke() {
                 .any(|entry| matches!(entry, luban_api::ConversationEntry::SystemEvent(_))),
             "expected conversation to include system events"
         );
+        for entry in &convo.entries {
+            match entry {
+                luban_api::ConversationEntry::SystemEvent(ev) => {
+                    assert!(ev.created_at_unix_ms > 0);
+                }
+                luban_api::ConversationEntry::UserEvent(ev) => {
+                    assert!(ev.created_at_unix_ms > 0);
+                }
+                luban_api::ConversationEntry::AgentEvent(ev) => {
+                    assert!(ev.created_at_unix_ms > 0);
+                }
+            }
+        }
     }
 
     // C-HTTP-CHANGES / C-HTTP-DIFF

--- a/docs/contracts/features/c-http-conversation.md
+++ b/docs/contracts/features/c-http-conversation.md
@@ -67,6 +67,7 @@ User events are structured:
 
 - `type`: `user_event`
 - `entry_id`: stable string identifier (unique within the conversation)
+- `created_at_unix_ms`: millisecond timestamp
 - `event.type`: `message` | `terminal_command_started` | `terminal_command_finished`
 
 For `event.type=message`:
@@ -94,6 +95,7 @@ Agent events are structured:
 
 - `type`: `agent_event`
 - `entry_id`: stable string identifier (unique within the conversation)
+- `created_at_unix_ms`: millisecond timestamp
 - `event.type`: `message` | `item` | `turn_usage` | `turn_duration` | `turn_canceled` | `turn_error`
 
 For `event.type=message`:

--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -33,6 +33,7 @@ Wire invariant for conversations:
 
 - `ConversationEntry` is tagged by `type` and only includes: `system_event`, `user_event`, `agent_event`.
 - Each `ConversationEntry` includes a stable `entry_id` (unique per entry).
+- Each `ConversationEntry` includes `created_at_unix_ms` (millisecond timestamp).
 - Streaming/tool updates are sent as additional appended `agent_event` entries (clients may fold by `AgentEvent.id` if desired).
 
 ## Invariants

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -64,7 +64,7 @@ Legend:
 - `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
-- `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).
+- `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id` and `created_at_unix_ms`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=system_event` may include `event_type=task_status_suggestion` to recommend a status change; clients apply via `ClientAction::TaskStatusSet`.
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=user_event` supports `event.type=message`, `terminal_command_started`, and `terminal_command_finished`.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.title` matches `ThreadMeta.title` and may be updated after the first user message.

--- a/web/components/chat-panel.tsx
+++ b/web/components/chat-panel.tsx
@@ -1032,7 +1032,6 @@ export function ChatPanel({
         <AgentRunningCard
           activities={activities}
           elapsedTime={agentRunElapsedLabel}
-          turnStartedAtMs={agentRunStartedAtMs}
           status={agentStatus}
           hasQueuedMessages={queuedPrompts.length > 0}
           editorValue={agentEditorValue}

--- a/web/components/shared/agent-running-card.tsx
+++ b/web/components/shared/agent-running-card.tsx
@@ -48,7 +48,6 @@ export type AgentRunningStatus = "running" | "cancelling" | "paused" | "resuming
 export function AgentRunningCard({
   activities,
   elapsedTime = "00:00",
-  turnStartedAtMs,
   status,
   hasQueuedMessages,
   editorValue,
@@ -70,7 +69,6 @@ export function AgentRunningCard({
 }: {
   activities: ActivityEvent[]
   elapsedTime?: string
-  turnStartedAtMs?: number | null
   status: AgentRunningStatus
   hasQueuedMessages: boolean
   editorValue: string
@@ -96,7 +94,7 @@ export function AgentRunningCard({
   const editorContainerRef = React.useRef<HTMLDivElement>(null)
   const anchorTopRef = React.useRef<number | null>(null)
   const isCompensatingScrollRef = React.useRef(false)
-  const { durationLabel: activityDurationLabel } = useActivityTiming(activities, { turnStartedAtMs })
+  const { durationLabel: activityDurationLabel } = useActivityTiming(activities)
 
   const showEditor = status === "cancelling" || status === "resuming"
   const isPaused = status === "paused"

--- a/web/lib/activity-timing.ts
+++ b/web/lib/activity-timing.ts
@@ -5,17 +5,7 @@ import { useEffect, useState } from "react"
 import type { ActivityEvent } from "@/lib/conversation-ui"
 import { formatDurationMs } from "@/lib/duration-format"
 
-type TimingMeta = {
-  startedAtMs: number
-  doneAtMs: number | null
-  status: ActivityEvent["status"]
-}
-
 const TURN_DURATION_TITLE_PREFIX = "Turn duration:"
-
-const globalTiming = new Map<string, TimingMeta>()
-const MAX_TIMING_ENTRIES = 50_000
-const PRUNE_BATCH_SIZE = 5_000
 
 function formatStepDuration(ms: number): string {
   return formatDurationMs(ms)
@@ -35,81 +25,12 @@ export function extractTurnDurationLabel(activities: ActivityEvent[]): string | 
 
 export function useActivityTiming(
   activities: ActivityEvent[],
-  opts?: { turnStartedAtMs?: number | null },
 ): {
   durationLabel: (event: ActivityEvent) => string | null
 } {
   const [tick, setTick] = useState(0)
 
-  useEffect(() => {
-    const now = Date.now()
-    const turnStartedAtMs =
-      typeof opts?.turnStartedAtMs === "number" && Number.isFinite(opts.turnStartedAtMs)
-        ? opts.turnStartedAtMs
-        : null
-
-    let maxExistingDoneAtMs: number | null = null
-    for (const event of activities) {
-      const doneAtMs = globalTiming.get(event.id)?.doneAtMs ?? null
-      if (typeof doneAtMs !== "number" || !Number.isFinite(doneAtMs)) continue
-      if (maxExistingDoneAtMs == null || doneAtMs > maxExistingDoneAtMs) {
-        maxExistingDoneAtMs = doneAtMs
-      }
-    }
-    const cursorStartAtMs =
-      turnStartedAtMs != null
-        ? Math.max(turnStartedAtMs, maxExistingDoneAtMs ?? turnStartedAtMs)
-        : null
-
-    const newDone = activities.filter((event) => !globalTiming.has(event.id) && event.status === "done")
-    const planned = new Map<string, { startedAtMs: number; doneAtMs: number }>()
-    if (cursorStartAtMs != null && newDone.length > 0) {
-      const spanMs = Math.max(0, now - cursorStartAtMs)
-      const chunk = Math.max(1, Math.floor(spanMs / newDone.length))
-      let cursor = cursorStartAtMs
-      for (let i = 0; i < newDone.length; i += 1) {
-        const event = newDone[i]
-        if (!event) continue
-        const doneAtMs = i === newDone.length - 1 ? now : Math.min(now, cursor + chunk)
-        planned.set(event.id, { startedAtMs: cursor, doneAtMs })
-        cursor = doneAtMs
-      }
-    }
-
-    for (const event of activities) {
-      const existing = globalTiming.get(event.id) ?? null
-      if (!existing) {
-        const plannedTimes = planned.get(event.id) ?? null
-        globalTiming.set(event.id, {
-          startedAtMs: plannedTimes?.startedAtMs ?? now,
-          doneAtMs:
-            event.status === "done"
-              ? plannedTimes?.doneAtMs ?? now
-              : null,
-          status: event.status,
-        })
-        continue
-      }
-
-      if (existing.status !== event.status) {
-        existing.status = event.status
-        if (event.status === "done" && existing.doneAtMs == null) {
-          existing.doneAtMs = now
-        }
-      }
-    }
-
-    if (globalTiming.size > MAX_TIMING_ENTRIES) {
-      let pruned = 0
-      for (const key of globalTiming.keys()) {
-        globalTiming.delete(key)
-        pruned += 1
-        if (pruned >= PRUNE_BATCH_SIZE || globalTiming.size <= MAX_TIMING_ENTRIES) break
-      }
-    }
-  }, [activities, opts?.turnStartedAtMs])
-
-  const hasRunningSteps = activities.some((e) => e.status === "running")
+  const hasRunningSteps = activities.some((e) => e.status === "running" && e.timing?.startedAtUnixMs != null)
   useEffect(() => {
     if (!hasRunningSteps) return
     const timer = window.setInterval(() => setTick((n) => (n + 1) % 1_000_000), 250)
@@ -118,10 +39,19 @@ export function useActivityTiming(
 
   const durationLabel = (event: ActivityEvent): string | null => {
     void tick
-    const meta = globalTiming.get(event.id) ?? null
-    if (!meta) return null
-    const end = meta.doneAtMs ?? Date.now()
-    return formatStepDuration(end - meta.startedAtMs)
+    const startedAtUnixMs = event.timing?.startedAtUnixMs ?? null
+    const doneAtUnixMs = event.timing?.doneAtUnixMs ?? null
+    if (typeof startedAtUnixMs !== "number" || !Number.isFinite(startedAtUnixMs) || startedAtUnixMs <= 0) return null
+
+    const end =
+      typeof doneAtUnixMs === "number" && Number.isFinite(doneAtUnixMs) && doneAtUnixMs > 0
+        ? doneAtUnixMs
+        : event.status === "running"
+          ? Date.now()
+          : null
+    if (end == null) return null
+
+    return formatStepDuration(Math.max(0, end - startedAtUnixMs))
   }
 
   return { durationLabel }

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -387,8 +387,8 @@ export type AgentItem = {
 
 export type ConversationEntry =
   | { type: "system_event"; entry_id: string; created_at_unix_ms: number; event: ConversationSystemEvent }
-  | { type: "user_event"; entry_id: string; event: UserEvent }
-  | { type: "agent_event"; entry_id: string; event: AgentEvent }
+  | { type: "user_event"; entry_id: string; created_at_unix_ms: number; event: UserEvent }
+  | { type: "agent_event"; entry_id: string; created_at_unix_ms: number; event: AgentEvent }
 
 export type UserEvent =
   | { type: "message"; text: string; attachments: AttachmentRef[] }

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -37,6 +37,7 @@ import { runTaskSummariesEventsRefresh } from './scenarios/task-summaries-events
 import { runQueuedPrompts } from './scenarios/queued-prompts.mjs';
 import { runProjectAllTasksView } from './scenarios/project-all-tasks-view.mjs';
 import { runKeyboardSequenceShortcuts } from './scenarios/keyboard-sequence-shortcuts.mjs';
+import { runTurnDurationEstimate } from './scenarios/turn-duration-estimate.mjs';
 
 async function canRun(command, args) {
   const proc = spawn(command, args, { stdio: 'ignore' });
@@ -188,6 +189,7 @@ async function main() {
     await runAgentRunnerIcons({ page, baseUrl });
     await runEscapeDoesNotLeakFromChatInput({ page, baseUrl });
     await runAgentRunningEventNoChevron({ page, baseUrl });
+    await runTurnDurationEstimate({ page, baseUrl });
     await runNewTaskDoubleSubmitNoDuplicate({ page, baseUrl });
     await runTaskSummariesEventsRefresh({ page, baseUrl });
     await runNoRightSidebar({ page, baseUrl });

--- a/web/tests/ui/scenarios/turn-duration-estimate.mjs
+++ b/web/tests/ui/scenarios/turn-duration-estimate.mjs
@@ -1,0 +1,27 @@
+export async function runTurnDurationEstimate({ page }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  await page.getByText('Mock: Turn states').first().click();
+
+  const firstTurn = page.getByTestId('agent-turn-card').first();
+  await firstTurn.waitFor({ state: 'visible' });
+  await firstTurn.scrollIntoViewIfNeeded();
+
+  const toggle = firstTurn.getByTestId('agent-turn-toggle');
+  await toggle.waitFor({ state: 'visible' });
+  await toggle.click();
+
+  const firstEvent = firstTurn.getByTestId('agent-turn-event').first();
+  await firstEvent.waitFor({ state: 'visible' });
+  const duration = firstEvent.getByTestId('activity-event-duration');
+  await duration.waitFor({ state: 'visible' });
+
+  const durationText = ((await duration.textContent()) ?? '').trim();
+  if (durationText === '< 1s') {
+    throw new Error('expected completed turn event to have a non-trivial duration estimate (not "< 1s")');
+  }
+  if (!/^(\d+s|\d+m \d+s|\d+h \d+m \d+s)$/.test(durationText)) {
+    throw new Error(`expected duration to look like a formatted duration, got "${durationText}"`);
+  }
+}


### PR DESCRIPTION

## What changed
- Add `created_at_unix_ms` to conversation entry payloads for `user_event` and `agent_event`.
- UI renders message timestamps and step durations from server-provided timestamps only (no client-side estimation).

## Contracts
- Updated `docs/contracts/features/c-http-conversation.md` and `docs/contracts/features/c-ws-events.md`.
- Updated `docs/contracts/progress.md`.

## Verification
- `just fmt`
- `just lint`
- `just test`
- `just test-ui`
