### PR TITLE
fix: unblock CI for runner field and droid mapping

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -1748,6 +1748,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                             ConversationEntry::AgentEvent {
                                                 entry_id: String::new(),
                                                 created_at_unix_ms: 0,
+                                                runner: None,
                                                 event: luban_domain::AgentEvent::Message {
                                                     id: id.clone(),
                                                     text: text.clone(),
@@ -1757,6 +1758,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         _ => ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::Item {
                                                 item: Box::new(item.clone()),
                                             },
@@ -1789,6 +1791,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnDuration {
                                                 duration_ms,
                                             },
@@ -1808,6 +1811,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                     vec![ConversationEntry::AgentEvent {
                                         entry_id: String::new(),
                                         created_at_unix_ms: 0,
+                                        runner: None,
                                         event: luban_domain::AgentEvent::TurnError {
                                             message: error.message.clone(),
                                         },
@@ -1830,6 +1834,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnDuration {
                                                 duration_ms,
                                             },
@@ -1849,6 +1854,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                     vec![ConversationEntry::AgentEvent {
                                         entry_id: String::new(),
                                         created_at_unix_ms: 0,
+                                        runner: None,
                                         event: luban_domain::AgentEvent::TurnError {
                                             message: message.clone(),
                                         },
@@ -1871,6 +1877,7 @@ impl ProjectWorkspaceService for GitWorkspaceService {
                                         vec![ConversationEntry::AgentEvent {
                                             entry_id: String::new(),
                                             created_at_unix_ms: 0,
+                                            runner: None,
                                             event: luban_domain::AgentEvent::TurnDuration {
                                                 duration_ms,
                                             },

--- a/crates/luban_server/src/engine.rs
+++ b/crates/luban_server/src/engine.rs
@@ -5766,6 +5766,7 @@ fn map_conversation_entry(entry: &ConversationEntry) -> luban_api::ConversationE
                     luban_domain::AgentRunnerKind::Codex => luban_api::AgentRunnerKind::Codex,
                     luban_domain::AgentRunnerKind::Amp => luban_api::AgentRunnerKind::Amp,
                     luban_domain::AgentRunnerKind::Claude => luban_api::AgentRunnerKind::Claude,
+                    luban_domain::AgentRunnerKind::Droid => luban_api::AgentRunnerKind::Droid,
                 }),
                 event,
             })


### PR DESCRIPTION
## Summary
- add missing `runner: None` when persisting `ConversationEntry::AgentEvent` in the Droid stream path
- add missing `Droid` arm in domain->api runner mapping in server engine
- unblock `just ci` failures caused by non-exhaustive/missing-field compile errors

## Verification
- just ci
