### PR TITLE
fix(telegram): keep one progress message and document relay semantics

### DIFF
--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -189,6 +189,14 @@ update this section.
 - `reconnect` can be used to attach a terminal UI to `WS /api/pty/{workdir_id}/{task_id}?reconnect=<token>` while the command is running.
 - `output_base64` is base64-encoded bytes captured from the PTY output history and may be empty when `output_byte_len=0`.
 
+### Telegram progress relay behavior (provider note)
+
+For Telegram-paired chats, provider-side forwarding of `ConversationChanged` to Telegram follows these rules:
+
+- During a running turn, the provider keeps a per-task progress message and updates it with `editMessageText`.
+- When a new turn starts for the same task target (same chat/topic/workspace/thread key), the provider reuses the existing progress message when possible instead of sending a new one.
+- If Telegram returns `Bad Request: message is not modified` for `editMessageText`, the provider treats it as an idempotent success and does not fallback to `sendMessage`.
+
 ## Event inventory (tracked)
 
 All `ServerEvent` variants are part of this contract surface:

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -61,6 +61,7 @@ Legend:
 - `C-WS-EVENTS`: `ClientAction::TaskStarSet` is implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_http.rs` (roundtrip: WS toggle then `GET /api/tasks`).
 - `C-WS-EVENTS`: `ClientAction::TaskStatusSet` updates per-task `TaskStatus` and is implemented in mock + provider.
 - `C-WS-EVENTS`: Telegram integration actions (`TelegramBotTokenSet` / `TelegramBotTokenClear` / `TelegramPairStart` / `TelegramUnpair`) are implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_ws_events_telegram.rs`.
+- `C-WS-EVENTS`: Telegram progress relay reuses a single per-task progress message via `editMessageText` and treats `message is not modified` as idempotent success (see `docs/contracts/features/c-ws-events.md`, "Telegram progress relay behavior").
 - `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.


### PR DESCRIPTION
## Summary
- Reuse the same Telegram progress message for the same task target at the beginning of each new turn when possible.
- Treat Telegram `editMessageText` response `message is not modified` as idempotent success to avoid unnecessary fallback sends.
- Document the Telegram progress relay behavior in contract docs.

## Behavior changes
- For the same `(chat_id, topic_id, workspace_id, thread_id)` target, a new turn now prefers editing the existing progress message instead of sending a new message.
- `message is not modified` no longer causes fallback `sendMessage` behavior.

## Files changed
- `crates/luban_server/src/telegram.rs`
- `docs/contracts/features/c-ws-events.md`
- `docs/contracts/progress.md`

## Verification
- `just fmt && just lint && just test`

## Manual verification
1. Pair Telegram integration and select a task.
2. Send a user message and wait until the progress message appears.
3. Send another user message to the same task.
4. Confirm the bot keeps updating the same progress message (instead of creating a new one per turn).
5. Confirm no extra fallback message is created when edit payload is unchanged.
