### PR TITLE
web: remove shell toggle from left task document composer

### DIFF
--- a/web/components/task-document-panel.tsx
+++ b/web/components/task-document-panel.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Terminal } from "lucide-react"
 
 import { ChatComposer } from "@/components/chat-composer"
 import { TiptapMarkdownEditor } from "@/components/tiptap-markdown-editor"
@@ -939,12 +938,6 @@ export function TaskDocumentPanel() {
               setChatAmpMode(activeWorkdirId, activeTaskId, mode)
             }}
             onSend={sendUnifiedComment}
-            secondaryAction={{
-              onClick: () => {},
-              ariaLabel: "Switch to shell",
-              icon: <Terminal className="w-3.5 h-3.5" />,
-              testId: "chat-mode-toggle",
-            }}
             canSend={commentCanSend}
             codexEnabled={app?.agent.codex_enabled ?? true}
             ampEnabled={app?.agent.amp_enabled ?? true}

--- a/web/tests/ui/scenarios/task-documents-panel.mjs
+++ b/web/tests/ui/scenarios/task-documents-panel.mjs
@@ -19,6 +19,10 @@ export async function runTaskDocumentsPanel({ page }) {
   }
   await panel.getByTestId('chat-attach').waitFor({ state: 'visible' });
   await panel.getByTestId('agent-selector').waitFor({ state: 'visible' });
+  const shellToggleCount = await panel.getByTestId('chat-mode-toggle').count();
+  if (shellToggleCount !== 0) {
+    throw new Error(`expected no left-side shell toggle in task documents panel, got ${shellToggleCount}`);
+  }
 
   // TipTap editor is always visible (seamless WYSIWYG) — click to focus, then select all
   const taskEditor = panel.getByTestId('task-document-editor-task');


### PR DESCRIPTION
## Summary
- remove the left-side shell toggle (`chat-mode-toggle`) from `TaskDocumentPanel` bottom comment composer
- keep right workspace shell behavior unchanged
- add UI smoke assertion to ensure no shell toggle is rendered in the task documents panel

## Verification
- just fmt
- just lint
- just test
- just test-ui
