### PR TITLE
fix: restore gpt-5.3-codex support (keep 5.2)

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -3296,7 +3296,7 @@ mod tests {
                 .expect("write cache file");
         }
 
-        std::fs::write(root.join("config.toml"), "model = \"gpt-5.2-codex\"")
+        std::fs::write(root.join("config.toml"), "model = \"gpt-5.3-codex\"")
             .expect("write config.toml");
         let prompts_dir = root.join("prompts");
         std::fs::create_dir_all(&prompts_dir).expect("prompts dir should be created");

--- a/crates/luban_backend/src/sqlite_store.rs
+++ b/crates/luban_backend/src/sqlite_store.rs
@@ -5007,7 +5007,7 @@ mod tests {
                 luban_domain::PersistedWorkspaceThreadRunConfigOverride {
                     runner: Some("amp".to_owned()),
                     amp_mode: Some("rush".to_owned()),
-                    model_id: "gpt-5.2-codex".to_owned(),
+                    model_id: "gpt-5.3-codex".to_owned(),
                     thinking_effort: "high".to_owned(),
                 },
             )]),
@@ -5167,7 +5167,7 @@ mod tests {
                 attachments: Vec::new(),
                 run_config: AgentRunConfig {
                     runner: luban_domain::AgentRunnerKind::Codex,
-                    model_id: "gpt-5.2-codex".to_owned(),
+                    model_id: "gpt-5.3-codex".to_owned(),
                     thinking_effort: ThinkingEffort::Minimal,
                     amp_mode: None,
                 },
@@ -5178,7 +5178,7 @@ mod tests {
                 attachments: Vec::new(),
                 run_config: AgentRunConfig {
                     runner: luban_domain::AgentRunnerKind::Codex,
-                    model_id: "gpt-5.2-codex".to_owned(),
+                    model_id: "gpt-5.3-codex".to_owned(),
                     thinking_effort: ThinkingEffort::Minimal,
                     amp_mode: None,
                 },
@@ -5230,7 +5230,7 @@ mod tests {
             "w",
             1,
             luban_domain::AgentRunnerKind::Codex,
-            "gpt-5.2-codex",
+            "gpt-5.3-codex",
             ThinkingEffort::High,
             None,
         )
@@ -5238,13 +5238,13 @@ mod tests {
 
         let snapshot = db.load_conversation("p", "w", 1).unwrap();
         assert_eq!(snapshot.runner, Some(luban_domain::AgentRunnerKind::Codex));
-        assert_eq!(snapshot.agent_model_id.as_deref(), Some("gpt-5.2-codex"));
+        assert_eq!(snapshot.agent_model_id.as_deref(), Some("gpt-5.3-codex"));
         assert_eq!(snapshot.thinking_effort, Some(ThinkingEffort::High));
         assert_eq!(snapshot.amp_mode, None);
 
         let snapshot = db.load_conversation_page("p", "w", 1, None, 10).unwrap();
         assert_eq!(snapshot.runner, Some(luban_domain::AgentRunnerKind::Codex));
-        assert_eq!(snapshot.agent_model_id.as_deref(), Some("gpt-5.2-codex"));
+        assert_eq!(snapshot.agent_model_id.as_deref(), Some("gpt-5.3-codex"));
         assert_eq!(snapshot.thinking_effort, Some(ThinkingEffort::High));
         assert_eq!(snapshot.amp_mode, None);
     }

--- a/crates/luban_domain/src/agent_settings.rs
+++ b/crates/luban_domain/src/agent_settings.rs
@@ -149,6 +149,7 @@ mod tests {
 
     #[test]
     fn agent_model_label_still_works_for_codex_models() {
+        assert_eq!(agent_model_label("gpt-5.3-codex"), Some("GPT-5.3-Codex"));
         assert_eq!(agent_model_label("gpt-5.2-codex"), Some("GPT-5.2-Codex"));
         assert_eq!(agent_model_label("gpt-5.2"), Some("GPT-5.2"));
     }
@@ -157,11 +158,11 @@ mod tests {
     fn model_valid_for_runner_checks_catalog() {
         assert!(model_valid_for_runner(
             AgentRunnerKind::Codex,
-            "gpt-5.2-codex"
-        ));
-        assert!(!model_valid_for_runner(
-            AgentRunnerKind::Codex,
             "gpt-5.3-codex"
+        ));
+        assert!(model_valid_for_runner(
+            AgentRunnerKind::Codex,
+            "gpt-5.2-codex"
         ));
         assert!(model_valid_for_runner(
             AgentRunnerKind::Droid,
@@ -252,6 +253,11 @@ const STANDARD_EFFORTS: &[ThinkingEffort] = &[
 ];
 
 const AGENT_MODELS: &[AgentModelSpec] = &[
+    AgentModelSpec {
+        id: "gpt-5.3-codex",
+        label: "GPT-5.3-Codex",
+        supported_thinking_efforts: STANDARD_EFFORTS,
+    },
     AgentModelSpec {
         id: "gpt-5.2-codex",
         label: "GPT-5.2-Codex",

--- a/crates/luban_domain/src/reducer.rs
+++ b/crates/luban_domain/src/reducer.rs
@@ -3151,7 +3151,7 @@ mod tests {
         state.apply(Action::ChatModelChanged {
             workspace_id,
             thread_id,
-            model_id: "gpt-5.2-codex".to_owned(),
+            model_id: "gpt-5.3-codex".to_owned(),
         });
         state.apply(Action::ThinkingEffortChanged {
             workspace_id,
@@ -3160,7 +3160,7 @@ mod tests {
         });
 
         state.apply(Action::CodexDefaultsLoaded {
-            model_id: Some("gpt-5.2-codex".to_owned()),
+            model_id: Some("gpt-5.3-codex".to_owned()),
             thinking_effort: Some(ThinkingEffort::High),
         });
 
@@ -3174,7 +3174,7 @@ mod tests {
         let conversation = state
             .workspace_thread_conversation(workspace_id, created_thread_id)
             .expect("missing conversation");
-        assert_eq!(conversation.agent_model_id, "gpt-5.2-codex");
+        assert_eq!(conversation.agent_model_id, "gpt-5.3-codex");
         assert_eq!(conversation.thinking_effort, ThinkingEffort::High);
     }
 
@@ -3361,7 +3361,7 @@ mod tests {
         state.apply(Action::ChatModelChanged {
             workspace_id,
             thread_id,
-            model_id: "gpt-5.2-codex".to_owned(),
+            model_id: "gpt-5.3-codex".to_owned(),
         });
         state.apply(Action::ThinkingEffortChanged {
             workspace_id,
@@ -3386,7 +3386,7 @@ mod tests {
                 _ => None,
             })
             .expect("missing RunAgentTurn effect");
-        assert_eq!(sent_model_id, "gpt-5.2-codex");
+        assert_eq!(sent_model_id, "gpt-5.3-codex");
         assert_eq!(sent_effort, ThinkingEffort::High);
 
         state.apply(Action::ChatModelChanged {
@@ -3403,7 +3403,7 @@ mod tests {
             .current_run_config
             .as_ref()
             .expect("missing current run config");
-        assert_eq!(running.model_id, "gpt-5.2-codex");
+        assert_eq!(running.model_id, "gpt-5.3-codex");
         assert_eq!(running.thinking_effort, ThinkingEffort::High);
     }
 
@@ -3559,7 +3559,7 @@ mod tests {
             is_git: true,
         });
         state.apply(Action::CodexDefaultsLoaded {
-            model_id: Some("gpt-5.2-codex".to_owned()),
+            model_id: Some("gpt-5.3-codex".to_owned()),
             thinking_effort: Some(ThinkingEffort::High),
         });
         let project_id = state.projects[0].id;
@@ -3594,7 +3594,7 @@ mod tests {
             thread_id: None,
             task_status: crate::TaskStatus::Todo,
             runner: None,
-            agent_model_id: Some("gpt-5.2-codex".to_owned()),
+            agent_model_id: Some("gpt-5.3-codex".to_owned()),
             thinking_effort: Some(ThinkingEffort::High),
             amp_mode: None,
             entries: Vec::new(),
@@ -3626,7 +3626,7 @@ mod tests {
             is_git: true,
         });
         state.apply(Action::CodexDefaultsLoaded {
-            model_id: Some("gpt-5.2-codex".to_owned()),
+            model_id: Some("gpt-5.3-codex".to_owned()),
             thinking_effort: Some(ThinkingEffort::High),
         });
         let project_id = state.projects[0].id;
@@ -3694,7 +3694,7 @@ mod tests {
         state.apply(Action::ChatModelChanged {
             workspace_id,
             thread_id,
-            model_id: "gpt-5.2-codex".to_owned(),
+            model_id: "gpt-5.3-codex".to_owned(),
         });
         state.apply(Action::ThinkingEffortChanged {
             workspace_id,
@@ -3746,7 +3746,7 @@ mod tests {
         assert_eq!(effects.len(), 1);
         match &effects[0] {
             Effect::RunAgentTurn { run_config, .. } => {
-                assert_eq!(run_config.model_id, "gpt-5.2-codex");
+                assert_eq!(run_config.model_id, "gpt-5.3-codex");
                 assert_eq!(run_config.thinking_effort, ThinkingEffort::Minimal);
             }
             other => panic!("unexpected effect: {other:?}"),
@@ -3759,7 +3759,7 @@ mod tests {
             .current_run_config
             .as_ref()
             .expect("missing current run config");
-        assert_eq!(running.model_id, "gpt-5.2-codex");
+        assert_eq!(running.model_id, "gpt-5.3-codex");
         assert_eq!(running.thinking_effort, ThinkingEffort::Minimal);
     }
 
@@ -5398,7 +5398,7 @@ mod tests {
                     attachments: Vec::new(),
                     run_config: AgentRunConfig {
                         runner: crate::AgentRunnerKind::Codex,
-                        model_id: "gpt-5.2-codex".to_owned(),
+                        model_id: "gpt-5.3-codex".to_owned(),
                         thinking_effort: ThinkingEffort::Minimal,
                         amp_mode: None,
                     },
@@ -5430,7 +5430,7 @@ mod tests {
                 thread_id: None,
                 task_status: crate::TaskStatus::Todo,
                 runner: None,
-                agent_model_id: Some("gpt-5.2-codex".to_owned()),
+                agent_model_id: Some("gpt-5.3-codex".to_owned()),
                 thinking_effort: Some(ThinkingEffort::High),
                 amp_mode: None,
                 entries: Vec::new(),
@@ -5446,7 +5446,7 @@ mod tests {
         let conversation = state
             .workspace_thread_conversation(workspace_id, thread_id)
             .expect("missing conversation");
-        assert_eq!(conversation.agent_model_id, "gpt-5.2-codex");
+        assert_eq!(conversation.agent_model_id, "gpt-5.3-codex");
         assert_eq!(conversation.thinking_effort, ThinkingEffort::High);
     }
 

--- a/web/lib/agent-settings.ts
+++ b/web/lib/agent-settings.ts
@@ -12,6 +12,11 @@ export const THINKING_EFFORTS: ThinkingEffort[] = ["minimal", "low", "medium", "
 
 export const AGENT_MODELS: AgentModelSpec[] = [
   {
+    id: "gpt-5.3-codex",
+    label: "GPT-5.3-Codex",
+    supportedThinkingEfforts: THINKING_EFFORTS,
+  },
+  {
     id: "gpt-5.2-codex",
     label: "GPT-5.2-Codex",
     supportedThinkingEfforts: THINKING_EFFORTS,


### PR DESCRIPTION
PR #251 unintentionally regressed the gpt-5.3-codex support introduced in #244; this PR restores gpt-5.3-codex while preserving existing gpt-5.2 compatibility.