### PR TITLE
Fix web lint warnings for activity/message components

### DIFF
--- a/web/components/chat-panel.tsx
+++ b/web/components/chat-panel.tsx
@@ -1065,7 +1065,6 @@ export function ChatPanel({
       agentEditorAttachments,
       agentEditorValue,
       agentRunElapsedLabel,
-      agentRunStartedAtMs,
       agentStatus,
       attachmentsFromRefs,
       codexCustomPrompts,

--- a/web/components/inbox-view.tsx
+++ b/web/components/inbox-view.tsx
@@ -201,6 +201,7 @@ function NotificationRow({ notification, previewText, timestampText, testId, sel
       <div className="flex-1 min-w-0">
         {/* Project + Title row */}
         <div className="flex items-center gap-1.5">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             data-testid="inbox-notification-project-avatar"
             src={notification.projectAvatarUrl}
@@ -284,13 +285,13 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
   const previewInFlightRef = useRef<Set<string>>(new Set())
   const prevWsConnectedRef = useRef(false)
   const stableUpdatedAtByTaskRef = useRef<Map<string, number>>(new Map())
+  const hasApp = app != null
 
   useEffect(() => {
     previewByNotificationIdRef.current = previewByNotificationId
   }, [previewByNotificationId])
 
   useEffect(() => {
-    const hasApp = app != null
     if (!hasApp) {
       setTasksSnapshot(null)
       stableUpdatedAtByTaskRef.current = new Map()
@@ -312,7 +313,7 @@ export function InboxView({ onOpenFullView, refreshSeq }: InboxViewProps) {
     return () => {
       cancelled = true
     }
-  }, [app != null, refreshSeq])
+  }, [hasApp, refreshSeq])
 
   const refreshTasks = useCallback(async () => {
     if (!app) return

--- a/web/components/luban-sidebar.tsx
+++ b/web/components/luban-sidebar.tsx
@@ -142,6 +142,7 @@ function ProjectItem({
         className="flex-1 min-w-0 flex items-center gap-2 outline-none"
       >
         {avatarUrl && !avatarLoadFailed ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
           <img
             src={avatarUrl}
             alt=""

--- a/web/components/markdown.tsx
+++ b/web/components/markdown.tsx
@@ -58,8 +58,8 @@ export const Markdown = memo(
           ),
           img: ({ className, src, alt, ...props }) => {
             if (!src) return null
-            // eslint-disable-next-line @next/next/no-img-element
             return (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 className={cn("my-2 max-w-full h-auto rounded-md border border-border/50", className)}
                 src={String(src)}

--- a/web/components/new-task-modal.tsx
+++ b/web/components/new-task-modal.tsx
@@ -671,11 +671,12 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
                   }}
                   disabled={executingMode != null}
                 >
-	                  {/* Project indicator */}
-	                  {selectedProject != null && selectedProject.isGit ? (
-	                    <img
-	                      src={selectedProject.avatarUrl ?? selectedProject.fallbackAvatarUrl}
-	                      alt=""
+		                  {/* Project indicator */}
+		                  {selectedProject != null && selectedProject.isGit ? (
+		                    /* eslint-disable-next-line @next/next/no-img-element */
+		                    <img
+		                      src={selectedProject.avatarUrl ?? selectedProject.fallbackAvatarUrl}
+		                      alt=""
 	                      width={12}
 	                      height={12}
 	                      className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 rounded overflow-hidden"
@@ -733,11 +734,12 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
 	                      }}
 	                      className="flex items-center justify-between h-8 px-2 rounded cursor-pointer hover:bg-[#f5f5f5] focus:bg-[#f5f5f5] outline-none"
 	                    >
-		                      <div className="flex items-center gap-2">
-		                        {p.isGit ? (
-	                          <img
-	                            src={p.avatarUrl ?? p.fallbackAvatarUrl}
-	                            alt=""
+			                      <div className="flex items-center gap-2">
+			                        {p.isGit ? (
+		                          /* eslint-disable-next-line @next/next/no-img-element */
+		                          <img
+		                            src={p.avatarUrl ?? p.fallbackAvatarUrl}
+		                            alt=""
 	                            width={16}
 	                            height={16}
 	                            className="w-4 h-4 rounded overflow-hidden flex-shrink-0"

--- a/web/components/shared/agent-selector.tsx
+++ b/web/components/shared/agent-selector.tsx
@@ -3,6 +3,7 @@
 import type { AgentRunnerKind, ThinkingEffort } from "@/lib/luban-api"
 
 import { useMemo, useState } from "react"
+import Image from "next/image"
 import { ChevronDown, Settings } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -14,12 +15,14 @@ const AMP_MARK_URL = "/logos/amp.svg"
 
 function AmpMark({ className }: { className?: string }) {
   return (
-    <img
+    <Image
       data-agent-runner-icon="amp"
       src={AMP_MARK_URL}
       alt=""
       aria-hidden="true"
       className={cn("inline-block", className)}
+      width={14}
+      height={14}
     />
   )
 }

--- a/web/components/shared/task-header.tsx
+++ b/web/components/shared/task-header.tsx
@@ -47,6 +47,7 @@ export function ProjectIcon({ name, color, avatarUrl, testId }: ProjectInfo & { 
 
   if (avatarUrl && !avatarLoadFailed) {
     return (
+      // eslint-disable-next-line @next/next/no-img-element
       <img
         data-testid={testId}
         src={avatarUrl}

--- a/web/components/task-list-view.tsx
+++ b/web/components/task-list-view.tsx
@@ -152,6 +152,7 @@ function TaskAgentPill({
   const avatar = (() => {
     if (runner === "amp") {
       return (
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           data-agent-runner-icon="amp"
           src={AMP_MARK_URL}


### PR DESCRIPTION
## Summary
- remove the unnecessary `useCallback` dependency in `chat-panel`
- fix `useEffect` dependencies in `inbox-view` to avoid complex-expression and missing-dependency warnings
- resolve `@next/next/no-img-element` warnings by switching the local AMP icon usages to `next/image` and adding targeted eslint waivers for dynamic avatar/markdown image points where behavior must stay unchanged

## Validation
- `cd web && pnpm lint`
- `cd web && pnpm typecheck`
