### PR TITLE
feat: agent/runner icon per entry

### DIFF
--- a/crates/luban_api/src/lib.rs
+++ b/crates/luban_api/src/lib.rs
@@ -681,6 +681,8 @@ pub struct AgentEventEntry {
     pub entry_id: String,
     #[serde(default)]
     pub created_at_unix_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner: Option<AgentRunnerKind>,
     pub event: AgentEvent,
 }
 

--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1322,6 +1322,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
                                                     created_at_unix_ms: 0,
+                                                    runner: None,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1331,6 +1332,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1364,6 +1366,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1383,6 +1386,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1406,6 +1410,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1425,6 +1430,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1448,6 +1454,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1533,6 +1540,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
                                                     created_at_unix_ms: 0,
+                                                    runner: None,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1542,6 +1550,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1575,6 +1584,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1594,6 +1604,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1617,6 +1628,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1636,6 +1648,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1659,6 +1672,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1740,6 +1754,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                                 ConversationEntry::AgentEvent {
                                                     entry_id: String::new(),
                                                     created_at_unix_ms: 0,
+                                                    runner: None,
                                                     event: luban_domain::AgentEvent::Message {
                                                         id: id.clone(),
                                                         text: text.clone(),
@@ -1749,6 +1764,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             _ => ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::Item {
                                                     item: Box::new(item.clone()),
                                                 },
@@ -1782,6 +1798,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1801,6 +1818,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: error.message.clone(),
                                             },
@@ -1824,6 +1842,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1843,6 +1862,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnError {
                                                 message: message.clone(),
                                             },
@@ -1866,6 +1886,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             vec![ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::TurnDuration {
                                                     duration_ms,
                                                 },
@@ -1901,6 +1922,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                         vec![ConversationEntry::AgentEvent {
                             entry_id: String::new(),
                             created_at_unix_ms: 0,
+                            runner: None,
                             event: luban_domain::AgentEvent::TurnDuration { duration_ms },
                         }],
                     )?;
@@ -1913,6 +1935,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                     vec![ConversationEntry::AgentEvent {
                         entry_id: String::new(),
                         created_at_unix_ms: 0,
+                        runner: None,
                         event: luban_domain::AgentEvent::TurnCanceled,
                     }],
                 )?;
@@ -1929,6 +1952,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                     vec![ConversationEntry::AgentEvent {
                         entry_id: String::new(),
                         created_at_unix_ms: 0,
+                        runner: None,
                         event: luban_domain::AgentEvent::Message {
                             id: id.clone(),
                             text: text.clone(),
@@ -1962,6 +1986,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                     vec![ConversationEntry::AgentEvent {
                         entry_id: String::new(),
                         created_at_unix_ms: 0,
+                        runner: None,
                         event: luban_domain::AgentEvent::TurnDuration { duration_ms },
                     }],
                 );
@@ -1974,6 +1999,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                 vec![ConversationEntry::AgentEvent {
                     entry_id: String::new(),
                     created_at_unix_ms: 0,
+                    runner: None,
                     event: luban_domain::AgentEvent::TurnError {
                         message: format!("{err:#}"),
                     },

--- a/crates/luban_backend/src/services/conversations.rs
+++ b/crates/luban_backend/src/services/conversations.rs
@@ -94,11 +94,13 @@ fn migrate_legacy_entry(entry: LegacyConversationEntry) -> Option<ConversationEn
             CodexThreadItem::AgentMessage { id, text } => Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: AgentEvent::Message { id, text },
             }),
             other => Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: AgentEvent::Item {
                     item: Box::new(other),
                 },
@@ -109,17 +111,20 @@ fn migrate_legacy_entry(entry: LegacyConversationEntry) -> Option<ConversationEn
             Some(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: AgentEvent::TurnDuration { duration_ms },
             })
         }
         LegacyConversationEntry::TurnCanceled => Some(ConversationEntry::AgentEvent {
             entry_id: String::new(),
             created_at_unix_ms: 0,
+            runner: None,
             event: AgentEvent::TurnCanceled,
         }),
         LegacyConversationEntry::TurnError { message } => Some(ConversationEntry::AgentEvent {
             entry_id: String::new(),
             created_at_unix_ms: 0,
+            runner: None,
             event: AgentEvent::TurnError { message },
         }),
     }
