### PR TITLE
Fix concurrent task allocation and enforce ULID task documents

### DIFF
--- a/crates/luban_backend/src/services.rs
+++ b/crates/luban_backend/src/services.rs
@@ -731,6 +731,16 @@ impl ProjectWorkspaceService for GitWorkspaceService {
             .map_err(anyhow_error_to_string)
     }
 
+    fn allocate_conversation_thread(
+        &self,
+        project_slug: String,
+        workspace_name: String,
+    ) -> Result<u64, String> {
+        self.sqlite
+            .allocate_conversation_thread(project_slug, workspace_name)
+            .map_err(anyhow_error_to_string)
+    }
+
     fn list_conversation_threads(
         &self,
         project_slug: String,

--- a/crates/luban_domain/src/adapters.rs
+++ b/crates/luban_domain/src/adapters.rs
@@ -390,6 +390,14 @@ pub trait ProjectWorkspaceService: Send + Sync {
         thread_id: u64,
     ) -> Result<(), String>;
 
+    fn allocate_conversation_thread(
+        &self,
+        _project_slug: String,
+        _workspace_name: String,
+    ) -> Result<u64, String> {
+        Err("unimplemented".to_owned())
+    }
+
     fn list_conversation_threads(
         &self,
         project_slug: String,

--- a/crates/luban_server/src/server.rs
+++ b/crates/luban_server/src/server.rs
@@ -815,7 +815,7 @@ fn ensure_task_document_identity(
     let now = now_unix_millis();
     let identity = TaskDocumentIdentityRecord {
         schema_version: TASK_DOCUMENT_SCHEMA_VERSION,
-        task_ulid: fallback_task_ulid(workspace_id, task_id),
+        task_ulid: ulid::Ulid::new().to_string(),
         workspace_id,
         task_id,
         created_at_unix_ms: now,

--- a/docs/contracts/features/c-http-task-documents.md
+++ b/docs/contracts/features/c-http-task-documents.md
@@ -49,8 +49,7 @@ Expose task-scoped document files for review and editing:
 - `kind` path parameter must be one of: `task`, `plan`, `memory`.
 - Request body: `{ "content": string }`.
 - Lazily creates task identity/directory on first write, then writes content atomically.
-- First-write identity uses deterministic fallback task id (`task-{workdir_id}-{task_id}`) to align
-  with agent-created files before provider writes.
+- Newly created task identity uses a generated ULID (`{task_ulid}`).
 - Response body: `TaskDocumentSnapshot`.
 
 ## Invariants

--- a/docs/contracts/progress.md
+++ b/docs/contracts/progress.md
@@ -67,6 +67,7 @@ Legend:
 - `C-WS-EVENTS`: Telegram passive conversation forwarding also keeps a single per-task relay message (after first send) and updates it via `editMessageText` on subsequent new updates.
 - `C-WS-EVENTS`: `ServerEvent::TaskSummariesChanged` pushes per-workdir `TaskSummarySnapshot[]` updates for task-first UI surfaces (inbox, global task lists).
 - `C-WS-EVENTS`: `ServerEvent::TaskDocumentChanged` is emitted from filesystem notifications under `tasks/v1/tasks/**` so the task document panel can refresh from FS truth.
+- `C-HTTP-TASK-DOCUMENTS`: task document identity directory (`task_ulid`) is ULID-based for newly created task identities (provider fallback `task-*` is legacy-compat only).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot` includes per-thread run config (`agent_runner` / `agent_model_id` / `thinking_effort` / `amp_mode`).
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.task_status` exposes the per-task lifecycle stage.
 - `C-HTTP-CONVERSATION`: `ConversationSnapshot.entries` is a timeline of `ConversationEntry` values tagged by `type` (`system_event` / `user_event` / `agent_event`). Each entry includes a stable `entry_id` and `created_at_unix_ms`, and streaming/tool updates are appended as additional `agent_event` entries (clients may fold by `AgentEvent.id` if desired).


### PR DESCRIPTION
## Summary
- add provider-backed atomic task/thread allocation in sqlite and wire engine task creation through it
- ensure new task document identities are always generated as ULIDs (engine + HTTP first-write path)
- keep legacy `task-*` identity handling for read compatibility only
- update task document contracts/progress notes and add regression assertions

## Validation
- just fmt
- just lint
- just test
