### PR TITLE
fix(telegram): reuse per-task relay message instead of repeated sends

### DIFF
--- a/docs/contracts/features/c-ws-events.md
+++ b/docs/contracts/features/c-ws-events.md
@@ -195,6 +195,7 @@ For Telegram-paired chats, provider-side forwarding of `ConversationChanged` to 
 
 - During a running turn, the provider keeps a per-task progress message and updates it with `editMessageText`.
 - When a new turn starts for the same task target (same chat/topic/workspace/thread key), the provider reuses the existing progress message when possible instead of sending a new one.
+- For passive task forwarding (when no running-turn progress relay is active), the provider keeps a per-task relay message after the first `sendMessage`, and applies subsequent new updates with `editMessageText` to the same message.
 - If Telegram returns `Bad Request: message is not modified` for `editMessageText`, the provider treats it as an idempotent success and does not fallback to `sendMessage`.
 
 ## Event inventory (tracked)

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -62,6 +62,7 @@ Legend:
 - `C-WS-EVENTS`: `ClientAction::TaskStatusSet` updates per-task `TaskStatus` and is implemented in mock + provider.
 - `C-WS-EVENTS`: Telegram integration actions (`TelegramBotTokenSet` / `TelegramBotTokenClear` / `TelegramPairStart` / `TelegramUnpair`) are implemented in mock + provider and verified in CI via `crates/luban_server/tests/contracts_ws_events_telegram.rs`.
 - `C-WS-EVENTS`: Telegram progress relay reuses a single per-task progress message via `editMessageText` and treats `message is not modified` as idempotent success (see `docs/contracts/features/c-ws-events.md`, "Telegram progress relay behavior").
+- `C-WS-EVENTS`: Telegram passive conversation forwarding also keeps a single per-task relay message (after first send) and updates it via `editMessageText` on subsequent new updates.
 - `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.


### PR DESCRIPTION
## Summary
- reuse a single per-task relay message for passive Telegram conversation forwarding
- switch subsequent updates to `editMessageText` instead of sending repeated new messages
- keep turn-start progress relay able to reuse existing relay/progress message IDs
- update Telegram relay contract notes in docs

## Testing
- just fmt
- just lint
- just test-fast
- just test