@@ -625,6 +630,7 @@ mod tests {
             ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: AgentEvent::Message {
                     id: "item_0".to_owned(),
                     text: "A".to_owned(),
@@ -641,6 +647,7 @@ mod tests {
             ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: AgentEvent::Message {
                     id: "item_0".to_owned(),
                     text: "B".to_owned(),

--- a/crates/luban_backend/src/sqlite_store.rs
+++ b/crates/luban_backend/src/sqlite_store.rs
@@ -4268,12 +4268,14 @@ fn migrate_conversation_entries_v17(conn: &mut Connection) -> anyhow::Result<()>
                     ConversationEntry::AgentEvent {
                         entry_id: String::new(),
                         created_at_unix_ms: 0,
+                        runner: None,
                         event: luban_domain::AgentEvent::Message { id, text },
                     }
                 }
                 other => ConversationEntry::AgentEvent {
                     entry_id: String::new(),
                     created_at_unix_ms: 0,
+                    runner: None,
                     event: luban_domain::AgentEvent::Item {
                         item: Box::new(other),
                     },
@@ -4282,23 +4284,27 @@ fn migrate_conversation_entries_v17(conn: &mut Connection) -> anyhow::Result<()>
             LegacyConversationEntry::TurnUsage { usage } => ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::TurnUsage { usage },
             },
             LegacyConversationEntry::TurnDuration { duration_ms } => {
                 ConversationEntry::AgentEvent {
                     entry_id: String::new(),
                     created_at_unix_ms: 0,
+                    runner: None,
                     event: luban_domain::AgentEvent::TurnDuration { duration_ms },
                 }
             }
             LegacyConversationEntry::TurnCanceled => ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::TurnCanceled,
             },
             LegacyConversationEntry::TurnError { message } => ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::TurnError { message },
             },
         }
