### PR TITLE
Fix startup hang from auto-archive cleanup

### DIFF
--- a/docs/contracts/features/c-http-tasks.md
+++ b/docs/contracts/features/c-http-tasks.md
@@ -1,7 +1,7 @@
 # C-HTTP-TASKS
 
 Status: Draft
-Verification: Mock=yes, Provider=yes, CI=no
+Verification: Mock=yes, Provider=yes, CI=yes
 
 ## Surface
 
@@ -18,6 +18,8 @@ client to iterate all workdirs and fan out requests.
 ## Query (optional)
 
 - `project_id`: `ProjectId` (string). When provided, only tasks for that project are returned.
+- `workdir_status`: `active` (default) / `archived` / `all`. Controls which workdir statuses are included in the response.
+- `task_status`: Comma-separated `TaskStatus` values. When provided, only tasks whose `task_status` is in the set are returned. Use `all` or omit to disable filtering. Legacy aliases are accepted (`in_progress` -> `iterating`, `in_review` -> `validating`).
 
 ## Response
 
@@ -41,4 +43,4 @@ client to iterate all workdirs and fan out requests.
 
 ## Web usage
 
-- `web/lib/luban-http.ts` `fetchTasks({ projectId? })`
+- `web/lib/luban-http.ts` `fetchTasks({ projectId?, workdirStatus? })`

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -70,6 +70,8 @@ Legend:
 - `C-HTTP-CONVERSATION`: `ConversationEntry.type=user_event` supports `event.type=message`, `terminal_command_started`, and `terminal_command_finished`.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.title` matches `ThreadMeta.title` and may be updated after the first user message.
 - `C-HTTP-TASKS`: `TaskSummarySnapshot` includes `is_starred` for rendering Favorites and in-view star toggles.
+- `C-HTTP-TASKS`: `GET /api/tasks` supports `workdir_status=active|archived|all` to control whether archived workdirs are included.
+- `C-HTTP-TASKS`: `GET /api/tasks` supports `task_status=...` (comma-separated) to filter by `TaskStatus` (use `all` or omit to disable filtering).
 - `C-HTTP-TASKS` / `C-HTTP-WORKDIR-TASKS`: thread metadata includes `created_at_unix_seconds` for stable creation-time sorting.
 - `C-HTTP-TASKS` / `C-HTTP-WORKDIR-TASKS`: thread metadata includes `task_status`, `turn_status`, and `last_turn_result` (see `docs/task-and-turn-status.md`).
 - `C-HTTP-WORKDIR-TASKS`: a workdir may start with zero tasks, and providers must not seed placeholder tasks on read; when legacy conversation storage exists, providers may perform a one-time migration to make tasks visible.

--- a/postmortem/2026-02-startup-blocked-by-auto-archive.md
+++ b/postmortem/2026-02-startup-blocked-by-auto-archive.md
@@ -1,0 +1,63 @@
+# Startup blocked by auto-archive cleanup
+
+## Summary
+
+On `v0.2.14+20260205`, Luban could appear to "start" but render an empty UI (for example the sidebar Projects list is empty) because the server engine never became responsive. The engine startup path awaited auto-archive maintenance that could take seconds (or effectively hang on slow filesystem/git operations), preventing HTTP/WebSocket handlers from serving snapshots and events.
+
+## Severity
+
+Sev-2 (High)
+
+## Impact
+
+- On launch, the web UI shows no projects/tasks and does not recover.
+- HTTP endpoints that depend on the engine (for example snapshot endpoints) can stall until maintenance finishes.
+- Users may misinterpret this as data loss.
+
+## Detection
+
+User report: "after upgrading from `v0.2.13+20260205` to `v0.2.14+20260205`, the UI is completely empty".
+
+## Root cause
+
+- `Engine::start` executed `engine.bootstrap().await` before entering the command loop that serves `EngineCommand`s.
+- `bootstrap()` performed synchronous maintenance:
+  - scanning workspaces and calling `list_conversation_threads` for each candidate
+  - triggering `ArchiveWorkspace` effects
+- `Effect::ArchiveWorkspace` awaited blocking cleanup work (git/worktree removal) via `spawn_blocking(...).await`.
+
+Because the command loop did not start until `bootstrap()` completed, any slow maintenance made the entire server appear unresponsive to the UI.
+
+## Triggering commits (introduced by)
+
+- `a66f848` ("Treat done/canceled tasks as archived") introduced auto-archive cleanup behavior that could run during startup.
+
+## Fix commits (resolved/mitigated by)
+
+- Unreleased patch: make startup maintenance non-blocking and make archive cleanup asynchronous.
+
+## Reproduction steps
+
+1. Have at least one git project with multiple workspaces.
+2. Ensure some workspaces are eligible for auto-archive (all tasks `done`/`canceled` and turns idle).
+3. Make `list_conversation_threads` and/or the workspace cleanup slow (for example slow disk or expensive git operations).
+4. Start Luban.
+5. Observe the UI loads but shows an empty Projects list and does not populate.
+
+## Resolution
+
+- Keep `bootstrap()` lightweight and schedule maintenance in background tasks.
+- Make `ArchiveWorkspace` effect fire-and-forget and report completion back into the engine loop via `EngineCommand::DispatchAction`.
+- Add regression tests to ensure:
+  - auto-archive scan cannot block `GetAppSnapshot`
+  - archive cleanup cannot block the engine from serving snapshots
+
+## Lessons learned
+
+- Startup should never await best-effort maintenance.
+- Long-running cleanup must not run on the engine command loop.
+
+## Prevention / action items
+
+- Keep a dedicated test for engine responsiveness during startup maintenance.
+- Treat archival/cleanup as bounded background work with explicit completion signals.

--- a/postmortem/README.md
+++ b/postmortem/README.md
@@ -10,6 +10,7 @@ This directory contains engineering postmortems for user-visible bugs, CI regres
 - **Sev-4 (Low)**: cosmetic or low-impact papercut.
 
 ## Index (by incident)
+- `2026-02-startup-blocked-by-auto-archive.md`
 
 - `2026-02-duplicate-thread-1-backlog-task.md`
 - `2026-02-task-list-project-avatar-inconsistency.md`

--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -300,7 +300,7 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
     let cancelled = false
     void (async () => {
       try {
-        const snap = await fetchTasks()
+        const snap = await fetchTasks({ workdirStatus: "active" })
         if (cancelled) return
         stableUpdatedAtByTaskRef.current = buildStableUpdatedAtMap(snap.tasks ?? [])
         setTasksSnapshot(snap)
@@ -317,7 +317,7 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
   const refreshTasks = useCallback(async () => {
     if (!app) return
     try {
-      const snap = await fetchTasks()
+      const snap = await fetchTasks({ workdirStatus: "active" })
       ensureStableUpdatedAtForNewTasks({ stable: stableUpdatedAtByTaskRef.current, tasks: snap.tasks ?? [] })
       setTasksSnapshot(snap)
     } catch (err) {

--- a/web/components/luban-sidebar.tsx
+++ b/web/components/luban-sidebar.tsx
@@ -211,7 +211,7 @@ export function LubanSidebar({
     let cancelled = false
     void (async () => {
       try {
-        const snap = await fetchTasks()
+        const snap = await fetchTasks({ workdirStatus: "all" })
         if (cancelled) return
         const starred = snap.tasks
           .filter((t) => t.is_starred)

--- a/web/components/task-detail-view.tsx
+++ b/web/components/task-detail-view.tsx
@@ -76,7 +76,7 @@ export function TaskDetailView({ taskId, taskTitle, workdir, projectName, projec
     let cancelled = false
     void (async () => {
       try {
-        const snap = await fetchTasks(projectPath ? { projectId: projectPath } : {})
+        const snap = await fetchTasks(projectPath ? { projectId: projectPath, workdirStatus: "all" } : { workdirStatus: "all" })
         if (cancelled) return
         const found =
           snap.tasks.find((t) => t.workdir_id === activeWorkspaceId && t.task_id === activeThreadId) ?? null

--- a/web/lib/luban-http.ts
+++ b/web/lib/luban-http.ts
@@ -8,6 +8,7 @@ import type {
   NewTaskDraftSnapshot,
   NewTaskDraftsSnapshot,
   NewTaskStashResponse,
+  TaskStatus,
   TasksSnapshot,
   ThreadsSnapshot,
   WorkspaceDiffSnapshot,
@@ -137,10 +138,16 @@ export async function fetchMentionItems(args: {
   return (await res.json()) as MentionItemSnapshot[]
 }
 
-export async function fetchTasks(args: { projectId?: string } = {}): Promise<TasksSnapshot> {
+export async function fetchTasks(args: {
+  projectId?: string
+  workdirStatus?: "active" | "archived" | "all"
+  taskStatus?: TaskStatus[]
+} = {}): Promise<TasksSnapshot> {
   if (isMockMode()) return await mockFetchTasks(args)
   const params = new URLSearchParams()
   if (args.projectId) params.set("project_id", args.projectId)
+  if (args.workdirStatus) params.set("workdir_status", args.workdirStatus)
+  if (args.taskStatus && args.taskStatus.length > 0) params.set("task_status", args.taskStatus.join(","))
   const suffix = params.toString() ? `?${params.toString()}` : ""
   const res = await fetch(`/api/tasks${suffix}`)
   if (!res.ok) throw new Error(`GET /api/tasks failed: ${res.status}`)

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -38,6 +38,7 @@ import { runQueuedPrompts } from './scenarios/queued-prompts.mjs';
 import { runProjectAllTasksView } from './scenarios/project-all-tasks-view.mjs';
 import { runKeyboardSequenceShortcuts } from './scenarios/keyboard-sequence-shortcuts.mjs';
 import { runTurnDurationEstimate } from './scenarios/turn-duration-estimate.mjs';
+import { runAllTasksIncludesArchivedWorkdirs } from './scenarios/all-tasks-includes-archived-workdirs.mjs';
 
 async function canRun(command, args) {
   const proc = spawn(command, args, { stdio: 'ignore' });
@@ -191,13 +192,14 @@ async function main() {
     await runAgentRunningEventNoChevron({ page, baseUrl });
     await runTurnDurationEstimate({ page, baseUrl });
     await runNewTaskDoubleSubmitNoDuplicate({ page, baseUrl });
-    await runTaskSummariesEventsRefresh({ page, baseUrl });
-    await runNoRightSidebar({ page, baseUrl });
-    await runCancelTaskClearsRunning({ page, baseUrl });
-  } catch (err) {
-    if (logFile) {
-      process.stderr.write(`ui smoke failed; log: ${logFile}\n`);
-    }
+	    await runTaskSummariesEventsRefresh({ page, baseUrl });
+	    await runNoRightSidebar({ page, baseUrl });
+	    await runCancelTaskClearsRunning({ page, baseUrl });
+	    await runAllTasksIncludesArchivedWorkdirs({ page, baseUrl });
+	  } catch (err) {
+	    if (logFile) {
+	      process.stderr.write(`ui smoke failed; log: ${logFile}\n`);
+	    }
     throw err;
   } finally {
     await browser?.close().catch(() => {});

--- a/web/tests/ui/scenarios/all-tasks-includes-archived-workdirs.mjs
+++ b/web/tests/ui/scenarios/all-tasks-includes-archived-workdirs.mjs
@@ -1,0 +1,57 @@
+import { waitForDataAttribute } from '../lib/utils.mjs';
+
+async function createTaskInNewWorkdir(page, { title }) {
+  await page.getByTestId('new-task-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'visible' });
+
+  const workdirSelector = page.getByTestId('new-task-workdir-selector');
+  await workdirSelector.waitFor({ state: 'visible' });
+  await workdirSelector.click();
+  await page.getByRole('menuitem').filter({ hasText: 'Create new...' }).first().click();
+  await waitForDataAttribute(workdirSelector, 'data-selected-workdir-id', '-1', 10_000);
+
+  await page.getByTestId('new-task-input').fill(title);
+  await page.getByTestId('new-task-submit-button').click();
+  await page.getByTestId('new-task-modal').waitFor({ state: 'hidden' });
+}
+
+async function setTaskStatusToDoneInAllTasksView(page, { title }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  await page.getByTestId('task-view-tab-all').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const doneGroupToggle = page.getByTestId('task-group-done');
+  await doneGroupToggle.waitFor({ state: 'visible' });
+
+  const knownDoneRow = page
+    .getByTestId('task-list-view')
+    .locator('div.group', { hasText: 'Done: completed successfully' })
+    .first();
+  if (!(await knownDoneRow.isVisible().catch(() => false))) {
+    await doneGroupToggle.click();
+    await knownDoneRow.waitFor({ state: 'visible' });
+  }
+
+  const row = page.getByTestId('task-list-view').locator('div.group', { hasText: title }).first();
+  await row.waitFor({ state: 'visible' });
+  await row.scrollIntoViewIfNeeded();
+
+  const trigger = row.locator('button[title^="Status:"]').first();
+  await trigger.waitFor({ state: 'visible' });
+  await trigger.click();
+  await page.getByTestId('task-status-option-done').click();
+
+  const doneRow = page.getByTestId('task-list-view').locator('div.group', { hasText: title }).first();
+  await doneRow.waitFor({ state: 'visible' });
+  const doneTrigger = doneRow.locator('button[title^="Status:"]').first();
+  await waitForDataAttribute(doneTrigger, 'title', 'Status: Done', 20_000);
+}
+
+export async function runAllTasksIncludesArchivedWorkdirs({ page }) {
+  const title = 'Smoke: archived workdir stays visible';
+
+  await createTaskInNewWorkdir(page, { title });
+  await setTaskStatusToDoneInAllTasksView(page, { title });
+}


### PR DESCRIPTION
## Summary

Fix a regression where Luban could appear to start with an empty UI because engine startup was blocked by auto-archive workspace cleanup.

## Changes

- Keep `Engine::bootstrap` lightweight and schedule maintenance (auto-archive scan + stale running turn reconciliation) in background tasks.
- Make `ArchiveWorkspace` cleanup fire-and-forget and report completion back into the engine loop via `EngineCommand::DispatchAction`.
- Add `GET /api/tasks` query filtering (`project_id`, `workdir_status`, `task_status`) and align web usage + contracts.
- Add regression tests to ensure snapshot endpoints remain responsive while auto-archive scan / archive cleanup are running.

## Verification

- `just fmt`
- `just lint`
- `just test`
- `just test-ui`

## Manual checks

1. Start Luban and confirm sidebar Projects renders immediately.
2. Confirm engine stays responsive while archive cleanup runs.
3. Confirm `GET /api/tasks?workdir_status=all` returns tasks from archived workdirs.

## Risk / rollback

- Archive cleanup is now asynchronous; state updates are applied when the completion action is dispatched.
- Rollback: revert this PR to restore the previous synchronous behavior (not recommended because it reintroduces startup blocking).
