### PR TITLE
feat: support font-family fallback lists in terminal and settings preview

### DIFF
--- a/web/components/pty-terminal.tsx
+++ b/web/components/pty-terminal.tsx
@@ -11,10 +11,18 @@ import { useLuban } from "@/lib/luban-context"
 import { openExternalUrl } from "@/lib/open-external-url"
 import { useAppearance } from "@/components/appearance-provider"
 import { isMockMode } from "@/lib/luban-mode"
+import { buildFontFamilyList } from "@/lib/font-family"
 
-function escapeCssFontName(value: string): string {
-  return value.replaceAll('"', '\\"')
-}
+const TERMINAL_FONT_FALLBACKS = [
+  "ui-monospace",
+  "SFMono-Regular",
+  "Menlo",
+  "Monaco",
+  "Consolas",
+  "Liberation Mono",
+  "Courier New",
+  "monospace",
+] as const
 
 function encodeBinaryString(value: string): Uint8Array {
   const out = new Uint8Array(value.length)
@@ -85,8 +93,7 @@ function getOrCreateReconnectToken(workspaceId: number, threadId: number): strin
 }
 
 function terminalFontFamily(fontName: string): string {
-  const escaped = escapeCssFontName(fontName.trim() || "Geist Mono")
-  return `"${escaped}", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`
+  return buildFontFamilyList(fontName.trim() || "Geist Mono", TERMINAL_FONT_FALLBACKS)
 }
 
 async function copyToClipboard(text: string): Promise<void> {

--- a/web/components/settings-panel.tsx
+++ b/web/components/settings-panel.tsx
@@ -47,6 +47,7 @@ import { toast } from "sonner"
 import { useAppearance } from "@/components/appearance-provider"
 import { useLuban } from "@/lib/luban-context"
 import { cn } from "@/lib/utils"
+import { buildFontFamilyList } from "@/lib/font-family"
 import type {
   AgentRunnerKind,
   AmpConfigEntrySnapshot,
@@ -719,14 +720,14 @@ function InlineFontInput({
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Enter font name..."
+        placeholder="Enter font family..."
         className={cn(
           "px-2 py-1 rounded-md text-xs transition-all w-32",
           "bg-muted border border-border",
           "focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary",
           mono ? "font-mono" : "",
         )}
-        style={{ fontFamily: `"${value}", ${mono ? "monospace" : "sans-serif"}` }}
+        style={{ fontFamily: buildFontFamilyList(value, [mono ? "monospace" : "sans-serif"]) }}
       />
     </div>
   )
@@ -771,7 +772,7 @@ function WorkspacePreviewWithFonts({
               />
             </div>
 
-            <div className="px-1" style={{ fontFamily: `"${uiFont}", sans-serif` }}>
+            <div className="px-1" style={{ fontFamily: buildFontFamilyList(uiFont, ["sans-serif"]) }}>
               <p className="text-xs text-muted-foreground leading-relaxed">The quick brown fox jumps over the lazy dog</p>
             </div>
           </div>
@@ -804,7 +805,7 @@ function WorkspacePreviewWithFonts({
                     onChange={setChatFont}
                   />
                 </div>
-                <div className="bg-secondary/40 rounded-lg p-3" style={{ fontFamily: `"${chatFont}", sans-serif` }}>
+                <div className="bg-secondary/40 rounded-lg p-3" style={{ fontFamily: buildFontFamilyList(chatFont, ["sans-serif"]) }}>
                   <p className="text-sm leading-relaxed text-muted-foreground">The quick brown fox jumps over the lazy dog</p>
                 </div>
               </div>
@@ -819,7 +820,7 @@ function WorkspacePreviewWithFonts({
                     mono
                   />
                 </div>
-                <div className="bg-secondary/60 border border-border rounded-lg p-3" style={{ fontFamily: `"${monoFont}", monospace` }}>
+                <div className="bg-secondary/60 border border-border rounded-lg p-3" style={{ fontFamily: buildFontFamilyList(monoFont, ["monospace"]) }}>
                   <pre className="text-sm leading-relaxed">
                     <span className="text-base08">fn</span>{" "}
                     <span className="text-base0e">hello</span>
@@ -855,7 +856,11 @@ function WorkspacePreviewWithFonts({
                 vertical
               />
             </div>
-            <div className="flex-1 px-3 pb-3" style={{ fontFamily: `"${terminalFont}", monospace` }}>
+            <div
+              data-testid="settings-terminal-font-preview"
+              className="flex-1 px-3 pb-3"
+              style={{ fontFamily: buildFontFamilyList(terminalFont, ["monospace"]) }}
+            >
               <p className="text-sm leading-relaxed text-muted-foreground">The quick brown fox jumps over the lazy dog</p>
             </div>
           </div>

--- a/web/lib/font-family.ts
+++ b/web/lib/font-family.ts
@@ -1,0 +1,101 @@
+const GENERIC_FONT_FAMILIES = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "emoji",
+  "math",
+  "fangsong",
+])
+
+function splitFontFamilyList(input: string): string[] {
+  const out: string[] = []
+  let current = ""
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (const ch of input) {
+    if (escaped) {
+      current += ch
+      escaped = false
+      continue
+    }
+
+    if (quote) {
+      current += ch
+      if (ch === "\\") {
+        escaped = true
+      } else if (ch === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      current += ch
+      continue
+    }
+
+    if (ch === ",") {
+      out.push(current)
+      current = ""
+      continue
+    }
+
+    current += ch
+  }
+
+  out.push(current)
+  return out
+}
+
+function stripWrappingQuotes(input: string): string {
+  const trimmed = input.trim()
+  if (trimmed.length < 2) return trimmed
+  const first = trimmed[0]
+  const last = trimmed[trimmed.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function normalizeFamilyName(input: string): string | null {
+  const stripped = stripWrappingQuotes(input)
+  if (!stripped) return null
+
+  const lowered = stripped.toLowerCase()
+  if (GENERIC_FONT_FAMILIES.has(lowered)) return lowered
+
+  const escaped = stripped.replaceAll("\\", "\\\\").replaceAll('"', '\\"')
+  return `"${escaped}"`
+}
+
+export function buildFontFamilyList(
+  preferred: string,
+  fallbacks: readonly string[] = [],
+): string {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  const push = (raw: string) => {
+    const item = normalizeFamilyName(raw)
+    if (!item) return
+    const key = item.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    normalized.push(item)
+  }
+
+  for (const raw of splitFontFamilyList(preferred)) push(raw)
+  for (const raw of fallbacks) push(raw)
+
+  return normalized.join(", ")
+}

--- a/web/tests/ui/scenarios/settings-panel.mjs
+++ b/web/tests/ui/scenarios/settings-panel.mjs
@@ -3,6 +3,14 @@ export async function runSettingsPanel({ page }) {
   await page.getByTestId('open-settings-button').click();
   await page.getByTestId('settings-panel').waitFor({ state: 'visible' });
 
+  await page.getByTestId('settings-terminal-font').fill('Primary Mono Test, Fallback NF Test');
+  const terminalPreviewFontFamily = await page
+    .getByTestId('settings-terminal-font-preview')
+    .evaluate((el) => el.style.fontFamily);
+  if (!/"Primary Mono Test"\s*,\s*"Fallback NF Test"\s*,\s*monospace/i.test(terminalPreviewFontFamily)) {
+    throw new Error(`expected terminal preview font fallback chain, got "${terminalPreviewFontFamily}"`);
+  }
+
   await page.getByRole('button', { name: 'Integrations' }).click();
   await page.getByRole('button', { name: 'Telegram' }).click();
 


### PR DESCRIPTION
This PR adds proper `font-family` fallback list support for terminal and settings font inputs: previously entering `MonoLisa Variable,Maple Mono NF CN` was treated as a single quoted name (`"MonoLisa Variable,Maple Mono NF CN"`) and failed to resolve, while now it is normalized into a real fallback chain (e.g. `"MonoLisa Variable", "Maple Mono NF CN", ...`), allowing the system to resolve and fall back to available fonts correctly.