### PR TITLE
fix(web): don't show empty task detail when closing NewTaskModal without creating

### DIFF
--- a/web/components/luban-ide.tsx
+++ b/web/components/luban-ide.tsx
@@ -243,7 +243,11 @@ export function LubanIDE() {
         onOpenChange={(open) => {
           setNewTaskOpen(open)
           if (!open) setNewTaskInitialDraft(null)
-          if (!open) setShowDetail(true)
+        }}
+        onTaskCreated={() => {
+          setSelectedTask(null)
+          setActiveView("tasks")
+          setShowDetail(true)
         }}
       />
     </>

--- a/web/components/new-task-modal.tsx
+++ b/web/components/new-task-modal.tsx
@@ -57,6 +57,7 @@ function buildFallbackAvatarUrl(displayName: string, size: number): string {
 interface NewTaskModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onTaskCreated?: () => void
   activeProjectId?: string | null
   initialDraft?: NewTaskDraft | null
 }
@@ -73,7 +74,7 @@ function normalizePathLike(raw: string): string {
   return raw.trim().replace(/\/+$/, "")
 }
 
-export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft }: NewTaskModalProps) {
+export function NewTaskModal({ open, onOpenChange, onTaskCreated, activeProjectId, initialDraft }: NewTaskModalProps) {
   const {
     app,
     executeTask,
@@ -549,6 +550,7 @@ export function NewTaskModal({ open, onOpenChange, activeProjectId, initialDraft
       setAttachments([])
       setEditingDraftId(null)
       void clearNewTaskStash().catch((err) => console.warn("clearNewTaskStash failed", err))
+      onTaskCreated?.()
       onOpenChange(false)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))


### PR DESCRIPTION
Closes: https://github.com/Xuanwo/luban/issues/260

The new behaviour:
* Clicking 'New task' and cancel directly: simply close the modal
* Create a task with description: go to the task detail