@@ -4557,6 +4563,7 @@ mod tests {
             &[ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::Message {
                     id: "m1".to_owned(),
                     text: "hi".to_owned(),
@@ -5018,11 +5025,13 @@ mod tests {
             CodexThreadItem::AgentMessage { id, text } => ConversationEntry::AgentEvent {
                 entry_id: "e_1".to_owned(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::Message { id, text },
             },
             other => ConversationEntry::AgentEvent {
                 entry_id: "e_1".to_owned(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::Item {
                     item: Box::new(other),
                 },
@@ -5178,6 +5187,7 @@ mod tests {
             let entry = ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: 0,
+                runner: None,
                 event: luban_domain::AgentEvent::TurnDuration { duration_ms: idx },
             };
             db.append_conversation_entries("p", "w", 1, std::slice::from_ref(&entry))
@@ -5270,6 +5280,7 @@ mod tests {
         let entry_a = ConversationEntry::AgentEvent {
             entry_id: String::new(),
             created_at_unix_ms: 0,
+            runner: None,
             event: luban_domain::AgentEvent::Message {
                 id: "turn-a/item_0".to_owned(),
                 text: "A".to_owned(),
@@ -5278,6 +5289,7 @@ mod tests {
         let entry_b = ConversationEntry::AgentEvent {
             entry_id: String::new(),
             created_at_unix_ms: 0,
+            runner: None,
             event: luban_domain::AgentEvent::Message {
                 id: "turn-b/item_0".to_owned(),
                 text: "B".to_owned(),

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -43,6 +43,7 @@ fn cancel_running_turn(conversation: &mut WorkspaceConversation) -> Option<u64> 
     conversation.push_entry(ConversationEntry::AgentEvent {
         entry_id: String::new(),
         created_at_unix_ms: 0,
+        runner: None,
         event: crate::AgentEvent::TurnCanceled,
     });
     Some(run_id)
@@ -1524,6 +1525,7 @@ impl AppState {
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
                                 created_at_unix_ms: 0,
+                                runner: None,
                                 event: crate::AgentEvent::TurnDuration { duration_ms },
                             });
                             Vec::new()
@@ -1545,6 +1547,7 @@ impl AppState {
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
                                 created_at_unix_ms: 0,
+                                runner: None,
                                 event: crate::AgentEvent::TurnError {
                                     message: error_message.clone(),
                                 },
@@ -1601,6 +1604,7 @@ impl AppState {
                             conversation.push_entry(ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
                                 created_at_unix_ms: 0,
+                                runner: None,
                                 event: crate::AgentEvent::TurnError {
                                     message: message.clone(),
                                 },
@@ -5246,6 +5250,7 @@ mod tests {
                     ConversationEntry::AgentEvent {
                         entry_id: String::new(),
                         created_at_unix_ms: 2,
+                        runner: None,
                         event: crate::AgentEvent::TurnDuration { duration_ms: 1234 },
                     },
                 ],

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -545,6 +545,7 @@ impl Engine {
                             vec![luban_domain::ConversationEntry::AgentEvent {
                                 entry_id: String::new(),
                                 created_at_unix_ms: 0,
+                                runner: None,
                                 event: luban_domain::AgentEvent::TurnError {
                                     message: "Agent run interrupted by server restart.".to_owned(),
                                 },
@@ -637,6 +638,7 @@ impl Engine {
                         vec![luban_domain::ConversationEntry::AgentEvent {
                             entry_id: String::new(),
                             created_at_unix_ms: 0,
+                            runner: None,
                             event: luban_domain::AgentEvent::TurnError {
                                 message: "Agent run interrupted by server restart.".to_owned(),
                             },
@@ -5437,6 +5439,7 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
         ConversationEntry::AgentEvent {
             entry_id,
             created_at_unix_ms,
+            runner,
             event,
         } => {
             let event = match event {
@@ -5468,6 +5471,11 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
             luban_api::ConversationEntry::AgentEvent(luban_api::AgentEventEntry {
                 entry_id: entry_id.clone(),
                 created_at_unix_ms: *created_at_unix_ms,
+                runner: runner.map(|r| match r {
+                    luban_domain::AgentRunnerKind::Codex => luban_api::AgentRunnerKind::Codex,
+                    luban_domain::AgentRunnerKind::Amp => luban_api::AgentRunnerKind::Amp,
+                    luban_domain::AgentRunnerKind::Claude => luban_api::AgentRunnerKind::Claude,
+                }),
                 event,
             })
         }
@@ -6795,6 +6803,7 @@ mod tests {
             convo.entries.push(ConversationEntry::AgentEvent {
                 entry_id: String::new(),
                 created_at_unix_ms: i as u64,
+                runner: None,
                 event: luban_domain::AgentEvent::Item {
                     item: Box::new(CodexThreadItem::CommandExecution {
                         id: format!("cmd_{i}"),

--- a/crates/luban_server/src/telegram.rs
+++ b/crates/luban_server/src/telegram.rs
@@ -3063,6 +3063,7 @@ mod tests {
         let entry = ConversationEntry::AgentEvent(luban_api::AgentEventEntry {
             entry_id: "e".to_owned(),
             created_at_unix_ms: 0,
+            runner: None,
             event: luban_api::AgentEvent::TurnDuration { duration_ms: 123 },
         });
         assert_eq!(format_conversation_entry_for_telegram(&entry), None);

--- a/web/lib/conversation-ui.ts
+++ b/web/lib/conversation-ui.ts
@@ -765,12 +765,15 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
 
     if (entry.type === "agent_event") {
       const ev = entry.event
+      // Reason: use per-entry runner so each message retains the icon
+      // of the model that generated it, falling back to conversation-level.
+      const entryRunner = entry.runner ?? conversation.agent_runner
       if (ev.type === "message") {
         const turnId = lastUserEntryId ? `t_${lastUserEntryId}` : `t_orphan_${ev.id}`
         const msg = ensureTurnMessage(turnId)
         const createdAtUnixMs = normalizeUnixMs(entry.created_at_unix_ms)
         const messageText = ev.text.trim()
-        msg.agentRunner = conversation.agent_runner
+        msg.agentRunner = entryRunner
         msg.content = messageText
         msg.timestamp = unixMsToIso(entry.created_at_unix_ms) ?? msg.timestamp
 
@@ -797,7 +800,8 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
       if (ev.type === "item") {
         if (!lastUserEntryId) continue
         const turnId = `t_${lastUserEntryId}`
-        ensureTurnMessage(turnId)
+        const turnMsg = ensureTurnMessage(turnId)
+        turnMsg.agentRunner = entryRunner
         const status = inferActivityStatusFromPayload(ev.payload)
         const activityKey = `item_${ev.id}`
         const rowId = activityKey
@@ -821,7 +825,8 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
       if (ev.type === "turn_duration") {
         if (!lastUserEntryId) continue
         const turnId = `t_${lastUserEntryId}`
-        ensureTurnMessage(turnId)
+        const turnMsg = ensureTurnMessage(turnId)
+        turnMsg.agentRunner = entryRunner
         const activityKey = `turn_duration_${ev.duration_ms}`
         const rowId = `${activityKey}_${entry.entry_id || out.length}`
         const createdAtUnixMs = normalizeUnixMs(entry.created_at_unix_ms)
@@ -844,7 +849,8 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
       if (ev.type === "turn_usage") {
         if (!lastUserEntryId) continue
         const turnId = `t_${lastUserEntryId}`
-        ensureTurnMessage(turnId)
+        const turnMsg = ensureTurnMessage(turnId)
+        turnMsg.agentRunner = entryRunner
         const activityKey = "turn_usage"
         const rowId = `${activityKey}_${entry.entry_id || out.length}`
         const createdAtUnixMs = normalizeUnixMs(entry.created_at_unix_ms)
@@ -868,7 +874,8 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
       if (ev.type === "turn_error") {
         if (!lastUserEntryId) continue
         const turnId = `t_${lastUserEntryId}`
-        ensureTurnMessage(turnId)
+        const turnMsg = ensureTurnMessage(turnId)
+        turnMsg.agentRunner = entryRunner
         applyTurnStatus(turnId, "error")
         const activityKey = "turn_error"
         const rowId = `${activityKey}_${entry.entry_id || out.length}`
@@ -893,7 +900,8 @@ function buildMessagesGroupedTurns(conversation: ConversationSnapshot): Message[
       if (ev.type === "turn_canceled") {
         if (!lastUserEntryId) continue
         const turnId = `t_${lastUserEntryId}`
-        ensureTurnMessage(turnId)
+        const turnMsg = ensureTurnMessage(turnId)
+        turnMsg.agentRunner = entryRunner
         applyTurnStatus(turnId, "canceled")
         const activityKey = "turn_canceled"
         const rowId = `${activityKey}_${entry.entry_id || out.length}`
@@ -1137,13 +1145,14 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
 
     if (entry.type === "agent_event") {
       const ev = entry.event
+      const entryRunner = entry.runner ?? conversation.agent_runner
       if (ev.type === "message") {
         const entryPart = entry.entry_id ? `_${entry.entry_id}` : `_${out.length}`
         out.push({
           id: `a_${ev.id}${entryPart}`,
           type: "assistant",
           eventSource: "agent",
-          agentRunner: conversation.agent_runner,
+          agentRunner: entryRunner,
           content: ev.text.trim(),
           timestamp: unixMsToIso(entry.created_at_unix_ms),
         })
@@ -1166,7 +1175,7 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
             id: baseId,
             type: "event",
             eventSource: "agent",
-            agentRunner: conversation.agent_runner,
+            agentRunner: entryRunner,
             status,
             content: activity.title,
             timestamp: unixMsToIso(entry.created_at_unix_ms),
@@ -1181,7 +1190,7 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
           id: `ae_turn_duration_${out.length}_${ev.duration_ms}`,
           type: "event",
           eventSource: "agent",
-          agentRunner: conversation.agent_runner,
+          agentRunner: entryRunner,
           status: "done",
           content: `Turn duration: ${formatDurationMs(ev.duration_ms)}`,
           timestamp: unixMsToIso(entry.created_at_unix_ms),
@@ -1194,7 +1203,7 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
           id: `ae_turn_usage_${out.length}`,
           type: "event",
           eventSource: "agent",
-          agentRunner: conversation.agent_runner,
+          agentRunner: entryRunner,
           status: "done",
           content: "Turn usage",
           timestamp: unixMsToIso(entry.created_at_unix_ms),
@@ -1207,7 +1216,7 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
           id: `ae_turn_error_${out.length}`,
           type: "event",
           eventSource: "agent",
-          agentRunner: conversation.agent_runner,
+          agentRunner: entryRunner,
           status: "done",
           content: `Turn error: ${ev.message}`,
           timestamp: unixMsToIso(entry.created_at_unix_ms),
@@ -1220,7 +1229,7 @@ function buildMessagesFlatEvents(conversation: ConversationSnapshot): Message[] 
           id: `ae_turn_canceled_${out.length}`,
           type: "event",
           eventSource: "agent",
-          agentRunner: conversation.agent_runner,
+          agentRunner: entryRunner,
           status: "done",
           content: "Turn canceled",
           timestamp: unixMsToIso(entry.created_at_unix_ms),

--- a/web/lib/luban-api.ts
+++ b/web/lib/luban-api.ts
@@ -389,7 +389,7 @@ export type AgentItem = {
 export type ConversationEntry =
   | { type: "system_event"; entry_id: string; created_at_unix_ms: number; event: ConversationSystemEvent }
   | { type: "user_event"; entry_id: string; created_at_unix_ms: number; event: UserEvent }
-  | { type: "agent_event"; entry_id: string; created_at_unix_ms: number; event: AgentEvent }
+  | { type: "agent_event"; entry_id: string; created_at_unix_ms: number; runner?: AgentRunnerKind; event: AgentEvent }
 
 export type UserEvent =
   | { type: "message"; text: string; attachments: AttachmentRef[] }


### PR DESCRIPTION
When we switch model in one chat/session, all history chat icon will be changed to new agent/runner, which is incorrect.

This PR resolved it by adding agent/runner per entry to display.

<img width="768" height="503" alt="image" src="https://github.com/user-attachments/assets/eea74193-18d5-4682-ac66-53c008d0e3e8" />
