### PR TITLE
fix(web): allow opening done/canceled tasks

### DIFF
--- a/web/components/task-list-view.tsx
+++ b/web/components/task-list-view.tsx
@@ -77,7 +77,7 @@ function TaskRow({
   const isArchived = task.status === "done" || task.status === "canceled"
   return (
     <div
-      onClick={isArchived ? undefined : onClick}
+      onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       data-task-row-id={task.id}

--- a/web/tests/ui/run.mjs
+++ b/web/tests/ui/run.mjs
@@ -40,6 +40,7 @@ import { runProjectAllTasksView } from './scenarios/project-all-tasks-view.mjs';
 import { runKeyboardSequenceShortcuts } from './scenarios/keyboard-sequence-shortcuts.mjs';
 import { runTurnDurationEstimate } from './scenarios/turn-duration-estimate.mjs';
 import { runAllTasksIncludesArchivedWorkdirs } from './scenarios/all-tasks-includes-archived-workdirs.mjs';
+import { runArchivedTaskOpenReadonly } from './scenarios/archived-task-open-readonly.mjs';
 
 async function canRun(command, args) {
   const proc = spawn(command, args, { stdio: 'ignore' });
@@ -198,6 +199,7 @@ async function main() {
 	    await runNoRightSidebar({ page, baseUrl });
 	    await runCancelTaskClearsRunning({ page, baseUrl });
 	    await runAllTasksIncludesArchivedWorkdirs({ page, baseUrl });
+	    await runArchivedTaskOpenReadonly({ page, baseUrl });
 	  } catch (err) {
 	    if (logFile) {
 	      process.stderr.write(`ui smoke failed; log: ${logFile}\n`);

--- a/web/tests/ui/scenarios/archived-task-open-readonly.mjs
+++ b/web/tests/ui/scenarios/archived-task-open-readonly.mjs
@@ -1,0 +1,33 @@
+export async function runArchivedTaskOpenReadonly({ page }) {
+  const archivedTaskTitle = 'Done: completed successfully';
+
+  await page.getByTestId('sidebar-project-mock-project-1').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const archivedBanner = page.getByTestId('archived-task-banner');
+  const archivedBannerVisibleBefore = await archivedBanner.isVisible().catch(() => false);
+  if (archivedBannerVisibleBefore) {
+    throw new Error('expected archived banner to be hidden before opening archived task');
+  }
+
+  await page.getByTestId('task-view-tab-all').click();
+  await page.getByTestId('task-list-view').waitFor({ state: 'visible' });
+
+  const doneGroupToggle = page.getByTestId('task-group-done');
+  await doneGroupToggle.waitFor({ state: 'visible' });
+
+  const archivedRow = page
+    .getByTestId('task-list-view')
+    .locator('div.group', { hasText: archivedTaskTitle })
+    .first();
+
+  if (!(await archivedRow.isVisible().catch(() => false))) {
+    await doneGroupToggle.click();
+    await archivedRow.waitFor({ state: 'visible' });
+  }
+
+  await archivedRow.scrollIntoViewIfNeeded();
+  await archivedRow.click();
+
+  await archivedBanner.waitFor({ state: 'visible' });
+}


### PR DESCRIPTION
## Summary
- allow clicking task rows even when task status is `done` or `canceled`
- keep archived behavior read-only by leaving composer interaction gating unchanged
- add a UI smoke scenario to verify archived tasks can be opened and show the archived banner

## Files changed
- `web/components/task-list-view.tsx`
- `web/tests/ui/scenarios/archived-task-open-readonly.mjs`
- `web/tests/ui/run.mjs`

## Verification
- `cd web && pnpm lint -- components/task-list-view.tsx tests/ui/run.mjs tests/ui/scenarios/archived-task-open-readonly.mjs`
- `cd web && pnpm typecheck`
- single-scenario run for `runArchivedTaskOpenReadonly`: pass

## Notes
- full `just test-ui` currently fails in existing scenario `runSubagentMockView` timeout locally (not reached by this change path).
