### PR TITLE
web: add mock subtask delegation activity demo

### DIFF
--- a/web/components/task-activity-view.tsx
+++ b/web/components/task-activity-view.tsx
@@ -213,6 +213,24 @@ function ActivityEventItem({ event, isExpanded, onToggle, duration }: ActivityEv
   const canToggle = hasExpandableDetail && !isAssistantMessage
   const shouldShowDetail = hasExpandableDetail && isExpanded
   const hasDuration = !isAssistantMessage && typeof duration === "string" && duration.trim().length > 0
+  const subagent = event.subagent ?? null
+  const subagentStatusLabel = (() => {
+    if (!subagent) return ""
+    if (subagent.status === "running") return "RUNNING"
+    if (subagent.status === "done") return "DONE"
+    if (subagent.status === "blocked") return "BLOCKED"
+    if (subagent.status === "failed") return "FAILED"
+    if (subagent.status === "canceled") return "CANCELED"
+    return "UNKNOWN"
+  })()
+  const subagentStatusColor = (() => {
+    if (!subagent) return COLORS.textMuted
+    if (subagent.status === "running") return COLORS.accent
+    if (subagent.status === "done") return "#15803d"
+    if (subagent.status === "blocked") return COLORS.warning
+    if (subagent.status === "failed" || subagent.status === "canceled") return "#dc2626"
+    return COLORS.textMuted
+  })()
 
   const icon = (() => {
     switch (event.type) {
@@ -300,6 +318,36 @@ function ActivityEventItem({ event, isExpanded, onToggle, duration }: ActivityEv
           {event.title}
         </span>
         <div data-testid="activity-event-trailing" className="flex items-center gap-1 flex-shrink-0">
+          {subagent && (
+            <>
+              <span
+                data-testid="activity-subagent-pill"
+                className="px-1.5 py-0.5 rounded"
+                style={{
+                  fontSize: "10px",
+                  fontWeight: 600,
+                  letterSpacing: "0.02em",
+                  color: COLORS.textMuted,
+                  backgroundColor: "rgba(0,0,0,0.04)",
+                }}
+              >
+                SUBTASK
+              </span>
+              <span
+                data-testid="activity-subagent-status"
+                className="px-1.5 py-0.5 rounded"
+                style={{
+                  fontSize: "10px",
+                  fontWeight: 600,
+                  letterSpacing: "0.02em",
+                  color: subagentStatusColor,
+                  backgroundColor: `${subagentStatusColor}22`,
+                }}
+              >
+                {subagentStatusLabel}
+              </span>
+            </>
+          )}
           {hasDuration && (
             <span
               data-testid="activity-event-duration"

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -29,6 +29,7 @@ import { runNewTaskDrafts } from './scenarios/new-task-drafts.mjs';
 import { runNoRightSidebar } from './scenarios/no-right-sidebar.mjs';
 import { runSettingsPanel } from './scenarios/settings-panel.mjs';
 import { runSidebarProjectAvatars } from './scenarios/sidebar-project-avatars.mjs';
+import { runSubagentMockView } from './scenarios/subagent-mock-view.mjs';
 import { runTaskListProjectIcon } from './scenarios/task-list-project-icon.mjs';
 import { runStarFavorites } from './scenarios/star-favorites.mjs';
 import { runTaskStatusChange } from './scenarios/task-status-change.mjs';
@@ -185,7 +186,8 @@ async function main() {
 	    await runTaskStatusChange({ page, baseUrl });
 	    await runKeyboardSequenceShortcuts({ page, baseUrl });
 	    await runQueuedPrompts({ page, baseUrl });
-	    await runLatestEventsVisible({ page, baseUrl });
+    await runLatestEventsVisible({ page, baseUrl });
+    await runSubagentMockView({ page, baseUrl });
     await runActivityWindowing({ page, baseUrl });
     await runAgentRunnerIcons({ page, baseUrl });
     await runEscapeDoesNotLeakFromChatInput({ page, baseUrl });

--- a/web/tests/ui/scenarios/subagent-mock-view.mjs
+++ b/web/tests/ui/scenarios/subagent-mock-view.mjs
@@ -1,0 +1,29 @@
+import { waitForLocatorCount } from '../lib/utils.mjs';
+
+export async function runSubagentMockView({ page }) {
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  await page.getByText('Mock: Subtask delegation demo').first().click();
+  const turnCard = page.getByTestId('agent-turn-card').first();
+  await turnCard.waitFor({ state: 'visible' });
+
+  await turnCard.getByTestId('agent-turn-toggle').click();
+
+  const subtaskPills = turnCard.getByTestId('activity-subagent-pill');
+  await waitForLocatorCount(subtaskPills, 3, 20_000);
+
+  const statusPills = turnCard.getByTestId('activity-subagent-status');
+  await waitForLocatorCount(statusPills, 3, 20_000);
+
+  const statusTexts = (await statusPills.allTextContents()).map((v) => v.trim());
+  if (!statusTexts.includes('RUNNING')) {
+    throw new Error(`expected at least one RUNNING subtask status, got: ${JSON.stringify(statusTexts)}`);
+  }
+  if (!statusTexts.includes('DONE')) {
+    throw new Error(`expected at least one DONE subtask status, got: ${JSON.stringify(statusTexts)}`);
+  }
+
+  const completedRow = turnCard.getByTestId('agent-turn-event').filter({ hasText: 'Completed subtask #201' }).first();
+  await completedRow.waitFor({ state: 'visible' });
+}


### PR DESCRIPTION
## Summary
- add mock fixture data for a dedicated `Mock: Subtask delegation demo` task
- detect Luban subtask delegation MCP events in `conversation-ui` and map them to structured subtask activity metadata
- render `SUBTASK` and status badges (`RUNNING` / `DONE` / etc.) in the activity timeline for those events
- add a new UI smoke scenario to verify the mock subtask visualization and wire it into `web/tests/ui/run.mjs`

## Verification
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `pnpm -C web test:ui`
- `just test-ui`
